### PR TITLE
Deploy 40-eth0.network during install to fix DNS on cellular sensors

### DIFF
--- a/unified_install/install.sh
+++ b/unified_install/install.sh
@@ -274,6 +274,21 @@ echo ""
 log_info "=== Phase 2: Network Setup ($NETWORK_PATH) ==="
 echo ""
 
+# --- Common: eth0 sensor interface config (applies to all network modes) ---
+log_step "Installing eth0 network configuration..."
+FILES_DIR="${FILES_DIR:-$REPO_ROOT/files}"
+NETWORK_DIR="/etc/systemd/network"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_dry_run "cp $FILES_DIR/40-eth0.network $NETWORK_DIR/"
+    manifest_add "copy" "src" "$FILES_DIR/40-eth0.network" "dst" "$NETWORK_DIR/40-eth0.network" "sudo" "true"
+else
+    sudo cp "$FILES_DIR/40-eth0.network" "$NETWORK_DIR/"
+    log_success "eth0 network config installed"
+fi
+
+echo ""
+
 if [[ "$NETWORK_PATH" == "wifi" ]]; then
     # --- WiFi Path ---
     source "$SCRIPT_DIR/lib/network_wifi.sh"

--- a/unified_install/lib/network_wwan.sh
+++ b/unified_install/lib/network_wwan.sh
@@ -128,12 +128,17 @@ setup_cellular_network() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "cp $FILES_DIR/20-wwan0.network $NETWORK_PATH/"
         log_dry_run "cp $FILES_DIR/30-eth1.network $NETWORK_PATH/"
+        log_dry_run "systemctl restart systemd-networkd"
         manifest_add "copy" "src" "$FILES_DIR/20-wwan0.network" "dst" "$NETWORK_PATH/20-wwan0.network" "sudo" "true"
         manifest_add "copy" "src" "$FILES_DIR/30-eth1.network" "dst" "$NETWORK_PATH/30-eth1.network" "sudo" "true"
+        manifest_add "command" "cmd" "systemctl restart systemd-networkd" "sudo" "true"
     else
         sudo cp "$FILES_DIR/20-wwan0.network" "$NETWORK_PATH/"
         sudo cp "$FILES_DIR/30-eth1.network" "$NETWORK_PATH/"
-        log_success "Network configs installed"
+        # Restart networkd so .network file changes take effect (safe for wwan0
+        # since it is Unmanaged=yes — only eth0/eth1 configs are reloaded)
+        sudo systemctl restart systemd-networkd
+        log_success "Network configs installed and networkd restarted"
     fi
 
     # --- Step 5: Copy WWAN scripts to /usr/local/bin ---


### PR DESCRIPTION
## Summary

- Adds step to `install.sh` that copies the corrected `40-eth0.network` (with bogus DNS entries removed) and restarts `systemd-networkd`
- The config file fix was already on `0.3.x` (`2aa92d5`), but the installer wasn't deploying it to sensors

## Deployed and verified

Applied to mj41, mj42, mj43 during Australia migration (2026-03-27/30). DNS working on all three.

## Test plan

- [x] 117 tests pass
- [x] Deployed to 3 production sensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)