### PR TITLE
AGS scrubber: scan, recover, purge, and operational deployment

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -53,6 +53,7 @@ config_version = 1
         method = "gchat"  # the method how we're going to send notifications
         channel = "status"
         key_file = "/home/pi/.googlechat"
+        scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -3,7 +3,9 @@ Plugin to monitor state variables from the charge controller.
 """
 
 from math import nan
+import shlex
 import shutil
+import subprocess
 
 # Third party imports
 from notifiers.slack import SlackSender
@@ -28,6 +30,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         key_file=None,
         low_pi_space=5,
         enable_drive_checks=True,
+        scrub_command="",
         **output_step_kwargs,
         ):
         """
@@ -58,6 +61,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         enable_drive_checks : bool, optional
             If True (default), check for archive drives and sensor drive space.
             Set to False for units without HAMMA sensor hardware connected.
+        scrub_command : str, optional
+            Shell command to run hamma_scrub.py when drive space is low.
+            If empty (default), no scrub is spawned. Protected by flock.
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -77,6 +83,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.sender = None  # Make sure we "initialize" the attribute
         self.low_pi_space = low_pi_space*1000000000
         self.enable_drive_checks = enable_drive_checks
+        self.scrub_command = scrub_command
 
         sender_class = {"slack": SlackSender, "gchat": GoogleChatSender}[method]
         try:
@@ -321,7 +328,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
 
         This will check to see how much space is remaining on a sensor USB drive.
         If it falls below the value given by the class attribute `low_space`,
-        send a message.
+        send a message and optionally spawn a scrub process.
 
         Parameters
         ----------
@@ -336,8 +343,26 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         """
         space_now, space_pre = self.now_then(input_data, 'bytes_remaining')
         if (space_now < self.low_space) and (space_pre > self.low_space):
+            self._spawn_scrub()
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
+
+    def _spawn_scrub(self):
+        """Spawn detached scrub process if scrub_command is configured."""
+        if not self.scrub_command or not self.scrub_command.strip():
+            return
+        lock_file = "/tmp/hamma_scrub.lock"
+        try:
+            cmd = ["flock", "-n", lock_file] + shlex.split(self.scrub_command)
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            self.logger.info("Spawned scrub: %s", " ".join(cmd))
+        except (OSError, ValueError) as e:
+            self.logger.error("Failed to spawn scrub: %s", e)
 
     def check_battery_voltage(self, input_data):
         """

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -1535,11 +1535,19 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         if failed_count:
             logger.warning("Recovery: %d failed", failed_count)
 
-    # Update mj_headers with recovered triggers
+    # Update mj_headers and missing list with recovered triggers
     if recovery_results:
+        recovered_headers = set()
         for r in recovery_results:
             if r["status"] == "recovered":
                 mj["headers"].add(r["header"])
+                recovered_headers.add(r["header"])
+        if recovered_headers:
+            comparison["missing_on_mj"] = [
+                e for e in comparison["missing_on_mj"]
+                if e["header"] not in recovered_headers
+            ]
+            results["missing_on_mj"] = comparison["missing_on_mj"]
 
     # Purge flow
     purge_results = None

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -160,12 +160,12 @@ def _parse_since(since_str):
     Parameters
     ----------
     since_str : str
-        Date string: 'YYYY-MM-DD' or 'YYYY-MM-DDTHH'.
+        Date string: 'YYYY-MM-DD', 'YYYY-MM-DDTHH', or 'auto'.
 
     Returns
     -------
     str
-        Normalized to 'YYYY-MM-DDTHH' format for directory comparison.
+        Normalized to 'YYYY-MM-DDTHH' format, or 'auto' sentinel.
 
     Raises
     ------
@@ -173,6 +173,8 @@ def _parse_since(since_str):
         If format is not recognized.
     """
     s = since_str.strip()
+    if s.lower() == 'auto':
+        return 'auto'
     # YYYY-MM-DDTHH (already has hour)
     if len(s) == 13 and s[10] == 'T':
         return s
@@ -180,7 +182,7 @@ def _parse_since(since_str):
     if len(s) == 10 and s[4] == '-' and s[7] == '-':
         return s + 'T00'
     raise ValueError(
-        "Invalid --since format '{}': expected YYYY-MM-DD or YYYY-MM-DDTHH".format(s)
+        "Invalid --since format '{}': expected YYYY-MM-DD, YYYY-MM-DDTHH, or auto".format(s)
     )
 
 
@@ -1495,7 +1497,8 @@ def _build_parser():
     )
     parser.add_argument(
         "--since",
-        help="Only scan MJ directories at or after this date (YYYY-MM-DD or YYYY-MM-DDTHH)",
+        help="Only scan MJ directories at or after this date "
+             "(YYYY-MM-DD, YYYY-MM-DDTHH, or 'auto' to detect from AGS)",
     )
     parser.add_argument(
         "--limit", type=int, default=DEFAULT_LIMIT,
@@ -1557,11 +1560,24 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
     since_cutoff = None
     if since:
         try:
-            since_cutoff = _parse_since(since)
-            logger.info("Filtering MJ directories to >= %s", since_cutoff)
+            parsed = _parse_since(since)
         except ValueError as e:
             logger.error("%s", e)
             return EXIT_NO_DATA
+
+        if parsed == 'auto':
+            try:
+                since_cutoff = detect_since_auto(ags_host, ags_path)
+            except RuntimeError as e:
+                logger.error("Auto-detect failed: %s", e)
+                return EXIT_SSH_ERROR
+            if since_cutoff:
+                logger.info("Auto-detected --since cutoff: %s", since_cutoff)
+            else:
+                logger.info("Auto-detect found no science data; scanning all MJ dirs")
+        else:
+            since_cutoff = parsed
+            logger.info("Filtering MJ directories to >= %s", since_cutoff)
 
     try:
         ags = scan_ags_files(ags_host, ags_path)

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -1548,6 +1548,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                 if e["header"] not in recovered_headers
             ]
             results["missing_on_mj"] = comparison["missing_on_mj"]
+            results["matched"] += len(recovered_headers)
 
     # Purge flow
     purge_results = None

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -584,6 +584,88 @@ def decode_gps_time(header):
         return None
 
 
+def detect_since_auto(ags_host, ags_path):
+    """Auto-detect earliest science trigger time on AGS.
+
+    Lists AGS data files, skips bad-GPS files (1980-*), reads the first
+    128-byte header from the earliest science file, decodes its GPS time,
+    and returns a YYYY-MM-DDTHH cutoff string.
+
+    Parameters
+    ----------
+    ags_host : str
+        SSH host for AGS sensor.
+    ags_path : str
+        Path to AGS data directory.
+
+    Returns
+    -------
+    str or None
+        'YYYY-MM-DDTHH' cutoff, or None if no science data found.
+
+    Raises
+    ------
+    RuntimeError
+        If SSH connection fails.
+    """
+    # List files on AGS
+    ls_cmd = ["ssh", ags_host,
+              "ls -1 {path}".format(path=shlex.quote(ags_path))]
+    logger.debug("Auto-detect: listing AGS files: %s", " ".join(ls_cmd))
+    result = subprocess.run(
+        ls_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode('utf-8', errors='replace').strip()
+        raise RuntimeError(
+            "Failed to list AGS files on {host}: {err}".format(
+                host=ags_host, err=stderr)
+        )
+
+    filenames = [f for f in result.stdout.decode('utf-8').strip().split('\n')
+                 if f]
+    if not filenames:
+        logger.info("Auto-detect: no files on AGS")
+        return None
+
+    # Separate 1980-* (bad GPS) from science files, sort each
+    science_files = sorted(f for f in filenames if not f.startswith("1980-"))
+    if not science_files:
+        logger.info("Auto-detect: only bad-GPS (1980-*) files on AGS")
+        return None
+
+    # Try reading first header from each science file until we get a valid one
+    for fname in science_files:
+        remote_path = "{path}/{fname}".format(
+            path=ags_path, fname=fname)
+        dd_cmd = ["ssh", ags_host,
+                  "dd if={rp} bs=128 count=1 2>/dev/null".format(
+                      rp=shlex.quote(remote_path))]
+        logger.debug("Auto-detect: reading header from %s", fname)
+        dd_result = subprocess.run(
+            dd_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=30,
+        )
+        if dd_result.returncode != 0 or len(dd_result.stdout) < HEADER_SIZE:
+            logger.debug("Auto-detect: could not read header from %s", fname)
+            continue
+
+        header = dd_result.stdout[:HEADER_SIZE]
+        timestamp = decode_gps_time(header)
+        if timestamp is None:
+            logger.debug("Auto-detect: bad GPS in header of %s", fname)
+            continue
+
+        # Truncate to YYYY-MM-DDTHH
+        cutoff = timestamp[:13]
+        logger.info("Auto-detect: earliest science trigger at %s (from %s)",
+                     cutoff, fname)
+        return cutoff
+
+    logger.warning("Auto-detect: no decodable headers found in science files")
+    return None
+
+
 def detect_unit_name(hostname=None):
     """Detect unit prefix and number from hostname.
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -586,87 +586,49 @@ def decode_gps_time(header):
         return None
 
 
-def detect_since_auto(ags_host, ags_path):
-    """Auto-detect earliest science trigger time on AGS.
+def earliest_ags_timestamp(ags_entries):
+    """Find the earliest valid GPS timestamp across all AGS entries.
 
-    Lists AGS data files, skips bad-GPS files (1980-*), reads the first
-    128-byte header from the earliest science file, decodes its GPS time,
-    and returns a YYYY-MM-DDTHH cutoff string.
+    Groups entries by filename, finds the first valid GPS timestamp
+    in each file (triggers within a file are sequential, so the first
+    valid one is the earliest), and returns the minimum across all files.
 
     Parameters
     ----------
-    ags_host : str
-        SSH host for AGS sensor.
-    ags_path : str
-        Path to AGS data directory.
+    ags_entries : list of dict
+        From scan_ags_files(), each with 'header', 'filename', 'offset',
+        'index'.
 
     Returns
     -------
     str or None
-        'YYYY-MM-DDTHH' cutoff, or None if no science data found.
-
-    Raises
-    ------
-    RuntimeError
-        If SSH connection fails.
+        'YYYY-MM-DDTHH' cutoff, or None if no valid GPS found.
     """
-    # List files on AGS
-    ls_cmd = ["ssh", ags_host,
-              "ls -1 {path}".format(path=shlex.quote(ags_path))]
-    logger.debug("Auto-detect: listing AGS files: %s", " ".join(ls_cmd))
-    result = subprocess.run(
-        ls_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30,
-    )
-    if result.returncode != 0:
-        stderr = result.stderr.decode('utf-8', errors='replace').strip()
-        raise RuntimeError(
-            "Failed to list AGS files on {host}: {err}".format(
-                host=ags_host, err=stderr)
-        )
-
-    filenames = [f for f in result.stdout.decode('utf-8').strip().split('\n')
-                 if f]
-    if not filenames:
-        logger.info("Auto-detect: no files on AGS")
+    if not ags_entries:
         return None
 
-    # Separate 1980 (bad GPS) from science files, sort each
-    # Filenames have "ags" prefix, e.g. "ags1980-01-06_..." so check with "in"
-    science_files = sorted(f for f in filenames if "1980-" not in f)
-    if not science_files:
-        logger.info("Auto-detect: only bad-GPS (1980) files on AGS")
-        return None
+    # Group entries by filename
+    files = {}
+    for entry in ags_entries:
+        files.setdefault(entry["filename"], []).append(entry)
 
-    # Try reading first header from each science file until we get a valid one
-    for fname in science_files:
-        remote_path = "{path}/{fname}".format(
-            path=ags_path, fname=fname)
-        dd_cmd = ["ssh", ags_host,
-                  "dd if={rp} bs=128 count=1 2>/dev/null".format(
-                      rp=shlex.quote(remote_path))]
-        logger.debug("Auto-detect: reading header from %s", fname)
-        dd_result = subprocess.run(
-            dd_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            timeout=30,
-        )
-        if dd_result.returncode != 0 or len(dd_result.stdout) < HEADER_SIZE:
-            logger.debug("Auto-detect: could not read header from %s", fname)
-            continue
+    earliest = None
+    for filename in sorted(files):
+        # Sort by index within file (triggers are sequential)
+        triggers = sorted(files[filename], key=lambda e: e["index"])
+        for trigger in triggers:
+            timestamp = decode_gps_time(trigger["header"])
+            if timestamp is not None:
+                cutoff = timestamp[:13]  # YYYY-MM-DDTHH
+                if earliest is None or cutoff < earliest:
+                    earliest = cutoff
+                logger.debug("Auto-detect: %s first valid GPS at %s",
+                             filename, cutoff)
+                break  # First valid in file = earliest in file
 
-        header = dd_result.stdout[:HEADER_SIZE]
-        timestamp = decode_gps_time(header)
-        if timestamp is None:
-            logger.debug("Auto-detect: bad GPS in header of %s", fname)
-            continue
-
-        # Truncate to YYYY-MM-DDTHH
-        cutoff = timestamp[:13]
-        logger.info("Auto-detect: earliest science trigger at %s (from %s)",
-                     cutoff, fname)
-        return cutoff
-
-    logger.warning("Auto-detect: no decodable headers found in science files")
-    return None
+    if earliest:
+        logger.info("Auto-detect: earliest AGS trigger at %s", earliest)
+    return earliest
 
 
 def detect_unit_name(hostname=None):
@@ -1559,6 +1521,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
 
     # Parse --since into normalized directory prefix
     since_cutoff = None
+    auto_detect = False
     if since:
         try:
             parsed = _parse_since(since)
@@ -1567,24 +1530,26 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
             return EXIT_NO_DATA
 
         if parsed == 'auto':
-            try:
-                since_cutoff = detect_since_auto(ags_host, ags_path)
-            except RuntimeError as e:
-                logger.error("Auto-detect failed: %s", e)
-                return EXIT_SSH_ERROR
-            if since_cutoff:
-                logger.info("Auto-detected --since cutoff: %s", since_cutoff)
-            else:
-                logger.info("Auto-detect found no science data; scanning all MJ dirs")
+            auto_detect = True
         else:
             since_cutoff = parsed
             logger.info("Filtering MJ directories to >= %s", since_cutoff)
 
+    # AGS scan runs first (needed for auto-detect and comparison)
     try:
         ags = scan_ags_files(ags_host, ags_path)
     except RuntimeError as e:
         logger.error("AGS scan failed: %s", e)
         return EXIT_SSH_ERROR
+
+    # Auto-detect: derive cutoff from the scanned AGS entries
+    if auto_detect:
+        since_cutoff = earliest_ags_timestamp(ags["entries"])
+        if since_cutoff:
+            logger.info("Auto-detected --since cutoff: %s", since_cutoff)
+        else:
+            logger.info(
+                "Auto-detect found no valid GPS data; scanning all MJ dirs")
 
     mj = scan_mj_files(mj_path, since=since_cutoff)
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -630,10 +630,11 @@ def detect_since_auto(ags_host, ags_path):
         logger.info("Auto-detect: no files on AGS")
         return None
 
-    # Separate 1980-* (bad GPS) from science files, sort each
-    science_files = sorted(f for f in filenames if not f.startswith("1980-"))
+    # Separate 1980 (bad GPS) from science files, sort each
+    # Filenames have "ags" prefix, e.g. "ags1980-01-06_..." so check with "in"
+    science_files = sorted(f for f in filenames if "1980-" not in f)
     if not science_files:
-        logger.info("Auto-detect: only bad-GPS (1980-*) files on AGS")
+        logger.info("Auto-detect: only bad-GPS (1980) files on AGS")
         return None
 
     # Try reading first header from each science file until we get a valid one

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -1840,9 +1840,55 @@ class TestMain:
                 "hamma", "/ags/data", str(tmp_path),
                 recover=True,
             )
-        assert rc == 1  # Still EXIT_MISSING even after recovery
+        assert rc == 0  # All missing recovered -> EXIT_OK
         mock_recover.assert_called_once()
         mock_filter.assert_called_once()
+
+    def test_run_partial_recovery_still_exit_missing(self, hamma_scrub, tmp_path):
+        """run() returns EXIT_MISSING when some recoveries fail."""
+        hdr_ok = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+        hdr_fail = b'\xf5\xff\x50\x5d' + b'\x02' + b'\x00' * 123
+        ags_result = {
+            "entries": [
+                {"header": hdr_ok, "filename": "f.bin", "offset": 0, "index": 0},
+                {"header": hdr_fail, "filename": "f.bin", "offset": 1000, "index": 1},
+            ],
+            "headers": {hdr_ok, hdr_fail},
+            "duplicate_count": 0,
+            "elapsed": 1.0,
+        }
+        mj_result = {
+            "headers": set(),
+            "file_count": 5,
+            "duplicate_count": 0,
+            "skipped": 0,
+            "dirs_skipped": 0,
+            "elapsed": 1.0,
+        }
+        mock_recovery = [
+            {"source_file": "f.bin", "source_offset": 0, "trigger_index": 0,
+             "target_path": "DATA37/test/ok.bin", "size": 100,
+             "status": "recovered", "header": hdr_ok, "error": None},
+            {"source_file": "f.bin", "source_offset": 1000, "trigger_index": 1,
+             "target_path": None, "size": 0,
+             "status": "failed", "header": hdr_fail, "error": "disk full"},
+        ]
+        with patch.object(hamma_scrub, "scan_ags_files", return_value=ags_result), \
+             patch.object(hamma_scrub, "scan_mj_files", return_value=mj_result), \
+             patch.object(hamma_scrub, "cleanup_orphaned_temps", return_value=0), \
+             patch.object(hamma_scrub, "filter_recovery_candidates") as mock_filter, \
+             patch.object(hamma_scrub, "recover_triggers", return_value=mock_recovery):
+            mock_filter.return_value = [
+                {"header": hdr_ok, "filename": "f.bin", "offset": 0,
+                 "index": 0, "skip_reason": None},
+                {"header": hdr_fail, "filename": "f.bin", "offset": 1000,
+                 "index": 1, "skip_reason": None},
+            ]
+            rc = hamma_scrub.run(
+                "hamma", "/ags/data", str(tmp_path),
+                recover=True,
+            )
+        assert rc == 1  # One failed -> EXIT_MISSING
 
     def test_run_without_recover_no_recovery(self, hamma_scrub):
         """run() without recover=True does NOT invoke recovery."""

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -1848,6 +1848,12 @@ class TestCLI:
         args = parser.parse_args([])
         assert args.purge is False
 
+    def test_since_auto(self, hamma_scrub):
+        """--since auto is accepted."""
+        parser = hamma_scrub._build_parser()
+        args = parser.parse_args(["--since", "auto"])
+        assert args.since == "auto"
+
 
 class TestMain:
     """Test main() integration."""

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -555,6 +555,139 @@ class TestDecodeGpsTime:
         assert result == "2025-03-05T11:19:43.500"
 
 
+class TestDetectSinceAuto:
+    """Test --since auto date detection from AGS."""
+
+    def test_returns_date_from_earliest_science_file(self, hamma_scrub):
+        """Earliest non-1980 file header decoded to YYYY-MM-DDTHH."""
+        # Build a header with known GPS time
+        header = bytearray(128)
+        header[0:4] = b'\xf5\xff\x50\x5d'
+        struct.pack_into('<I', header, 10, 100)  # datasize
+        # GPS week 2000, timeOfWeek 259200.0 (3 days), utcOffset 18.0
+        struct.pack_into('<f', header, 80, 259200.0)
+        struct.pack_into('<h', header, 84, 2000)
+        struct.pack_into('<f', header, 86, 18.0)
+        struct.pack_into('<I', header, 94, 100)
+        struct.pack_into('<I', header, 98, 1000000000)
+        header = bytes(header)
+
+        # Expected: decode this header's GPS time, truncate to YYYY-MM-DDTHH
+        expected_ts = hamma_scrub.decode_gps_time(header)
+        expected_cutoff = expected_ts[:13]  # "YYYY-MM-DDTHH"
+
+        ls_output = "1980-01-06_00.00.00\n2026-03-15_14.30.00\n2026-03-16_10.00.00\n"
+        dd_output = header
+
+        with patch("subprocess.run") as mock_run:
+            # First call: ssh ls
+            ls_result = MagicMock()
+            ls_result.returncode = 0
+            ls_result.stdout = ls_output.encode()
+            # Second call: ssh dd (read first 128 bytes)
+            dd_result = MagicMock()
+            dd_result.returncode = 0
+            dd_result.stdout = dd_output
+            mock_run.side_effect = [ls_result, dd_result]
+
+            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
+            assert result == expected_cutoff
+
+    def test_skips_1980_files(self, hamma_scrub):
+        """All 1980-* files are skipped; uses first non-1980 file."""
+        header = bytearray(128)
+        header[0:4] = b'\xf5\xff\x50\x5d'
+        struct.pack_into('<I', header, 10, 100)
+        struct.pack_into('<f', header, 80, 259200.0)
+        struct.pack_into('<h', header, 84, 2000)
+        struct.pack_into('<f', header, 86, 18.0)
+        struct.pack_into('<I', header, 94, 100)
+        struct.pack_into('<I', header, 98, 1000000000)
+        header = bytes(header)
+
+        ls_output = "1980-01-05_00.00.00\n1980-01-06_12.00.00\n2026-04-01_08.00.00\n"
+
+        with patch("subprocess.run") as mock_run:
+            ls_result = MagicMock()
+            ls_result.returncode = 0
+            ls_result.stdout = ls_output.encode()
+            dd_result = MagicMock()
+            dd_result.returncode = 0
+            dd_result.stdout = header
+            mock_run.side_effect = [ls_result, dd_result]
+
+            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
+
+        # dd called on the first non-1980 file
+        dd_call = mock_run.call_args_list[1]
+        assert "2026-04-01_08.00.00" in dd_call[0][0][-1]
+
+    def test_all_1980_files_returns_none(self, hamma_scrub):
+        """If only 1980-* files exist, return None (no science data)."""
+        ls_output = "1980-01-05_00.00.00\n1980-01-06_12.00.00\n"
+
+        with patch("subprocess.run") as mock_run:
+            ls_result = MagicMock()
+            ls_result.returncode = 0
+            ls_result.stdout = ls_output.encode()
+            mock_run.return_value = ls_result
+
+            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
+            assert result is None
+
+    def test_empty_directory_returns_none(self, hamma_scrub):
+        """Empty AGS data directory returns None."""
+        with patch("subprocess.run") as mock_run:
+            ls_result = MagicMock()
+            ls_result.returncode = 0
+            ls_result.stdout = b""
+            mock_run.return_value = ls_result
+
+            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
+            assert result is None
+
+    def test_ssh_failure_raises(self, hamma_scrub):
+        """SSH failure raises RuntimeError."""
+        with patch("subprocess.run") as mock_run:
+            ls_result = MagicMock()
+            ls_result.returncode = 1
+            ls_result.stderr = b"Connection refused"
+            mock_run.return_value = ls_result
+
+            with pytest.raises(RuntimeError, match="Failed to list AGS"):
+                hamma_scrub.detect_since_auto("hamma", "/ags/data")
+
+    def test_bad_header_in_first_file_tries_next(self, hamma_scrub):
+        """If first science file header can't be decoded, try next file."""
+        bad_header = b'\x00' * 128  # No sync marker, decode_gps_time returns None
+        good_header = bytearray(128)
+        good_header[0:4] = b'\xf5\xff\x50\x5d'
+        struct.pack_into('<I', good_header, 10, 100)
+        struct.pack_into('<f', good_header, 80, 259200.0)
+        struct.pack_into('<h', good_header, 84, 2000)
+        struct.pack_into('<f', good_header, 86, 18.0)
+        struct.pack_into('<I', good_header, 94, 100)
+        struct.pack_into('<I', good_header, 98, 1000000000)
+        good_header = bytes(good_header)
+
+        ls_output = "2026-03-10_08.00.00\n2026-03-11_09.00.00\n"
+
+        with patch("subprocess.run") as mock_run:
+            ls_result = MagicMock()
+            ls_result.returncode = 0
+            ls_result.stdout = ls_output.encode()
+            dd_bad = MagicMock()
+            dd_bad.returncode = 0
+            dd_bad.stdout = bad_header
+            dd_good = MagicMock()
+            dd_good.returncode = 0
+            dd_good.stdout = good_header
+            mock_run.side_effect = [ls_result, dd_bad, dd_good]
+
+            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
+            assert result is not None
+
+
 class TestDetectUnitName:
     """Test hostname-based unit name detection."""
 

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -298,6 +298,15 @@ class TestParseSince:
     def test_strips_whitespace(self, hamma_scrub):
         assert hamma_scrub._parse_since("  2026-04-10  ") == "2026-04-10T00"
 
+    def test_auto_value_returns_sentinel(self, hamma_scrub):
+        """'auto' returns the sentinel string 'auto'."""
+        assert hamma_scrub._parse_since("auto") == "auto"
+
+    def test_auto_case_insensitive(self, hamma_scrub):
+        """'AUTO' and 'Auto' also return 'auto'."""
+        assert hamma_scrub._parse_since("AUTO") == "auto"
+        assert hamma_scrub._parse_since("Auto") == "auto"
+
 
 class TestStriderProtocol:
     """Test encoding/decoding of the strider binary protocol."""
@@ -2166,3 +2175,82 @@ class TestMain:
         # Purge was called even though no triggers were missing
         mock_identify.assert_called_once()
         mock_purge.assert_called_once()
+
+
+class TestRunSinceAuto:
+    """Test --since auto integration in run()."""
+
+    def test_since_auto_calls_detect(self, hamma_scrub):
+        """run() with since='auto' calls detect_since_auto()."""
+        hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+        ags_result = {
+            "entries": [{"header": hdr, "filename": "f.bin",
+                         "offset": 0, "index": 0}],
+            "headers": {hdr},
+            "duplicate_count": 0,
+            "elapsed": 1.0,
+        }
+        mj_result = {
+            "headers": {hdr},
+            "file_count": 5,
+            "duplicate_count": 0,
+            "skipped": 0,
+            "dirs_skipped": 0,
+            "elapsed": 1.0,
+        }
+
+        with patch.object(hamma_scrub, "detect_since_auto",
+                          return_value="2026-03-15T14") as mock_detect, \
+             patch.object(hamma_scrub, "scan_ags_files",
+                          return_value=ags_result), \
+             patch.object(hamma_scrub, "scan_mj_files",
+                          return_value=mj_result):
+            rc = hamma_scrub.run(
+                ags_host="hamma", ags_path="/ags/data",
+                mj_path="/media/pi", since="auto",
+            )
+            mock_detect.assert_called_once_with("hamma", "/ags/data")
+            assert rc == 0
+
+    def test_since_auto_none_skips_filter(self, hamma_scrub):
+        """If detect_since_auto() returns None, no since filter is applied."""
+        hdr = b'\xf5\xff\x50\x5d' + b'\x02' + b'\x00' * 123
+        ags_result = {
+            "entries": [{"header": hdr, "filename": "f.bin",
+                         "offset": 0, "index": 0}],
+            "headers": {hdr},
+            "duplicate_count": 0,
+            "elapsed": 1.0,
+        }
+        mj_result = {
+            "headers": {hdr},
+            "file_count": 5,
+            "duplicate_count": 0,
+            "skipped": 0,
+            "dirs_skipped": 0,
+            "elapsed": 1.0,
+        }
+
+        with patch.object(hamma_scrub, "detect_since_auto",
+                          return_value=None) as mock_detect, \
+             patch.object(hamma_scrub, "scan_ags_files",
+                          return_value=ags_result), \
+             patch.object(hamma_scrub, "scan_mj_files",
+                          return_value=mj_result) as mock_mj:
+            rc = hamma_scrub.run(
+                ags_host="hamma", ags_path="/ags/data",
+                mj_path="/media/pi", since="auto",
+            )
+            # scan_mj_files called without since filter
+            mock_mj.assert_called_once_with("/media/pi", since=None)
+            assert rc == 0
+
+    def test_since_auto_ssh_error(self, hamma_scrub):
+        """If detect_since_auto() raises RuntimeError, return EXIT_SSH_ERROR."""
+        with patch.object(hamma_scrub, "detect_since_auto",
+                          side_effect=RuntimeError("SSH failed")):
+            rc = hamma_scrub.run(
+                ags_host="hamma", ags_path="/ags/data",
+                mj_path="/media/pi", since="auto",
+            )
+            assert rc == hamma_scrub.EXIT_SSH_ERROR

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -585,7 +585,7 @@ class TestDetectSinceAuto:
         expected_ts = hamma_scrub.decode_gps_time(header)
         expected_cutoff = expected_ts[:13]  # "YYYY-MM-DDTHH"
 
-        ls_output = "1980-01-06_00.00.00\n2026-03-15_14.30.00\n2026-03-16_10.00.00\n"
+        ls_output = "ags1980-01-06_00.00.00\nags2026-03-15_14.30.00\nags2026-03-16_10.00.00\n"
         dd_output = header
 
         with patch("subprocess.run") as mock_run:
@@ -614,7 +614,7 @@ class TestDetectSinceAuto:
         struct.pack_into('<I', header, 98, 1000000000)
         header = bytes(header)
 
-        ls_output = "1980-01-05_00.00.00\n1980-01-06_12.00.00\n2026-04-01_08.00.00\n"
+        ls_output = "ags1980-01-05_00.00.00\nags1980-01-06_12.00.00\nags2026-04-01_08.00.00\n"
 
         with patch("subprocess.run") as mock_run:
             ls_result = MagicMock()
@@ -629,11 +629,11 @@ class TestDetectSinceAuto:
 
         # dd called on the first non-1980 file
         dd_call = mock_run.call_args_list[1]
-        assert "2026-04-01_08.00.00" in dd_call[0][0][-1]
+        assert "ags2026-04-01_08.00.00" in dd_call[0][0][-1]
 
     def test_all_1980_files_returns_none(self, hamma_scrub):
         """If only 1980-* files exist, return None (no science data)."""
-        ls_output = "1980-01-05_00.00.00\n1980-01-06_12.00.00\n"
+        ls_output = "ags1980-01-05_00.00.00\nags1980-01-06_12.00.00\n"
 
         with patch("subprocess.run") as mock_run:
             ls_result = MagicMock()
@@ -679,7 +679,7 @@ class TestDetectSinceAuto:
         struct.pack_into('<I', good_header, 98, 1000000000)
         good_header = bytes(good_header)
 
-        ls_output = "2026-03-10_08.00.00\n2026-03-11_09.00.00\n"
+        ls_output = "ags2026-03-10_08.00.00\nags2026-03-11_09.00.00\n"
 
         with patch("subprocess.run") as mock_run:
             ls_result = MagicMock()

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -27,6 +27,24 @@ def _make_trigger(datasize=TEST_DATASIZE, sync=SYNC_MARKER, pad=4):
     return bytes(header), payload + padding
 
 
+def _make_gps_header(week=2412, tow=522847.0, utc_offset=18.0,
+                     subsecond=808000000, ecc=1000000000):
+    """Build a 128-byte header with configurable GPS fields.
+
+    Defaults produce timestamp 2026-04-04T01:13:50.808.
+    Use week=0, tow=0.0 for bad GPS (year < 2000 -> decode returns None).
+    """
+    header = bytearray(128)
+    header[0:4] = SYNC_MARKER
+    struct.pack_into('<I', header, 10, TEST_DATASIZE)
+    struct.pack_into('<f', header, 80, tow)
+    struct.pack_into('<h', header, 84, week)
+    struct.pack_into('<f', header, 86, utc_offset)
+    struct.pack_into('<I', header, 94, subsecond)
+    struct.pack_into('<I', header, 98, ecc)
+    return bytes(header)
+
+
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 SCRIPT_PATH = REPO_ROOT / "scripts" / "hamma_scrub.py"
 
@@ -564,137 +582,90 @@ class TestDecodeGpsTime:
         assert result == "2025-03-05T11:19:43.500"
 
 
-class TestDetectSinceAuto:
-    """Test --since auto date detection from AGS."""
+class TestEarliestAgsTimestamp:
+    """Test earliest_ags_timestamp() — derives --since cutoff from AGS data."""
 
-    def test_returns_date_from_earliest_science_file(self, hamma_scrub):
-        """Earliest non-1980 file header decoded to YYYY-MM-DDTHH."""
-        # Build a header with known GPS time
-        header = bytearray(128)
-        header[0:4] = b'\xf5\xff\x50\x5d'
-        struct.pack_into('<I', header, 10, 100)  # datasize
-        # GPS week 2000, timeOfWeek 259200.0 (3 days), utcOffset 18.0
-        struct.pack_into('<f', header, 80, 259200.0)
-        struct.pack_into('<h', header, 84, 2000)
-        struct.pack_into('<f', header, 86, 18.0)
-        struct.pack_into('<I', header, 94, 100)
-        struct.pack_into('<I', header, 98, 1000000000)
-        header = bytes(header)
+    def test_returns_earliest_valid_gps(self, hamma_scrub):
+        """Returns YYYY-MM-DDTHH from earliest valid GPS across files."""
+        # week 2412, tow ~522847 -> 2026-04-04T01
+        hdr_early = _make_gps_header(week=2412, tow=522847.0)
+        # week 2413, tow ~522847 -> ~1 week later
+        hdr_late = _make_gps_header(week=2413, tow=522847.0)
+        entries = [
+            {"header": hdr_late, "filename": "ags2026-04-11.bin",
+             "offset": 0, "index": 0},
+            {"header": hdr_early, "filename": "ags2026-04-04.bin",
+             "offset": 0, "index": 0},
+        ]
+        expected = hamma_scrub.decode_gps_time(hdr_early)[:13]
+        result = hamma_scrub.earliest_ags_timestamp(entries)
+        assert result == expected
 
-        # Expected: decode this header's GPS time, truncate to YYYY-MM-DDTHH
-        expected_ts = hamma_scrub.decode_gps_time(header)
-        expected_cutoff = expected_ts[:13]  # "YYYY-MM-DDTHH"
+    def test_includes_1980_files(self, hamma_scrub):
+        """1980-named files are examined, not skipped."""
+        # 1980 file: first trigger bad GPS, second trigger has valid GPS
+        hdr_bad = _make_gps_header(week=0, tow=0.0)  # bad GPS
+        hdr_1980_good = _make_gps_header(week=2410, tow=100000.0)
+        # ags2026 file: valid GPS but later
+        hdr_2026 = _make_gps_header(week=2412, tow=522847.0)
+        entries = [
+            {"header": hdr_bad, "filename": "ags1980-01-06.bin",
+             "offset": 0, "index": 0},
+            {"header": hdr_1980_good, "filename": "ags1980-01-06.bin",
+             "offset": 22000000, "index": 1},
+            {"header": hdr_2026, "filename": "ags2026-04-04.bin",
+             "offset": 0, "index": 0},
+        ]
+        expected = hamma_scrub.decode_gps_time(hdr_1980_good)[:13]
+        result = hamma_scrub.earliest_ags_timestamp(entries)
+        assert result == expected
 
-        ls_output = "ags1980-01-06_00.00.00\nags2026-03-15_14.30.00\nags2026-03-16_10.00.00\n"
-        dd_output = header
+    def test_skips_bad_gps_within_file(self, hamma_scrub):
+        """Bad GPS triggers (year < 2000) are skipped; first valid wins."""
+        hdr_bad = _make_gps_header(week=0, tow=0.0)
+        hdr_good = _make_gps_header(week=2412, tow=522847.0)
+        entries = [
+            {"header": hdr_bad, "filename": "ags1980-01-06.bin",
+             "offset": 0, "index": 0},
+            {"header": hdr_good, "filename": "ags1980-01-06.bin",
+             "offset": 22000000, "index": 1},
+        ]
+        expected = hamma_scrub.decode_gps_time(hdr_good)[:13]
+        result = hamma_scrub.earliest_ags_timestamp(entries)
+        assert result == expected
 
-        with patch("subprocess.run") as mock_run:
-            # First call: ssh ls
-            ls_result = MagicMock()
-            ls_result.returncode = 0
-            ls_result.stdout = ls_output.encode()
-            # Second call: ssh dd (read first 128 bytes)
-            dd_result = MagicMock()
-            dd_result.returncode = 0
-            dd_result.stdout = dd_output
-            mock_run.side_effect = [ls_result, dd_result]
+    def test_all_bad_gps_returns_none(self, hamma_scrub):
+        """If no trigger has valid GPS, return None."""
+        hdr_bad = _make_gps_header(week=0, tow=0.0)
+        entries = [
+            {"header": hdr_bad, "filename": "ags1980-01-06.bin",
+             "offset": 0, "index": 0},
+            {"header": hdr_bad, "filename": "ags1980-01-06.bin",
+             "offset": 22000000, "index": 1},
+        ]
+        assert hamma_scrub.earliest_ags_timestamp(entries) is None
 
-            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
-            assert result == expected_cutoff
+    def test_empty_entries_returns_none(self, hamma_scrub):
+        """Empty entry list returns None."""
+        assert hamma_scrub.earliest_ags_timestamp([]) is None
 
-    def test_skips_1980_files(self, hamma_scrub):
-        """All 1980-* files are skipped; uses first non-1980 file."""
-        header = bytearray(128)
-        header[0:4] = b'\xf5\xff\x50\x5d'
-        struct.pack_into('<I', header, 10, 100)
-        struct.pack_into('<f', header, 80, 259200.0)
-        struct.pack_into('<h', header, 84, 2000)
-        struct.pack_into('<f', header, 86, 18.0)
-        struct.pack_into('<I', header, 94, 100)
-        struct.pack_into('<I', header, 98, 1000000000)
-        header = bytes(header)
-
-        ls_output = "ags1980-01-05_00.00.00\nags1980-01-06_12.00.00\nags2026-04-01_08.00.00\n"
-
-        with patch("subprocess.run") as mock_run:
-            ls_result = MagicMock()
-            ls_result.returncode = 0
-            ls_result.stdout = ls_output.encode()
-            dd_result = MagicMock()
-            dd_result.returncode = 0
-            dd_result.stdout = header
-            mock_run.side_effect = [ls_result, dd_result]
-
-            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
-
-        # dd called on the first non-1980 file
-        dd_call = mock_run.call_args_list[1]
-        assert "ags2026-04-01_08.00.00" in dd_call[0][0][-1]
-
-    def test_all_1980_files_returns_none(self, hamma_scrub):
-        """If only 1980-* files exist, return None (no science data)."""
-        ls_output = "ags1980-01-05_00.00.00\nags1980-01-06_12.00.00\n"
-
-        with patch("subprocess.run") as mock_run:
-            ls_result = MagicMock()
-            ls_result.returncode = 0
-            ls_result.stdout = ls_output.encode()
-            mock_run.return_value = ls_result
-
-            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
-            assert result is None
-
-    def test_empty_directory_returns_none(self, hamma_scrub):
-        """Empty AGS data directory returns None."""
-        with patch("subprocess.run") as mock_run:
-            ls_result = MagicMock()
-            ls_result.returncode = 0
-            ls_result.stdout = b""
-            mock_run.return_value = ls_result
-
-            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
-            assert result is None
-
-    def test_ssh_failure_raises(self, hamma_scrub):
-        """SSH failure raises RuntimeError."""
-        with patch("subprocess.run") as mock_run:
-            ls_result = MagicMock()
-            ls_result.returncode = 1
-            ls_result.stderr = b"Connection refused"
-            mock_run.return_value = ls_result
-
-            with pytest.raises(RuntimeError, match="Failed to list AGS"):
-                hamma_scrub.detect_since_auto("hamma", "/ags/data")
-
-    def test_bad_header_in_first_file_tries_next(self, hamma_scrub):
-        """If first science file header can't be decoded, try next file."""
-        bad_header = b'\x00' * 128  # No sync marker, decode_gps_time returns None
-        good_header = bytearray(128)
-        good_header[0:4] = b'\xf5\xff\x50\x5d'
-        struct.pack_into('<I', good_header, 10, 100)
-        struct.pack_into('<f', good_header, 80, 259200.0)
-        struct.pack_into('<h', good_header, 84, 2000)
-        struct.pack_into('<f', good_header, 86, 18.0)
-        struct.pack_into('<I', good_header, 94, 100)
-        struct.pack_into('<I', good_header, 98, 1000000000)
-        good_header = bytes(good_header)
-
-        ls_output = "ags2026-03-10_08.00.00\nags2026-03-11_09.00.00\n"
-
-        with patch("subprocess.run") as mock_run:
-            ls_result = MagicMock()
-            ls_result.returncode = 0
-            ls_result.stdout = ls_output.encode()
-            dd_bad = MagicMock()
-            dd_bad.returncode = 0
-            dd_bad.stdout = bad_header
-            dd_good = MagicMock()
-            dd_good.returncode = 0
-            dd_good.stdout = good_header
-            mock_run.side_effect = [ls_result, dd_bad, dd_good]
-
-            result = hamma_scrub.detect_since_auto("hamma", "/ags/data")
-            assert result is not None
+    def test_stops_at_first_valid_per_file(self, hamma_scrub):
+        """Only examines triggers until first valid GPS in each file."""
+        hdr_bad = _make_gps_header(week=0, tow=0.0)
+        hdr_first = _make_gps_header(week=2412, tow=100000.0)
+        hdr_second = _make_gps_header(week=2412, tow=200000.0)
+        entries = [
+            {"header": hdr_bad, "filename": "file.bin",
+             "offset": 0, "index": 0},
+            {"header": hdr_first, "filename": "file.bin",
+             "offset": 22000000, "index": 1},
+            {"header": hdr_second, "filename": "file.bin",
+             "offset": 44000000, "index": 2},
+        ]
+        # Should return cutoff from hdr_first, not hdr_second
+        expected = hamma_scrub.decode_gps_time(hdr_first)[:13]
+        result = hamma_scrub.earliest_ags_timestamp(entries)
+        assert result == expected
 
 
 class TestDetectUnitName:
@@ -2186,9 +2157,10 @@ class TestMain:
 class TestRunSinceAuto:
     """Test --since auto integration in run()."""
 
-    def test_since_auto_calls_detect(self, hamma_scrub):
-        """run() with since='auto' calls detect_since_auto()."""
-        hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+    def test_since_auto_derives_cutoff_from_ags(self, hamma_scrub):
+        """run() with since='auto' derives cutoff from AGS entries."""
+        hdr = _make_gps_header()
+        expected_cutoff = hamma_scrub.decode_gps_time(hdr)[:13]
         ags_result = {
             "entries": [{"header": hdr, "filename": "f.bin",
                          "offset": 0, "index": 0}],
@@ -2205,31 +2177,31 @@ class TestRunSinceAuto:
             "elapsed": 1.0,
         }
 
-        with patch.object(hamma_scrub, "detect_since_auto",
-                          return_value="2026-03-15T14") as mock_detect, \
-             patch.object(hamma_scrub, "scan_ags_files",
+        with patch.object(hamma_scrub, "scan_ags_files",
                           return_value=ags_result), \
              patch.object(hamma_scrub, "scan_mj_files",
-                          return_value=mj_result):
+                          return_value=mj_result) as mock_mj:
             rc = hamma_scrub.run(
                 ags_host="hamma", ags_path="/ags/data",
                 mj_path="/media/pi", since="auto",
             )
-            mock_detect.assert_called_once_with("hamma", "/ags/data")
+            # scan_mj_files called with cutoff derived from AGS data
+            mock_mj.assert_called_once_with("/media/pi", since=expected_cutoff)
             assert rc == 0
 
-    def test_since_auto_none_skips_filter(self, hamma_scrub):
-        """If detect_since_auto() returns None, no since filter is applied."""
-        hdr = b'\xf5\xff\x50\x5d' + b'\x02' + b'\x00' * 123
+    def test_since_auto_no_valid_gps_scans_all(self, hamma_scrub):
+        """If no AGS entry has valid GPS, no since filter is applied."""
+        hdr_bad = _make_gps_header(week=0, tow=0.0)
+        hdr_mj = b'\xf5\xff\x50\x5d' + b'\x02' + b'\x00' * 123
         ags_result = {
-            "entries": [{"header": hdr, "filename": "f.bin",
+            "entries": [{"header": hdr_bad, "filename": "f.bin",
                          "offset": 0, "index": 0}],
-            "headers": {hdr},
+            "headers": {hdr_bad},
             "duplicate_count": 0,
             "elapsed": 1.0,
         }
         mj_result = {
-            "headers": {hdr},
+            "headers": {hdr_mj},
             "file_count": 5,
             "duplicate_count": 0,
             "skipped": 0,
@@ -2237,9 +2209,7 @@ class TestRunSinceAuto:
             "elapsed": 1.0,
         }
 
-        with patch.object(hamma_scrub, "detect_since_auto",
-                          return_value=None) as mock_detect, \
-             patch.object(hamma_scrub, "scan_ags_files",
+        with patch.object(hamma_scrub, "scan_ags_files",
                           return_value=ags_result), \
              patch.object(hamma_scrub, "scan_mj_files",
                           return_value=mj_result) as mock_mj:
@@ -2249,11 +2219,10 @@ class TestRunSinceAuto:
             )
             # scan_mj_files called without since filter
             mock_mj.assert_called_once_with("/media/pi", since=None)
-            assert rc == 0
 
-    def test_since_auto_ssh_error(self, hamma_scrub):
-        """If detect_since_auto() raises RuntimeError, return EXIT_SSH_ERROR."""
-        with patch.object(hamma_scrub, "detect_since_auto",
+    def test_since_auto_ags_scan_fails(self, hamma_scrub):
+        """If AGS scan fails, return EXIT_SSH_ERROR."""
+        with patch.object(hamma_scrub, "scan_ags_files",
                           side_effect=RuntimeError("SSH failed")):
             rc = hamma_scrub.run(
                 ags_host="hamma", ags_path="/ags/data",

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -1,0 +1,181 @@
+"""Tests for state_monitor scrub-on-low-space integration."""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# --- Module loading with mocked dependencies ---
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PLUGIN_PATH = REPO_ROOT / "plugins" / "state_monitor.py"
+
+
+class MockOutputStep:
+    """Stand-in for brokkr.pipeline.base.OutputStep."""
+
+    def __init__(self, **kwargs):
+        self.logger = MagicMock()
+        self.name = kwargs.get("name", "test_step")
+
+
+def load_state_monitor_module():
+    """Load the state_monitor plugin with mocked dependencies."""
+    mock_base = MagicMock()
+    mock_base.OutputStep = MockOutputStep
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.base = mock_base
+
+    mock_brokkr = MagicMock()
+    mock_brokkr.pipeline = mock_pipeline
+    mock_brokkr.pipeline.base = mock_base
+
+    with patch.dict("sys.modules", {
+        "brokkr": mock_brokkr,
+        "brokkr.pipeline": mock_pipeline,
+        "brokkr.pipeline.base": mock_base,
+        "brokkr.pipeline.decode": MagicMock(),
+        "brokkr.utils": MagicMock(),
+        "brokkr.utils.output": MagicMock(),
+        "notifiers": MagicMock(),
+        "notifiers.slack": MagicMock(),
+        "notifiers.google_chat": MagicMock(),
+    }):
+        spec = importlib.util.spec_from_file_location(
+            "state_monitor", str(PLUGIN_PATH))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+    return module
+
+
+MODULE = load_state_monitor_module()
+StateMonitor = MODULE.StateMonitor
+
+
+# --- Helpers ---
+
+class FakeDataValue:
+    """Minimal stand-in for brokkr DataValue."""
+    def __init__(self, value):
+        self.value = value
+
+
+def make_input_data(bytes_remaining):
+    """Create minimal input_data dict with bytes_remaining."""
+    return {"bytes_remaining": FakeDataValue(bytes_remaining)}
+
+
+def make_monitor(scrub_command="", low_space=100, space_previous=150):
+    """Create a StateMonitor instance with test defaults."""
+    mon = StateMonitor.__new__(StateMonitor)
+    mon.low_space = low_space
+    mon.scrub_command = scrub_command
+    mon.logger = MagicMock()
+    mon._previous_data = make_input_data(space_previous)
+    return mon
+
+
+# --- Tests ---
+
+class TestScrubSpawning:
+    """Test that check_sensor_drive spawns scrub on threshold crossing."""
+
+    def test_scrub_spawned_on_low_space(self):
+        """When space drops below threshold, scrub process is spawned."""
+        mon = make_monitor(
+            scrub_command="python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto",
+            space_previous=150,
+        )
+
+        with patch("subprocess.Popen") as mock_popen:
+            msg = mon.check_sensor_drive(make_input_data(90))
+
+        assert msg is not None
+        mock_popen.assert_called_once()
+        popen_cmd = mock_popen.call_args[0][0]
+        assert "flock" in popen_cmd[0]
+
+    def test_no_scrub_when_already_below(self):
+        """No scrub if space was already below threshold (not a crossing)."""
+        mon = make_monitor(
+            scrub_command="python3 /path/to/scrub.py --recover --purge --since auto",
+            space_previous=80,
+        )
+
+        with patch("subprocess.Popen") as mock_popen:
+            msg = mon.check_sensor_drive(make_input_data(70))
+
+        assert msg is None
+        mock_popen.assert_not_called()
+
+    def test_no_scrub_when_command_empty(self):
+        """No scrub if scrub_command is empty."""
+        mon = make_monitor(scrub_command="", space_previous=150)
+
+        with patch("subprocess.Popen") as mock_popen:
+            msg = mon.check_sensor_drive(make_input_data(90))
+
+        assert msg is not None  # alert still fires
+        mock_popen.assert_not_called()
+
+    def test_scrub_failure_logged_not_raised(self):
+        """If Popen fails, error is logged but check_sensor_drive still returns."""
+        mon = make_monitor(
+            scrub_command="python3 /path/to/scrub.py",
+            space_previous=150,
+        )
+
+        with patch("subprocess.Popen", side_effect=OSError("flock not found")):
+            msg = mon.check_sensor_drive(make_input_data(90))
+
+        assert msg is not None
+        mon.logger.error.assert_called()
+
+    def test_flock_uses_lock_file(self):
+        """Popen command uses flock with a specific lock file."""
+        mon = make_monitor(
+            scrub_command="python3 /path/to/scrub.py --recover --purge --since auto",
+            space_previous=150,
+        )
+
+        with patch("subprocess.Popen") as mock_popen:
+            mon.check_sensor_drive(make_input_data(90))
+
+        popen_cmd = mock_popen.call_args[0][0]
+        # Should be: flock -n /tmp/hamma_scrub.lock <scrub_command>
+        assert popen_cmd[0] == "flock"
+        assert popen_cmd[1] == "-n"
+        assert "hamma_scrub.lock" in popen_cmd[2]
+        popen_kwargs = mock_popen.call_args[1]
+        assert popen_kwargs["start_new_session"] is True
+        assert popen_kwargs["stdout"] == subprocess.DEVNULL
+        assert popen_kwargs["stderr"] == subprocess.DEVNULL
+
+    def test_no_scrub_when_command_whitespace_only(self):
+        """No scrub if scrub_command is whitespace-only."""
+        mon = make_monitor(scrub_command="   ", space_previous=150)
+
+        with patch("subprocess.Popen") as mock_popen:
+            msg = mon.check_sensor_drive(make_input_data(90))
+
+        assert msg is not None  # alert still fires
+        mock_popen.assert_not_called()
+
+
+class TestScrubConfig:
+    """Test scrub_command config wiring."""
+
+    def test_init_accepts_scrub_command(self):
+        """StateMonitor accepts scrub_command parameter."""
+        mon = make_monitor(scrub_command="python3 /path/to/scrub.py")
+        assert mon.scrub_command == "python3 /path/to/scrub.py"
+
+    def test_init_default_scrub_command_empty(self):
+        """Default scrub_command is empty string (disabled)."""
+        mon = make_monitor(scrub_command="")
+        assert mon.scrub_command == ""


### PR DESCRIPTION
## Summary

- **`--since auto`**: Auto-detects earliest AGS trigger time from scanned data (not filenames) and uses it as the MJ directory filter cutoff. Examines all files including 1980-dated ones — AGS filenames are unreliable, reflecting only GPS lock state at first trigger.
- **State monitor integration**: `_spawn_scrub()` fires on low drive space, guarded by `flock` to prevent concurrent runs. Configurable via `scrub_command` in `[steps.state_monitor]`.
- **Config**: Added `scrub_command` to `main.toml` state_monitor step.

## Implementation

`earliest_ags_timestamp()` replaces the old `detect_since_auto()` SSH pre-scan. Instead of guessing from filenames, it derives the cutoff from the AGS strider scan that already reads every header. Run order: AGS scan → derive cutoff → MJ scan.

## Testing

- 149 unit tests for hamma_scrub + 8 for state_monitor scrub integration
- E2E verified on mj05, mj41, mj42, mj43
- mj43 confirmed the fix: two 1980 files had valid GPS from 2026-03-27, almost a month before the first ags2026 file — old code would have set the cutoff to April 20 and missed that data

## Test plan

- [x] Unit tests pass (`pytest tests/python/test_hamma_scrub.py tests/python/test_state_monitor_scrub.py`)
- [x] E2E `--since auto` on mj05 (local site)
- [x] E2E `--since auto` on mj41 (remote, cellular)
- [x] E2E `--since auto` on mj42
- [x] E2E `--since auto` on mj43 (has 1980 files with month-old valid GPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)