### PR TITLE
Disable state notifier in test mode and formally release Mjolnir-HAMMA 0.2.0

### DIFF
--- a/config/mode.toml
+++ b/config/mode.toml
@@ -22,3 +22,6 @@ config_version = 1
 
     [test.main.pipelines.telemetry]
         monitor_interval_s = 5
+
+    [test.main.steps.state_monitor]
+        _enabled = false

--- a/metadata.toml
+++ b/metadata.toml
@@ -19,11 +19,11 @@ repo = "https://github.com/hamma-dev/mjolnir-hamma"
 license = ""
 
 # Version of the config package; should follow SemVer and PEP 396
-version = "0.2.0dev2"
+version = "0.2.0"
 # Minimum Brokkr version this version of the config package needs to work
 brokkr_version_min = "0.4.0a2"
 # As above, but maximum version (e.g. "0.3.99" for < 0.4.x)
 brokkr_version_max = ""
-# Ibid, for Sindri
-sindri_version_min = "0.3.0"
-sindri_version_max = ""
+# As above, but for Sindri
+sindri_version_min = "0.2.0"
+sindri_version_max = "0.2.99"


### PR DESCRIPTION
Since #10 , running `brokkr start` with the Mjolnir-HAMMA system requires `notifiers` be installed, and attempts to send notification messages even in `test` `mode`. Given this is rather undesirable, this PR disables the `state_notifier` `OutputStep` when running in `test` mode, to avoid these issues.

Furthermore, since Brokkr 0.4.x is now stable (with the 0.4.0 release shortly) and Mjolnir-HAMMA has been apparently working well on the various sensors, we formally update the metadata and release 0.2.0 and cut the 0.2.x branch so we can proceed with merging the 0.3.x work for Sindri 0.3.x.