### PR TITLE
feat(sensors): notify on on/off/failure via state_monitor channel

### DIFF
--- a/scripts/sensors.py
+++ b/scripts/sensors.py
@@ -16,6 +16,7 @@ import argparse
 import datetime
 import glob as glob_module
 import os
+import socket
 import subprocess
 import sys
 
@@ -28,6 +29,7 @@ import tomli
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT = os.path.normpath(os.path.join(SCRIPT_DIR, ".."))
 SYSTEM_UNIT_TOML = os.path.join(REPO_ROOT, "config", "unit.toml")
+SYSTEM_MAIN_TOML = os.path.join(REPO_ROOT, "config", "main.toml")
 LOCAL_UNIT_TOML = os.path.expanduser(
     "~/.config/brokkr/hamma/unit.toml")
 
@@ -115,6 +117,181 @@ def load_relay_config(local_path=None, system_path=None):
         sys.exit(1)
 
     return relay
+
+
+# --- Notifications (uses same channel as state_monitor) ---
+
+def load_notifier_config(main_toml_path=None):
+    """Load notifier config from main.toml's [steps.state_monitor] block.
+
+    Reuses the same method/channel/key_file that the state_monitor plugin
+    uses, so on/off notifications land in the same chat channel.
+
+    Parameters
+    ----------
+    main_toml_path : str, optional
+        Path to main.toml. Defaults to repo config/main.toml.
+
+    Returns
+    -------
+    dict or None
+        Dict with 'method', 'channel', 'key_file' (any may be None), or
+        None if main.toml or the state_monitor block is missing/malformed.
+    """
+    if main_toml_path is None:
+        main_toml_path = SYSTEM_MAIN_TOML
+    if not os.path.isfile(main_toml_path):
+        return None
+    try:
+        with open(main_toml_path, "rb") as f:
+            data = tomli.load(f)
+    except (tomli.TOMLDecodeError, OSError):
+        return None
+    try:
+        sm = data["steps"]["state_monitor"]
+    except (KeyError, TypeError):
+        return None
+    return {
+        "method": sm.get("method"),
+        "channel": sm.get("channel"),
+        "key_file": sm.get("key_file"),
+    }
+
+
+def build_sender(notifier_config):
+    """Instantiate a notifier sender from config.
+
+    Returns None on any failure (missing config, unknown method, import
+    error, missing key file). All failures print a [WARN] to stderr and
+    are swallowed so notifications never block the main on/off operation.
+
+    Parameters
+    ----------
+    notifier_config : dict or None
+        Output of load_notifier_config().
+
+    Returns
+    -------
+    object or None
+        Sender with a .send(msg) method, or None.
+    """
+    if not notifier_config:
+        return None
+    method = notifier_config.get("method")
+    key_file = notifier_config.get("key_file")
+    channel = notifier_config.get("channel")
+    if not method or not key_file:
+        return None
+
+    try:
+        if method == "gchat":
+            from notifiers.google_chat import GoogleChatSender
+            cls = GoogleChatSender
+        elif method == "slack":
+            from notifiers.slack import SlackSender
+            cls = SlackSender
+        else:
+            print("[WARN] Unknown notifier method '{}'; "
+                  "skipping notification.".format(method), file=sys.stderr)
+            return None
+    except ImportError as exc:
+        print("[WARN] Could not import notifier ({}); "
+              "skipping notification.".format(exc), file=sys.stderr)
+        return None
+
+    try:
+        return cls(key_file, channel=channel)
+    except FileNotFoundError:
+        print("[WARN] Notifier key file not found: {}; "
+              "skipping notification.".format(key_file), file=sys.stderr)
+        return None
+    except Exception as exc:
+        print("[WARN] Could not initialize notifier ({}: {}); "
+              "skipping notification.".format(type(exc).__name__, exc),
+              file=sys.stderr)
+        return None
+
+
+def get_unit_identifier(local_path=None):
+    """Return (sensor_name, site_description) for notification messages.
+
+    sensor_name is 'MjolnirNN' from unit.toml's 'number'. Falls back to
+    socket.gethostname() if the number is missing or the file can't be
+    read. site_description is None if not set in unit.toml.
+
+    Parameters
+    ----------
+    local_path : str, optional
+        Path to local unit.toml. Defaults to LOCAL_UNIT_TOML.
+
+    Returns
+    -------
+    tuple of (str, str or None)
+    """
+    if local_path is None:
+        local_path = LOCAL_UNIT_TOML
+    try:
+        if os.path.isfile(local_path):
+            with open(local_path, "rb") as f:
+                config = tomli.load(f)
+            number = config.get("number")
+            site = config.get("site_description") or None
+            if isinstance(number, int):
+                return "Mjolnir{:02d}".format(number), site
+    except (tomli.TOMLDecodeError, OSError):
+        pass
+    return socket.gethostname(), None
+
+
+def build_message(sensor_name, site, action, success, rc=None):
+    """Construct the notification message for an on/off event.
+
+    Parameters
+    ----------
+    sensor_name : str
+        e.g. 'Mjolnir02'.
+    site : str or None
+        e.g. 'SWI Berm'. Included in parentheses if non-empty.
+    action : str
+        'on' or 'off' (case-insensitive).
+    success : bool
+        True for success, False for failure.
+    rc : int, optional
+        Return code on failure. Included in the message if provided.
+
+    Returns
+    -------
+    str
+    """
+    header = "{} ({}): ".format(sensor_name, site) if site else "{}: ".format(sensor_name)
+    if success:
+        body = "sensor turned {}".format(action.upper())
+    else:
+        rc_str = "rc={}".format(rc) if rc is not None else "rc=?"
+        body = "sensor turn-{} FAILED ({})".format(action.upper(), rc_str)
+    return header + body
+
+
+def send_notification(sender, msg):
+    """Send a notification, swallowing any errors.
+
+    Notifications are best-effort: a send failure must never fail the
+    on/off operation that has already happened on the hardware.
+
+    Parameters
+    ----------
+    sender : object or None
+        Sender with a .send(msg) method. If None, this is a no-op.
+    msg : str
+    """
+    if sender is None:
+        return
+    try:
+        sender.send(msg)
+        print("[OK] Notification sent")
+    except Exception as exc:
+        print("[WARN] Notification send failed ({}: {})".format(
+            type(exc).__name__, exc), file=sys.stderr)
 
 
 # --- Relay polarity ---
@@ -469,7 +646,7 @@ def parse_args(argv=None):
     return args
 
 
-def run(argv=None, config_path=None):
+def run(argv=None, config_path=None, main_toml_path=None):
     """Main entry point.
 
     Parameters
@@ -477,7 +654,10 @@ def run(argv=None, config_path=None):
     argv : list, optional
         CLI arguments. Defaults to sys.argv[1:].
     config_path : str, optional
-        Override config path (for testing).
+        Override unit.toml path (for testing).
+    main_toml_path : str, optional
+        Override main.toml path (for testing). Used to locate the
+        state_monitor notifier config.
     """
     args = parse_args(argv)
 
@@ -516,11 +696,24 @@ def run(argv=None, config_path=None):
         print("  sudo systemctl start {}".format(BROKKR_SERVICE))
         return 0
 
+    # Prepare the notifier up front; failures here are non-fatal and just
+    # disable notifications for this run.
+    sender = build_sender(load_notifier_config(main_toml_path))
+    sensor_name, site = get_unit_identifier(config_path)
+    action = "on" if args.sensor_on else "off"
+
     # Execute
     if args.sensor_on:
-        return sensor_on(pin=config["pin"], active_high=config["active_high"])
+        rc = sensor_on(pin=config["pin"], active_high=config["active_high"])
     else:
-        return sensor_off(pin=config["pin"], active_high=config["active_high"])
+        rc = sensor_off(pin=config["pin"], active_high=config["active_high"])
+
+    msg = build_message(
+        sensor_name, site, action,
+        success=(rc == 0),
+        rc=rc if rc != 0 else None)
+    send_notification(sender, msg)
+    return rc
 
 
 def main():

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,26 @@
+# server/
+
+Scripts that run on the HAMMA VPS (`hamma.dev`), not on the sensor Pis.
+
+| Script | Purpose |
+| ------ | ------- |
+| `mjol_array.py` | Drive sensor power on/off across an array by SSHing into each Pi and running `sensors.py`. Also reports per-Pi status. |
+| `webgen.py` | Regenerate the per-array status HTML pages served at `hamma.dev`. |
+| `install.sh` | Symlink the above onto `PATH` (default `/usr/local/bin`). Idempotent. |
+
+## Install
+
+```bash
+cd ~/dev/mjolnir-hamma
+bash server/install.sh
+```
+
+After install, `mjol_array` and `webgen` resolve from anywhere on `PATH`.
+
+## Usage
+
+End-user guide (commands, examples, troubleshooting):
+**[mjol_array — Sensor On/Off from the VPS](https://hsvltg.atlassian.net/wiki/spaces/HAMMA/pages/497221633)** on Confluence.
+
+For what `sensors.py` does on each Pi when `mjol_array` calls it:
+**[sensors.py — Sensor Power Control](https://hsvltg.atlassian.net/wiki/spaces/HAMMA/pages/489914369)**.

--- a/tests/python/test_sensors.py
+++ b/tests/python/test_sensors.py
@@ -548,3 +548,328 @@ class TestDryRun:
         mock_off.assert_not_called()
         mock_stop.assert_not_called()
         mock_relay.assert_not_called()
+
+
+# --- Notifications ---
+
+class TestLoadNotifierConfig:
+    """Tests for load_notifier_config() reading [steps.state_monitor]."""
+
+    def test_reads_state_monitor_block(self, sensors, tmp_path):
+        """Returns method/channel/key_file from main.toml."""
+        main_toml = tmp_path / "main.toml"
+        main_toml.write_text(textwrap.dedent("""\
+            [steps]
+                [steps.state_monitor]
+                method = "gchat"
+                channel = "status"
+                key_file = "/home/pi/.googlechat"
+        """))
+        cfg = sensors.load_notifier_config(str(main_toml))
+        assert cfg == {
+            "method": "gchat",
+            "channel": "status",
+            "key_file": "/home/pi/.googlechat",
+        }
+
+    def test_missing_file_returns_none(self, sensors, tmp_path):
+        """Non-existent main.toml returns None (notifications disabled)."""
+        assert sensors.load_notifier_config(str(tmp_path / "nope.toml")) is None
+
+    def test_missing_state_monitor_returns_none(self, sensors, tmp_path):
+        """No [steps.state_monitor] block returns None."""
+        main_toml = tmp_path / "main.toml"
+        main_toml.write_text("[steps]\n[steps.other_step]\nfoo = \"bar\"\n")
+        assert sensors.load_notifier_config(str(main_toml)) is None
+
+    def test_invalid_toml_returns_none(self, sensors, tmp_path):
+        """Malformed TOML returns None instead of raising."""
+        main_toml = tmp_path / "main.toml"
+        main_toml.write_text("[steps\nbroken")
+        assert sensors.load_notifier_config(str(main_toml)) is None
+
+    def test_partial_block_keeps_none_values(self, sensors, tmp_path):
+        """Missing keys come back as None rather than KeyError."""
+        main_toml = tmp_path / "main.toml"
+        main_toml.write_text(textwrap.dedent("""\
+            [steps]
+                [steps.state_monitor]
+                method = "gchat"
+        """))
+        cfg = sensors.load_notifier_config(str(main_toml))
+        assert cfg["method"] == "gchat"
+        assert cfg["channel"] is None
+        assert cfg["key_file"] is None
+
+
+class TestBuildSender:
+    """Tests for build_sender() instantiation."""
+
+    def test_none_config_returns_none(self, sensors):
+        """No config -> no sender."""
+        assert sensors.build_sender(None) is None
+
+    def test_missing_method_returns_none(self, sensors):
+        """Missing method -> no sender."""
+        assert sensors.build_sender(
+            {"method": None, "key_file": "/x", "channel": "y"}) is None
+
+    def test_missing_key_file_returns_none(self, sensors):
+        """Missing key_file -> no sender."""
+        assert sensors.build_sender(
+            {"method": "gchat", "key_file": None, "channel": "y"}) is None
+
+    def test_unknown_method_returns_none(self, sensors):
+        """Unknown notifier method -> warn + None (no crash)."""
+        cfg = {"method": "carrier_pigeon", "key_file": "/x", "channel": "y"}
+        assert sensors.build_sender(cfg) is None
+
+    def test_gchat_instantiation(self, sensors):
+        """Resolves gchat -> GoogleChatSender and instantiates with key_file/channel."""
+        cfg = {"method": "gchat", "key_file": "/k", "channel": "status"}
+        fake_sender = MagicMock()
+        fake_cls = MagicMock(return_value=fake_sender)
+        # Patch the notifiers.google_chat module's GoogleChatSender symbol.
+        with patch.dict("sys.modules", {
+                "notifiers": MagicMock(),
+                "notifiers.google_chat": MagicMock(GoogleChatSender=fake_cls)}):
+            result = sensors.build_sender(cfg)
+        assert result is fake_sender
+        fake_cls.assert_called_once_with("/k", channel="status")
+
+    def test_slack_instantiation(self, sensors):
+        """Resolves slack -> SlackSender."""
+        cfg = {"method": "slack", "key_file": "/k", "channel": "status"}
+        fake_sender = MagicMock()
+        fake_cls = MagicMock(return_value=fake_sender)
+        with patch.dict("sys.modules", {
+                "notifiers": MagicMock(),
+                "notifiers.slack": MagicMock(SlackSender=fake_cls)}):
+            result = sensors.build_sender(cfg)
+        assert result is fake_sender
+        fake_cls.assert_called_once_with("/k", channel="status")
+
+    def test_key_file_not_found_returns_none(self, sensors):
+        """Missing key file at instantiation -> warn + None."""
+        cfg = {"method": "gchat", "key_file": "/k", "channel": "status"}
+        fake_cls = MagicMock(side_effect=FileNotFoundError())
+        with patch.dict("sys.modules", {
+                "notifiers": MagicMock(),
+                "notifiers.google_chat": MagicMock(GoogleChatSender=fake_cls)}):
+            assert sensors.build_sender(cfg) is None
+
+    def test_unexpected_exception_returns_none(self, sensors):
+        """Any other exception at instantiation -> warn + None."""
+        cfg = {"method": "gchat", "key_file": "/k", "channel": "status"}
+        fake_cls = MagicMock(side_effect=RuntimeError("boom"))
+        with patch.dict("sys.modules", {
+                "notifiers": MagicMock(),
+                "notifiers.google_chat": MagicMock(GoogleChatSender=fake_cls)}):
+            assert sensors.build_sender(cfg) is None
+
+
+class TestGetUnitIdentifier:
+    """Tests for get_unit_identifier() name + site lookup."""
+
+    def test_reads_number_and_site(self, sensors, tmp_path):
+        """Number formatted as 'MjolnirNN', site_description passed through."""
+        unit = tmp_path / "unit.toml"
+        unit.write_text(textwrap.dedent("""\
+            number = 3
+            site_description = "SWI Berm"
+            [relay]
+            pin = 4
+            active_high = true
+        """))
+        name, site = sensors.get_unit_identifier(str(unit))
+        assert name == "Mjolnir03"
+        assert site == "SWI Berm"
+
+    def test_no_site_returns_none(self, sensors, tmp_path):
+        """site_description absent -> None."""
+        unit = tmp_path / "unit.toml"
+        unit.write_text("number = 7\n[relay]\npin = 4\nactive_high = true\n")
+        name, site = sensors.get_unit_identifier(str(unit))
+        assert name == "Mjolnir07"
+        assert site is None
+
+    def test_empty_site_returns_none(self, sensors, tmp_path):
+        """Empty site_description -> None (not the empty string)."""
+        unit = tmp_path / "unit.toml"
+        unit.write_text(
+            'number = 2\nsite_description = ""\n'
+            '[relay]\npin = 4\nactive_high = true\n')
+        _, site = sensors.get_unit_identifier(str(unit))
+        assert site is None
+
+    def test_missing_file_falls_back_to_hostname(self, sensors, tmp_path):
+        """Missing unit.toml -> hostname, None."""
+        with patch("socket.gethostname", return_value="mjolnir99"):
+            name, site = sensors.get_unit_identifier(str(tmp_path / "nope.toml"))
+        assert name == "mjolnir99"
+        assert site is None
+
+    def test_missing_number_falls_back_to_hostname(self, sensors, tmp_path):
+        """unit.toml present but no 'number' -> hostname."""
+        unit = tmp_path / "unit.toml"
+        unit.write_text("site_description = \"Lab\"\n")
+        with patch("socket.gethostname", return_value="mjolnir99"):
+            name, site = sensors.get_unit_identifier(str(unit))
+        assert name == "mjolnir99"
+        # Site is NOT returned when we fall back — the (name, site) pair
+        # must be consistent (both from unit.toml, or both from hostname).
+        assert site is None
+
+
+class TestBuildMessage:
+    """Tests for build_message() text format."""
+
+    def test_success_with_site(self, sensors):
+        msg = sensors.build_message(
+            "Mjolnir02", "SWI Berm", "on", success=True)
+        assert msg == "Mjolnir02 (SWI Berm): sensor turned ON"
+
+    def test_success_without_site(self, sensors):
+        msg = sensors.build_message(
+            "Mjolnir02", None, "off", success=True)
+        assert msg == "Mjolnir02: sensor turned OFF"
+
+    def test_failure_with_rc(self, sensors):
+        msg = sensors.build_message(
+            "Mjolnir02", None, "off", success=False, rc=1)
+        assert msg == "Mjolnir02: sensor turn-OFF FAILED (rc=1)"
+
+    def test_failure_without_rc(self, sensors):
+        msg = sensors.build_message(
+            "Mjolnir02", None, "on", success=False)
+        assert msg == "Mjolnir02: sensor turn-ON FAILED (rc=?)"
+
+    def test_action_case_normalized(self, sensors):
+        """action is uppercased in message regardless of input case."""
+        msg = sensors.build_message(
+            "Mjolnir02", None, "ON", success=True)
+        assert "ON" in msg
+
+
+class TestSendNotification:
+    """Tests for send_notification() error-swallowing wrapper."""
+
+    def test_none_sender_no_op(self, sensors):
+        """None sender -> no exception, no call."""
+        sensors.send_notification(None, "hello")  # must not raise
+
+    def test_calls_sender_send(self, sensors):
+        """Sender.send is called with the message."""
+        sender = MagicMock()
+        sensors.send_notification(sender, "hello")
+        sender.send.assert_called_once_with("hello")
+
+    def test_swallows_exception(self, sensors):
+        """Exception from sender.send is caught (must not propagate)."""
+        sender = MagicMock()
+        sender.send.side_effect = RuntimeError("network down")
+        sensors.send_notification(sender, "hello")  # must not raise
+
+
+class TestRunNotifications:
+    """Tests that run() wires notifications correctly into the on/off flow."""
+
+    @pytest.fixture
+    def configs(self, tmp_path):
+        unit = tmp_path / "unit.toml"
+        unit.write_text(textwrap.dedent("""\
+            number = 2
+            site_description = "Lab"
+            [relay]
+            pin = 4
+            active_high = true
+        """))
+        main = tmp_path / "main.toml"
+        main.write_text(textwrap.dedent("""\
+            [steps]
+                [steps.state_monitor]
+                method = "gchat"
+                channel = "status"
+                key_file = "/home/pi/.googlechat"
+        """))
+        return str(unit), str(main)
+
+    def test_off_success_sends_success_message(self, sensors, configs):
+        """Successful --off triggers a 'sensor turned OFF' notification."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        with patch.object(sensors, "build_sender", return_value=fake_sender), \
+             patch.object(sensors, "sensor_off", return_value=0):
+            rc = sensors.run(
+                ["--off"], config_path=unit, main_toml_path=main)
+        assert rc == 0
+        fake_sender.send.assert_called_once()
+        msg = fake_sender.send.call_args[0][0]
+        assert "Mjolnir02" in msg
+        assert "Lab" in msg
+        assert "turned OFF" in msg
+
+    def test_on_success_sends_success_message(self, sensors, configs):
+        """Successful --on triggers a 'sensor turned ON' notification."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        with patch.object(sensors, "build_sender", return_value=fake_sender), \
+             patch.object(sensors, "sensor_on", return_value=0):
+            rc = sensors.run(
+                ["--on"], config_path=unit, main_toml_path=main)
+        assert rc == 0
+        msg = fake_sender.send.call_args[0][0]
+        assert "turned ON" in msg
+
+    def test_failure_sends_failure_message(self, sensors, configs):
+        """Failed --off triggers a FAILED notification with the rc."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        with patch.object(sensors, "build_sender", return_value=fake_sender), \
+             patch.object(sensors, "sensor_off", return_value=2):
+            rc = sensors.run(
+                ["--off"], config_path=unit, main_toml_path=main)
+        assert rc == 2
+        msg = fake_sender.send.call_args[0][0]
+        assert "FAILED" in msg
+        assert "rc=2" in msg
+
+    def test_dry_run_no_notification(self, sensors, configs):
+        """--dry-run must not send a notification."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        with patch.object(sensors, "build_sender", return_value=fake_sender):
+            sensors.run(
+                ["--off", "--dry-run"],
+                config_path=unit, main_toml_path=main)
+        fake_sender.send.assert_not_called()
+
+    def test_status_no_notification(self, sensors, configs):
+        """--status must not send a notification."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        with patch.object(sensors, "build_sender", return_value=fake_sender), \
+             patch.object(sensors, "sensor_status", return_value="ok"):
+            sensors.run(
+                ["--status"], config_path=unit, main_toml_path=main)
+        fake_sender.send.assert_not_called()
+
+    def test_no_sender_still_completes(self, sensors, configs):
+        """If build_sender returns None, run() still succeeds (no crash)."""
+        unit, main = configs
+        with patch.object(sensors, "build_sender", return_value=None), \
+             patch.object(sensors, "sensor_off", return_value=0):
+            rc = sensors.run(
+                ["--off"], config_path=unit, main_toml_path=main)
+        assert rc == 0
+
+    def test_send_failure_does_not_change_rc(self, sensors, configs):
+        """A failing sender.send() must not affect the return code."""
+        unit, main = configs
+        fake_sender = MagicMock()
+        fake_sender.send.side_effect = RuntimeError("network down")
+        with patch.object(sensors, "build_sender", return_value=fake_sender), \
+             patch.object(sensors, "sensor_off", return_value=0):
+            rc = sensors.run(
+                ["--off"], config_path=unit, main_toml_path=main)
+        assert rc == 0


### PR DESCRIPTION
## Summary

- `sensors.py` now emits a chat notification (Google Chat or Slack) after every successful `--on`, successful `--off`, and on failure, reusing the method/channel/key_file already configured for `state_monitor` in `main.toml`. Notifications fire identically whether `sensors.py` was triggered locally on the Pi or via `mjol_array.py` from the VPS, so on/off events show up in the operations channel regardless of who triggered them.
- New `server/README.md` points VPS users to the new Confluence guide for `mjol_array` (HAMMA → Usage Guides → "mjol_array — Sensor On/Off from the VPS"), sibling of the existing `sensors.py` guide.

## What changed in `sensors.py`

- `load_notifier_config()` — reads `[steps.state_monitor]` from `config/main.toml` (method / channel / key_file).
- `build_sender()` — lazily imports `notifiers.{google_chat,slack}` so unit tests don't need the package; returns `None` and prints a `[WARN]` on any failure path so notifications are strictly best-effort.
- `get_unit_identifier()` — reads `number` and `site_description` from local `unit.toml`; falls back to hostname if missing.
- `build_message()` — formats `"MjolnirNN (site): sensor turned ON/OFF"` (success) and `"MjolnirNN (site): sensor turn-ON/OFF FAILED (rc=N)"` (failure).
- `send_notification()` — fail-soft wrapper; a chat-send error never changes the return code of the on/off operation.
- `--dry-run` and `--status` do not notify.

## Tests

33 new unit tests, full sensors suite: **84 passed**.

```
TestLoadNotifierConfig      ✓ 5 tests
TestBuildSender             ✓ 8 tests
TestGetUnitIdentifier       ✓ 5 tests
TestBuildMessage            ✓ 5 tests
TestSendNotification        ✓ 3 tests
TestRunNotifications        ✓ 7 tests (run() wiring incl. failure-path and dry-run no-notify)
```

## E2E

Deployed the modified `sensors.py` to mj00 (lab unit) at `/tmp/sensors_notify_test.py` and invoked the helpers directly via the lab Pi's `ltgenv` python. Real `main.toml` was parsed, real `GoogleChatSender` was instantiated against the real `/home/pi/.googlechat` key, real messages were delivered to the **status** channel:

```
Mjolnir00 (SWIRLL Lab - Test unit): sensor turned OFF
Mjolnir00 (SWIRLL Lab - Test unit): sensor turn-ON FAILED (rc=2)
```

(Test messages were prefixed `[notify-e2e]` so they don't get confused with real ops.) Recipient confirmed receipt before this PR was opened.

## Test plan

- [x] Unit: `pytest tests/python/test_sensors.py -v` (84 passed)
- [x] E2E on mj00: helpers invoked against real notifier package, real key file, real webhook; chat receipt confirmed
- [ ] Real on/off cycle on a deployed sensor after merge (separate sensor-log issue when it happens)

## Docs

- Confluence: [mjol_array — Sensor On/Off from the VPS](https://hsvltg.atlassian.net/wiki/spaces/HAMMA/pages/497221633) (new, child of HAMMA → Usage Guides)
- `server/README.md` (new) — short stub with links to both Confluence pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)