### PR TITLE
feat: trigger sensors from the VPS (ags das_manual_trigger over autossh tunnel)

### DIFF
--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -145,6 +145,60 @@ class MjolnirArray():
                   f"with code {out.returncode}.")
 
     @staticmethod
+    def trigger(port, command="das_manual_trigger", quiet=False):
+        # Send an AGS command (default: a manual trigger) to a sensor.
+        # port is fully qualified (10000 + unit number).
+        # We reach the Pi over its autossh tunnel and run ags.py there; the
+        # AGS command port (10.10.10.1:8082) is only reachable from the Pi.
+        sensor_num = port - 10000
+
+        # First, make sure the SSH tunnel for this Pi is reachable...
+        is_pi_up = MjolnirArray.status(port)
+
+        if not is_pi_up:
+            if not quiet:
+                print(f"[SKIP] mj{sensor_num:02} (port {port}): tunnel down, "
+                      f"not triggered.")
+            return
+
+        cmd = MjolnirArray._pi_ssh_cmd(port)
+        cmd = cmd + ['/home/pi/dev/mjolnir-hamma/scripts/ags.py', command]
+
+        if not quiet:
+            print(f"--- mj{sensor_num:02}: sending AGS '{command}' ---")
+
+        try:
+            out = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            if not quiet:
+                print(f"[FAIL] mj{sensor_num:02}: ags.py did not complete "
+                      f"in 30s.")
+            return
+        except Exception as e:
+            if not quiet:
+                print(f"[FAIL] mj{sensor_num:02}: error running ags.py: {e}")
+            return
+
+        if quiet:
+            return
+
+        # Surface the AGS reply so the operator sees the result.
+        stdout = out.stdout.decode(errors="replace") if out.stdout else ""
+        stderr = out.stderr.decode(errors="replace") if out.stderr else ""
+        if stdout:
+            print(stdout, end="" if stdout.endswith("\n") else "\n")
+        if stderr:
+            print(stderr, end="" if stderr.endswith("\n") else "\n")
+        if out.returncode != 0:
+            print(f"[FAIL] mj{sensor_num:02}: ags.py exited "
+                  f"with code {out.returncode}.")
+
+    @staticmethod
     def status_fcm(port):
         # Return a boolean if the FCM sensor is up (True) or down (False)
         # port is fully qualified
@@ -181,6 +235,17 @@ class MjolnirArray():
 
         for p in ports:
             MjolnirArray.updown(p, bring_up)
+
+    def trigger_array(self, ports=None, command="das_manual_trigger"):
+        # Send an AGS command (default: a manual trigger) to one or more sensors.
+        # ports is mod 10000 (list). If None, use all of this array's sensors.
+        if ports is None:
+            ports = [10000 + i for i in self.sensors]
+        else:
+            ports = [10000 + int(p) for p in ports]  # Make this an integer
+
+        for p in ports:
+            MjolnirArray.trigger(p, command=command)
 
     def status_array(self, ports=None, quiet=False):
         # Get status report for a number of sensors in an array
@@ -310,12 +375,13 @@ def main():
                             default=False,
                             )
 
-    # arg_parser.add_argument("--trig",
-    #                  help="Trig statsus",
-    #                  dest="do_trig",
-    #                  action='store_true',
-    #                  default=False,
-    #                  )
+    arg_parser.add_argument("--trigger",
+                            help="Send a manual trigger (ags das_manual_trigger) "
+                                 "to the sensor(s)",
+                            dest="do_trigger",
+                            action='store_true',
+                            default=False,
+                            )
 
     grp = arg_parser.add_mutually_exclusive_group()
     grp.add_argument("--up",
@@ -352,8 +418,8 @@ def main():
 
     if parsed_args.do_status:
         _ = mj_array.status_array(ports=parsed_args.ports)
-    # elif parsed_args.do_trig:
-    #     _ = status_latest_trigger(port=parsed_args.ports)
+    elif parsed_args.do_trigger:
+        mj_array.trigger_array(ports=parsed_args.ports)
     elif parsed_args.bring_up | parsed_args.bring_down:
         # Is it up or down?
         # bring_up = parsed_args.bring_up

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -228,3 +228,80 @@ class TestStatusServices:
         service_names = [c[0][0][-1] for c in calls]
         assert 'brokkr-hamma-default' in service_names
         assert 'sindri-hamma-client' in service_names
+
+
+class TestTrigger:
+    """Tests for MjolnirArray.trigger()."""
+
+    def test_trigger_calls_ags_manual_trigger(self, mjol):
+        """Default trigger should run ags.py with das_manual_trigger."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            with patch.object(mjol.MjolnirArray, 'status', return_value=True):
+                mjol.MjolnirArray.trigger(10002)
+
+        cmd = mock_sub.run.call_args[0][0]
+        assert '/home/pi/dev/mjolnir-hamma/scripts/ags.py' in cmd
+        assert 'das_manual_trigger' in cmd
+
+    def test_trigger_ssh_target_and_port(self, mjol):
+        """Trigger should SSH to the unit's tunnel (pi@localhost, port)."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            with patch.object(mjol.MjolnirArray, 'status', return_value=True):
+                mjol.MjolnirArray.trigger(10005)
+
+        cmd = mock_sub.run.call_args[0][0]
+        assert 'pi@localhost' in cmd
+        assert '10005' in cmd
+
+    def test_trigger_custom_command(self, mjol):
+        """A custom AGS command should be forwarded verbatim."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            with patch.object(mjol.MjolnirArray, 'status', return_value=True):
+                mjol.MjolnirArray.trigger(10002, command="help")
+
+        cmd = mock_sub.run.call_args[0][0]
+        assert 'help' in cmd
+        assert 'das_manual_trigger' not in cmd
+
+    def test_trigger_has_timeout(self, mjol):
+        """subprocess.run should be called with timeout=30."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            with patch.object(mjol.MjolnirArray, 'status', return_value=True):
+                mjol.MjolnirArray.trigger(10002)
+
+        kwargs = mock_sub.run.call_args[1]
+        assert kwargs.get('timeout') == 30
+
+    def test_trigger_pi_down_skips(self, mjol):
+        """If the tunnel is down, trigger should not call subprocess."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            with patch.object(mjol.MjolnirArray, 'status', return_value=False):
+                mjol.MjolnirArray.trigger(10002, quiet=True)
+
+        mock_sub.run.assert_not_called()
+
+    def test_trigger_timeout_catches_exception(self, mjol):
+        """On timeout, trigger should catch the exception and not raise."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.side_effect = subprocess.TimeoutExpired(cmd="test", timeout=30)
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            with patch.object(mjol.MjolnirArray, 'status', return_value=True):
+                # Should not raise
+                mjol.MjolnirArray.trigger(10002, quiet=True)
+
+    def test_trigger_array_iterates_ports(self, mjol):
+        """trigger_array should call trigger once per port (10000 + unit)."""
+        arr = mjol.MjolnirArray(sensors=[2, 3])
+        with patch.object(mjol.MjolnirArray, 'trigger') as mock_trigger:
+            arr.trigger_array(ports=[2, 3])
+
+        called_ports = [c[0][0] for c in mock_trigger.call_args_list]
+        assert called_ports == [10002, 10003]


### PR DESCRIPTION
Closes #62.

## What
Adds a VPS-side helper to trigger HAMMA sensors (AGS `das_manual_trigger`) from the VPS. The AGS command port (`10.10.10.1:8082`) is only reachable from the mjolnir Pi, so the helper reaches the Pi over its autossh tunnel and runs `scripts/ags.py` there.

- `MjolnirArray.trigger(port, command="das_manual_trigger", quiet=False)` — checks the tunnel (`status()`), then runs `scripts/ags.py das_manual_trigger` on the Pi via `_pi_ssh_cmd()`, surfacing the AGS reply.
- `MjolnirArray.trigger_array(ports=None, command=...)` — fan out across an array.
- `--trigger` CLI action (makes the long-standing commented-out `--trig` stub real).

Mirrors the existing `updown()` pattern and reuses `_pi_ssh_cmd()` / `status()` — no new SSH plumbing.

## Usage
```
python server/mjol_array.py -p 2 --trigger      # trigger mj02
python server/mjol_array.py -a hamma --trigger  # trigger the whole HAMMA array
```

## Tests
7 new unit tests (ssh target/port, `das_manual_trigger` command, custom command, 30s timeout, tunnel-down skip, timeout-safe, array fan-out) with mocked `subprocess`/`status`. **29/29** `mjol_array`, **351** full `tests/python` suite green.

## E2E (real VPS → mj02)
Ran `mjol_array.py -p 2 --trigger` on the VPS (`monitor` user): VPS → autossh tunnel `:10002` → mj02 → `ags.py das_manual_trigger` → AGS replied `Setting trigger to manual.` → a new trigger was captured and flowed through brokkr's realtime pipeline. Full VPS→Pi→AGS chain confirmed end-to-end. (Downstream `noise_diag` CSV row also appeared, but that plugin lives on a separate branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
