### PR TITLE
fix(state_monitor): use >= for pre-value in edge checks

### DIFF
--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -284,7 +284,10 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         curr_now, curr_pre = self.now_then(input_data, 'adc_il_f')
 
         power_now, power_pre = load_now * curr_now, load_pre * curr_pre
-        if (power_now < self.power_delim) and (power_pre > self.power_delim):
+        # Use >= for `pre` so a previous sample sitting exactly on the
+        # threshold still counts as above it. Strict `>` silently misses
+        # the edge when pre lands on power_delim.
+        if (power_now < self.power_delim) and (power_pre >= self.power_delim):
             return f"Power has dropped from {power_pre:.2f} to {power_now:.2f}."
         return None
 
@@ -342,7 +345,11 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
 
         """
         space_now, space_pre = self.now_then(input_data, 'bytes_remaining')
-        if (space_now < self.low_space) and (space_pre > self.low_space):
+        # Use >= for `pre` so a previous sample sitting exactly on the
+        # threshold still counts as above it. Strict `>` silently misses
+        # the edge when pre lands on low_space (a real case on mj07:
+        # 100.0 -> 99.96 with low_space=100 never fired).
+        if (space_now < self.low_space) and (space_pre >= self.low_space):
             self._spawn_scrub()
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
@@ -388,7 +395,10 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         CRITICAL_VOLTAGE = low_voltage_val + 0.5
 
         batt_now, batt_pre = self.now_then(input_data, 'adc_vb_f')
-        if (batt_now <= CRITICAL_VOLTAGE) and (batt_pre > CRITICAL_VOLTAGE):
+        # Use >= for `pre` so a previous sample sitting exactly on the
+        # threshold still counts as above it. Strict `>` silently misses
+        # the edge when pre lands on CRITICAL_VOLTAGE.
+        if (batt_now <= CRITICAL_VOLTAGE) and (batt_pre >= CRITICAL_VOLTAGE):
             return f"Battery voltage critically low ({batt_now:.3f} V)"
         return None
 

--- a/tests/python/test_state_monitor.py
+++ b/tests/python/test_state_monitor.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -88,3 +89,162 @@ class TestConstructMessage:
             result = StateMonitor.construct_message(alert)
 
         assert result == "mj05: Power has dropped from 25.00 to 12.00."
+
+
+# --- Edge-trigger boundary tests ---
+
+def _dv(value):
+    """Wrap a scalar as a DataValue-like object (just exposes .value)."""
+    return SimpleNamespace(value=value)
+
+
+def _make_monitor(**overrides):
+    """Build a StateMonitor with mocked dependencies and reasonable defaults.
+
+    Uses method='gchat' so the sender_class lookup succeeds; the actual
+    GoogleChatSender is a MagicMock so the key_file is never touched.
+    """
+    kwargs = dict(
+        method="gchat",
+        channel="status",
+        key_file="/dev/null",
+        low_space=100,
+        power_delim=15,
+        enable_drive_checks=True,
+    )
+    kwargs.update(overrides)
+    monitor = StateMonitor(**kwargs)
+    return monitor
+
+
+class TestCheckSensorDriveBoundary:
+    """check_sensor_drive must fire when pre lands exactly on low_space.
+
+    Real-world miss (mj07, 2026-05-28 15:25:03 UTC):
+    bytes_remaining went from 100.0 -> 99.96 GB. Strict `>` against
+    low_space=100 missed the edge. After that, bytes_remaining only
+    decreased, so no future edge could ever fire.
+    """
+
+    def test_pre_exactly_at_threshold_fires(self):
+        """pre = low_space exactly; now below -> fires."""
+        m = _make_monitor(low_space=100)
+        m._previous_data = {"bytes_remaining": _dv(100.0)}
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(99.96)})
+        spawn.assert_called_once()
+        assert msg is not None
+        assert "99.9" in msg or "100.0" in msg or "99.96" in msg
+
+    def test_pre_above_now_below_fires(self):
+        """Standard down-cross: pre clearly above, now clearly below -> fires."""
+        m = _make_monitor(low_space=100)
+        m._previous_data = {"bytes_remaining": _dv(150.0)}
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(80.0)})
+        spawn.assert_called_once()
+        assert msg is not None
+
+    def test_both_below_threshold_no_fire(self):
+        """No edge if already below: pre=50, now=45 -> no fire."""
+        m = _make_monitor(low_space=100)
+        m._previous_data = {"bytes_remaining": _dv(50.0)}
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(45.0)})
+        spawn.assert_not_called()
+        assert msg is None
+
+    def test_both_above_threshold_no_fire(self):
+        """No edge if still above: pre=200, now=150 -> no fire."""
+        m = _make_monitor(low_space=100)
+        m._previous_data = {"bytes_remaining": _dv(200.0)}
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(150.0)})
+        spawn.assert_not_called()
+        assert msg is None
+
+    def test_now_exactly_at_threshold_no_fire(self):
+        """now exactly on threshold is NOT below; spec is strict `now <`."""
+        m = _make_monitor(low_space=100)
+        m._previous_data = {"bytes_remaining": _dv(150.0)}
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(100.0)})
+        spawn.assert_not_called()
+        assert msg is None
+
+
+class TestCheckPowerBoundary:
+    """check_power must fire when prior power lands exactly on power_delim."""
+
+    def _input(self, load_v, current_a):
+        # power = load * current
+        return {"adc_vl_f": _dv(load_v), "adc_il_f": _dv(current_a)}
+
+    def test_pre_exactly_at_threshold_fires(self):
+        """pre power == power_delim, now below -> fires."""
+        m = _make_monitor(power_delim=15)
+        # pre: 15 V * 1.0 A = 15 W exactly
+        m._previous_data = self._input(15.0, 1.0)
+        # now: 14 V * 1.0 A = 14 W
+        msg = m.check_power(self._input(14.0, 1.0))
+        assert msg is not None
+        assert "15.00" in msg
+        assert "14.00" in msg
+
+    def test_pre_above_now_below_fires(self):
+        """Standard down-cross."""
+        m = _make_monitor(power_delim=15)
+        m._previous_data = self._input(25.0, 1.0)  # 25 W
+        msg = m.check_power(self._input(10.0, 1.0))  # 10 W
+        assert msg is not None
+
+    def test_both_below_no_fire(self):
+        m = _make_monitor(power_delim=15)
+        m._previous_data = self._input(10.0, 1.0)  # 10 W
+        msg = m.check_power(self._input(8.0, 1.0))  # 8 W
+        assert msg is None
+
+    def test_both_above_no_fire(self):
+        m = _make_monitor(power_delim=15)
+        m._previous_data = self._input(25.0, 1.0)
+        msg = m.check_power(self._input(20.0, 1.0))
+        assert msg is None
+
+
+class TestCheckBatteryVoltageBoundary:
+    """check_battery_voltage must fire when pre lands on CRITICAL_VOLTAGE.
+
+    CRITICAL_VOLTAGE = v_lvd + 0.5, taken from input_data each iteration.
+    """
+
+    def _input(self, batt, v_lvd):
+        return {"adc_vb_f": _dv(batt), "v_lvd": _dv(v_lvd)}
+
+    def test_pre_exactly_at_critical_fires(self):
+        """pre == CRITICAL; now <= CRITICAL -> fires."""
+        m = _make_monitor()
+        # v_lvd=11.0 -> CRITICAL = 11.5; pre and now both 11.5
+        # With the fix (>=), pre at threshold counts -> fires.
+        m._previous_data = self._input(batt=11.5, v_lvd=11.0)
+        msg = m.check_battery_voltage(self._input(batt=11.5, v_lvd=11.0))
+        assert msg is not None
+        assert "11.500" in msg
+
+    def test_pre_above_now_at_critical_fires(self):
+        """pre above CRITICAL, now equals CRITICAL -> fires (now uses <=)."""
+        m = _make_monitor()
+        m._previous_data = self._input(batt=12.0, v_lvd=11.0)
+        msg = m.check_battery_voltage(self._input(batt=11.5, v_lvd=11.0))
+        assert msg is not None
+
+    def test_pre_above_now_above_no_fire(self):
+        m = _make_monitor()
+        m._previous_data = self._input(batt=13.0, v_lvd=11.0)
+        msg = m.check_battery_voltage(self._input(batt=12.0, v_lvd=11.0))
+        assert msg is None
+
+    def test_both_below_no_fire(self):
+        m = _make_monitor()
+        m._previous_data = self._input(batt=11.0, v_lvd=11.0)  # below 11.5
+        msg = m.check_battery_voltage(self._input(batt=10.8, v_lvd=11.0))
+        assert msg is None


### PR DESCRIPTION
## Summary

Three edge-triggered checks in `state_monitor` used `(now < threshold AND pre > threshold)` with a strict `>`. When the previous sample lands **exactly on** the threshold, the down-cross is silently missed. Once missed, the alarm condition can never edge-trigger again because the values stay on the wrong side.

## Real-world miss

mj07, 2026-05-28 15:25:03 UTC:

```
bytes_remaining: 100.0 -> 99.96 GB    (low_space = 100)
```

- `space_now < 100` → `99.96 < 100` → True
- `space_pre > 100` → `100.0 > 100` → **False** (strict `>`)
- Result: no fire, no `scrub_command` spawned.

bytes_remaining only decreased after that. By today (2026-06-01) mj07's sensor was at `bytes_rem=0.0, triggers_rem=0.0` and had stopped collecting. A manual scrub recovered it (separate sensor-log entry).

## Fix

Three lines, same shape:

| Line | Check | Before | After |
|------|-------|--------|-------|
| 287 | `check_power` | `power_pre > self.power_delim` | `power_pre >= self.power_delim` |
| 345 | `check_sensor_drive` | `space_pre > self.low_space` | `space_pre >= self.low_space` |
| 391 | `check_battery_voltage` | `batt_pre > CRITICAL_VOLTAGE` | `batt_pre >= CRITICAL_VOLTAGE` |

Comments on each line explain why.

## Tests

13 new boundary tests covering:

- pre exactly at threshold + now below → fires (the bug)
- pre above + now below → still fires
- both above → no fire
- both below → no fire
- now exactly at threshold → no fire (preserves the `now <` semantics)

```
TestCheckSensorDriveBoundary      5 tests
TestCheckPowerBoundary            4 tests
TestCheckBatteryVoltageBoundary   4 tests
```

Full python suite: **357 passed** (no regressions).

## Test plan

- [x] Unit boundary tests pass
- [x] Full python test suite passes
- [ ] After merge, deploy and observe: next time a sensor's `bytes_remaining` drops past 100, scrub should spawn even if the prior sample was exactly 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)