### PR TITLE
Use public hamma.diagnostic_data in NoiseDiag plugin (low priority)

### DIFF
--- a/plugins/noise_diag.py
+++ b/plugins/noise_diag.py
@@ -6,7 +6,7 @@ import csv
 from pathlib import Path
 
 import hamma
-from hamma.header.core import _diagnostic_data
+from hamma import diagnostic_data
 
 # HAMMA2 fast-channel sample rate. preTriggerSize is a count of fast samples;
 # the header's sampleRateFast field is not populated, so use the known rate.
@@ -92,7 +92,7 @@ class NoiseDiag(brokkr.pipeline.base.OutputStep):
                 pretrigger_ms, self.min_pretrigger_ms)
             return None
 
-        offset, vmax, vmin, noise = _diagnostic_data(data.voltFast, self.medsize)
+        offset, vmax, vmin, noise = diagnostic_data(data.voltFast, self.medsize)
         vpp = float(vmax) - float(vmin)
         snr = vpp / noise if noise else float("nan")
         threshold = float(h.data.threshold.iloc[0])

--- a/tests/python/test_noise_diag.py
+++ b/tests/python/test_noise_diag.py
@@ -26,6 +26,7 @@ def load_module(diag_return=(0.1, 4.7, -4.7, 0.035), volt_fast=object(), thresho
     mock_brokkr.pipeline.base = mock_base
 
     mock_hamma = MagicMock()
+    mock_hamma.diagnostic_data.return_value = diag_return
     if times_fast is None:
         times_fast = np.array(["2026-06-23T21:36:57.000", "2026-06-23T21:36:58.857",
                                "2026-06-23T21:36:59.000"], dtype="datetime64[ms]")
@@ -43,7 +44,6 @@ def load_module(diag_return=(0.1, 4.7, -4.7, 0.035), volt_fast=object(), thresho
         return col
     header.data.__getitem__.side_effect = _col
     mock_hamma.Header.return_value = header
-    mock_core = MagicMock(); mock_core._diagnostic_data.return_value = diag_return
 
     with patch.dict("sys.modules", {
         "brokkr": mock_brokkr, "brokkr.pipeline": mock_pipeline,
@@ -53,7 +53,6 @@ def load_module(diag_return=(0.1, 4.7, -4.7, 0.035), volt_fast=object(), thresho
         "brokkr.config.unit": MagicMock(),
         "brokkr.config.metadata": MagicMock(),
         "hamma": mock_hamma, "hamma.header": MagicMock(),
-        "hamma.header.core": mock_core,
         "notifiers": MagicMock(),
     }):
         spec = importlib.util.spec_from_file_location("noise_diag", str(PLUGIN_PATH))
@@ -135,7 +134,7 @@ def test_compute_skips_short_pretrigger():
     step.medsize = 200000
     step.min_pretrigger_ms = 50
     step.logger = MagicMock()
-    with patch.object(module, "_diagnostic_data") as mock_diag:
+    with patch.object(module, "diagnostic_data") as mock_diag:
         result = step._compute(make_input())
     assert result is None
     mock_diag.assert_not_called()


### PR DESCRIPTION
## Summary
Switches the `NoiseDiag` plugin (`plugins/noise_diag.py`) from the private `hamma.header.core._diagnostic_data` to the public `hamma.diagnostic_data` (released in hamma 0.3.0). This is the **last consumer** in the shared-noise-primitive consolidation — the on-demand `scripts/hamma_noise.py` swap already shipped in 0.4.0 (PR #52, commit `ffa73c2`).

- `plugins/noise_diag.py`: `from hamma import diagnostic_data`; call site uses it, arguments unchanged.
- `tests/python/test_noise_diag.py` updated to the new path. **11 passed.**
- Pure import/call rename — no behavior change (`diagnostic_data` returns the same `(median, max, min, noise)`).

## Draft / no rush
NoiseDiag **works as-is** on 0.4.0: hamma 0.3.0 deliberately **retains `_diagnostic_data` as a deprecated alias**, so the plugin resolves on every sensor (0.2a and 0.3.0). This is hygiene (use the public name), not a bug fix — fine to ride the next release with other content rather than cut a release just for it.

## Dependency / rollout
Once merged + deployed, the plugin imports the public name directly, so it needs `hamma >= 0.3.0` on the sensor — the **same dependency 0.4.0 already declares**. Keep it aligned with the coordinated fleet-to-0.3.0 rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)