### PR TITLE
Fix non-returned value

### DIFF
--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -152,11 +152,12 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
                     "%s data: %r", pretty_name,
                     {key: str(value) for key, value in data.items()})
 
-        # Update state for next pass through the pipeline
-        self._previous_data = input_data
+        finally:
+            # Update state for next pass through the pipeline
+            self._previous_data = input_data
 
-        # Pass through the input for consumption by any further steps
-        return input_data
+            # Pass through the input for consumption by any further steps
+            return input_data
 
     def send_message(self, msg):
         """


### PR DESCRIPTION
If a state variable was not present, or had a bad/NaN value, an exception would be raised. In this case, the `_previous_data` attribute would not be updated, and the error would persist at future steps. This makes sure previous data is update AND make sure the input data is returned for other steps in the brokkr chain.