### PR TITLE
feat(server): add install.sh to symlink mjol_array and webgen onto PATH

### DIFF
--- a/server/install.sh
+++ b/server/install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Install symlinks for the server-side mjolnir-hamma scripts so they can be
+# invoked by name from anywhere on PATH (e.g. `mjol_array --status -a hamma`
+# instead of `./mjol_array.py`).
+#
+# Usage:
+#     bash server/install.sh                      # default: /usr/local/bin (uses sudo)
+#     bash server/install.sh ~/.local/bin         # user-local, no sudo
+#     bash server/install.sh /custom/bin          # custom dir
+#
+# Idempotent: re-running just refreshes the symlinks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+TARGET_DIR="${1:-/usr/local/bin}"
+
+# `sudo` only when we don't own the target dir
+if [[ -w "$TARGET_DIR" ]] || { [[ ! -e "$TARGET_DIR" ]] && [[ -w "$(dirname "$TARGET_DIR")" ]]; }; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+$SUDO mkdir -p "$TARGET_DIR"
+
+for tool in mjol_array webgen; do
+    src="$SCRIPT_DIR/${tool}.py"
+    dest="$TARGET_DIR/$tool"
+
+    if [[ ! -f "$src" ]]; then
+        echo "[FAIL] $src not found, skipping" >&2
+        continue
+    fi
+
+    chmod +x "$src"
+    $SUDO ln -sfn "$src" "$dest"
+    echo "[OK] $dest -> $src"
+done
+
+case ":$PATH:" in
+    *":$TARGET_DIR:"*) ;;
+    *)
+        echo
+        echo "Note: $TARGET_DIR is not on \$PATH. Add it to your shell rc, e.g.:"
+        echo "    echo 'export PATH=\"$TARGET_DIR:\$PATH\"' >> ~/.bashrc"
+        ;;
+esac


### PR DESCRIPTION
## Summary

Cherry-picked from the abandoned `claude/fix-pandas-shutdown-wsMqM` branch as the second of two logical units (the first, the `pandas`/`numpy` lazy-import fix, is opened as #57).

Adds `server/install.sh` so operators can invoke `mjol_array --status -a hamma` from any directory on the VPS instead of `./mjol_array.py` from the repo.

- Default install dir: `/usr/local/bin` (uses `sudo` if the target isn't writable)
- Override: pass a dir as the first arg, e.g. `bash server/install.sh ~/.local/bin`
- Idempotent — re-running just refreshes the symlinks
- Symlinks both `mjol_array` and `webgen`
- Warns if the chosen dir isn't on `$PATH`

## Test plan

- [x] `bash -n server/install.sh` — syntax clean
- [ ] On VPS: `bash server/install.sh` then `mjol_array --status -a hamma` from `~`
- [ ] Re-run installer to confirm idempotence
- [ ] Try a non-PATH dir and confirm the warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)