### PR TITLE
Server-side threshold & gain control (mjol_array + ags.py)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-server-threshold-gain-control.md
+++ b/docs/superpowers/plans/2026-06-29-server-threshold-gain-control.md
@@ -1,0 +1,1143 @@
+# Server-side Threshold & Gain Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator set a HAMMA2 sensor's trigger threshold (input-referred mV) and FCM gain (level 0–3) from the VPS, for one/many/all sensors, with an optional `--persist` flag that survives a DAS reset.
+
+**Architecture:** Add clearly-named functions + CLI subcommands to the Pi-side `scripts/ags.py` (which owns the AGS command socket `10.10.10.1:8082`); add dispatch actions to the VPS-side `server/mjol_array.py` that invoke `ags.py` over the existing autossh tunnel, reusing its `-a/-p` fan-out — a near-clone of the existing `--trigger` action. `--persist` rewrites the matching line of the sensor's `/ags/scripts/startup` script via `ssh hamma`.
+
+**Tech Stack:** Python 3.6+ (stdlib only: `argparse`, `socket`, `subprocess`), pytest with `importlib.util.spec_from_file_location` module loading and `unittest.mock`.
+
+## Global Constraints
+
+- **Python 3.6+ compatible.** No walrus, no `subprocess.run(capture_output=...)` (3.7+) — use `stdout=subprocess.PIPE, stderr=subprocess.PIPE`.
+- **stdlib only** in `ags.py` and `mjol_array.py` action paths (no pandas/numpy at import scope).
+- **Threshold conversion:** `ags = millivolts / 1000 * 6.024`; inverse `mv = ags / 6.024 * 1000`. `GAIN_FACTOR = 6.024`.
+- **No hard upper cap** on threshold mV (firmware enforces); reject only `mv < 0`. High mV is **sent silently** (no client warning).
+- **Gain registers (bare hex):** FAST-E = `"8"` (0x08), SLOW-E = `"10"` (0x10). Gain level ∈ {0,1,2,3}.
+- **Threshold channels:** {1, 2} only (reject 3–8).
+- **Pi script path on sensors:** `/home/pi/dev/mjolnir-hamma/scripts/ags.py`.
+- **AGS host ssh alias (from the Pi):** `hamma`; startup script path `/ags/scripts/startup`.
+- **Tests live in** `tests/python/`; load modules via `importlib.util.spec_from_file_location`.
+- **Commit** after every passing task. Branch: `feature/server-threshold-gain-control`.
+
+---
+
+## File Structure
+
+- **Modify** `scripts/ags.py` — add `GAIN_FACTOR`, gain register map, conversion helpers (`mv_to_ags`, `ags_to_mv`), `set_threshold`, `set_gain`, startup-file helpers (`rewrite_startup`, `parse_startup_state`, `persist_startup`), and CLI subcommand branching in `main()`. Keep the existing generic passthrough.
+- **Modify** `server/mjol_array.py` — add `_run_ags_command` helper, refactor `trigger()` onto it, add `set_threshold`/`set_gain` static methods + `set_threshold_array`/`set_gain_array` wrappers, add `--set-threshold`/`--set-gain`/`--persist` CLI options and `main()` dispatch.
+- **Create** `tests/python/test_ags.py` — unit tests for all new `ags.py` functions + CLI.
+- **Modify** `tests/python/test_mjol_array.py` — tests for the new actions, wrappers, helper, and CLI dispatch.
+
+---
+
+## Task 1: ags.py — threshold conversion helpers
+
+**Files:**
+- Modify: `scripts/ags.py` (add constants + two functions near the top, after the existing `SOCKET_BUFFER` constant)
+- Test: `tests/python/test_ags.py` (create)
+
+**Interfaces:**
+- Produces: `GAIN_FACTOR = 6.024`; `mv_to_ags(millivolts) -> float` (raises `ValueError` if `millivolts < 0`); `ags_to_mv(ags) -> float`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/python/test_ags.py`:
+
+```python
+"""Tests for ags.py — AGS command wrapper (threshold/gain control)."""
+
+import importlib.util
+import pathlib
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ags.py"
+
+
+def load_ags():
+    spec = importlib.util.spec_from_file_location("ags", str(SCRIPT_PATH))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def ags():
+    return load_ags()
+
+
+class TestConversion:
+    def test_mv_to_ags_known_points(self, ags):
+        assert ags.mv_to_ags(830) == pytest.approx(5.0, abs=1e-3)
+        assert ags.mv_to_ags(83) == pytest.approx(0.5, abs=1e-3)
+        assert ags.mv_to_ags(0) == 0.0
+
+    def test_ags_to_mv_is_inverse(self, ags):
+        assert ags.ags_to_mv(5.0) == pytest.approx(830, abs=1.0)
+        assert ags.ags_to_mv(0.5) == pytest.approx(83, abs=1.0)
+
+    def test_negative_mv_rejected(self, ags):
+        with pytest.raises(ValueError):
+            ags.mv_to_ags(-1)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd <repo> && python -m pytest tests/python/test_ags.py -v`
+Expected: FAIL — `AttributeError: module 'ags' has no attribute 'mv_to_ags'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/ags.py`, after the existing constants (`SOCKET_BUFFER = 4096`), add:
+
+```python
+GAIN_FACTOR = 6.024  # fixed analog factor; input-referred volts = ags_value / GAIN_FACTOR
+
+
+def mv_to_ags(millivolts):
+    """Convert an input-referred threshold in mV to the AGS das value."""
+    millivolts = float(millivolts)
+    if millivolts < 0:
+        raise ValueError("threshold mV must be non-negative")
+    return millivolts / 1000.0 * GAIN_FACTOR
+
+
+def ags_to_mv(ags):
+    """Convert an AGS das value back to the input-referred threshold in mV."""
+    return float(ags) / GAIN_FACTOR * 1000.0
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): threshold mV<->ags conversion helpers"
+```
+
+---
+
+## Task 2: ags.py — set_threshold (live)
+
+**Files:**
+- Modify: `scripts/ags.py`
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Consumes: `mv_to_ags`, `send_ags_command`, `SENSOR_IP`, `AGS_COMMAND_PORT`.
+- Produces: `set_threshold(channel, millivolts, persist=False, host=SENSOR_IP, port=AGS_COMMAND_PORT) -> str`. Sends `das_set_threshold <channel> <ags>`. Validates `channel ∈ {1,2}`. `persist` is accepted but unused until Task 6. Helper `_format_ags(ags) -> str` returns `f"{ags:g}"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`:
+
+```python
+class TestSetThreshold:
+    def test_sends_das_set_threshold(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            reply = ags.set_threshold(1, 830)
+        sent = mock_send.call_args[0][0]
+        toks = sent.split()
+        assert toks[0] == "das_set_threshold"
+        assert toks[1] == "1"
+        assert float(toks[2]) == pytest.approx(5.0, abs=1e-3)
+        assert reply == "OK"
+
+    def test_channel_2(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_threshold(2, 83)
+        toks = mock_send.call_args[0][0].split()
+        assert toks[1] == "2"
+        assert float(toks[2]) == pytest.approx(0.5, abs=1e-3)
+
+    def test_rejects_bad_channel(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_threshold(3, 83)
+            mock_send.assert_not_called()
+
+    def test_high_mv_sent_without_cap(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_threshold(1, 5000)  # far above nominal full-scale
+        toks = mock_send.call_args[0][0].split()
+        assert float(toks[2]) == pytest.approx(ags.mv_to_ags(5000), abs=1e-3)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestSetThreshold -v`
+Expected: FAIL — `module 'ags' has no attribute 'set_threshold'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/ags.py`, after `send_ags_command`, add:
+
+```python
+THRESHOLD_CHANNELS = (1, 2)
+
+
+def _format_ags(ags_value):
+    return "{:g}".format(ags_value)
+
+
+def set_threshold(channel, millivolts, persist=False,
+                  host=SENSOR_IP, port=AGS_COMMAND_PORT):
+    """Set a DAC trigger threshold (input-referred mV) on a HAMMA2 sensor."""
+    channel = int(channel)
+    if channel not in THRESHOLD_CHANNELS:
+        raise ValueError("threshold channel must be 1 or 2")
+    ags_value = mv_to_ags(millivolts)
+    command = "das_set_threshold {} {}".format(channel, _format_ags(ags_value))
+    return send_ags_command(command, host=host, port=port)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py::TestSetThreshold -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): set_threshold sends das_set_threshold (mV input)"
+```
+
+---
+
+## Task 3: ags.py — set_gain (live)
+
+**Files:**
+- Modify: `scripts/ags.py`
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Consumes: `send_ags_command`, `SENSOR_IP`, `AGS_COMMAND_PORT`.
+- Produces: `GAIN_REGISTERS = {"fast-e": "8", "slow-e": "10"}`; `GAIN_LEVELS = (0,1,2,3)`; `set_gain(channel, level, persist=False, host=SENSOR_IP, port=AGS_COMMAND_PORT) -> str`. Sends `das_send_command <reg> <level>`. Validates channel name and level.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`:
+
+```python
+class TestSetGain:
+    def test_fast_e_register(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_gain("fast-e", 2)
+        assert mock_send.call_args[0][0] == "das_send_command 8 2"
+
+    def test_slow_e_register(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_gain("slow-e", 0)
+        assert mock_send.call_args[0][0] == "das_send_command 10 0"
+
+    def test_rejects_bad_channel(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_gain("middle-e", 1)
+            mock_send.assert_not_called()
+
+    def test_rejects_bad_level(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_gain("fast-e", 4)
+            mock_send.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestSetGain -v`
+Expected: FAIL — `module 'ags' has no attribute 'set_gain'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/ags.py`, after `set_threshold`, add:
+
+```python
+GAIN_REGISTERS = {"fast-e": "8", "slow-e": "10"}
+GAIN_LEVELS = (0, 1, 2, 3)
+
+
+def set_gain(channel, level, persist=False,
+             host=SENSOR_IP, port=AGS_COMMAND_PORT):
+    """Set an FCM gain level (0-3) on a HAMMA2 sensor."""
+    if channel not in GAIN_REGISTERS:
+        raise ValueError("gain channel must be one of: "
+                         + ", ".join(sorted(GAIN_REGISTERS)))
+    level = int(level)
+    if level not in GAIN_LEVELS:
+        raise ValueError("gain level must be 0, 1, 2, or 3")
+    register = GAIN_REGISTERS[channel]
+    command = "das_send_command {} {}".format(register, level)
+    return send_ags_command(command, host=host, port=port)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py::TestSetGain -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): set_gain sends das_send_command to FCM gain registers"
+```
+
+---
+
+## Task 4: ags.py — rewrite_startup (pure line-rewrite)
+
+**Files:**
+- Modify: `scripts/ags.py`
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Produces: `rewrite_startup(text, match_tokens, new_line) -> str`. Replaces the line whose leading whitespace-split tokens equal `match_tokens` with `new_line`, preserving all other lines and the trailing newline. If no match, inserts `new_line` immediately before the first `das_reset` line (or appends if none). Token-based match avoids `"8"` matching `"80"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`:
+
+```python
+STARTUP_SAMPLE = (
+    "ds_enable\n"
+    "das_enable\n"
+    "das_set_threshold 1 0.5\n"
+    "das_set_threshold 2 0\n"
+    "das_send_command 8 1\n"
+    "das_send_command 10 1\n"
+    "das_set_mask 3\n"
+    "das_reset\n"
+)
+
+
+class TestRewriteStartup:
+    def test_replaces_matching_threshold_line(self, ags):
+        out = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        assert "das_set_threshold 1 5\n" in out
+        assert "das_set_threshold 1 0.5" not in out
+        # other lines untouched
+        assert "das_set_threshold 2 0\n" in out
+        assert "das_send_command 8 1\n" in out
+
+    def test_replaces_only_exact_register(self, ags):
+        out = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_send_command", "8"], "das_send_command 8 3")
+        assert "das_send_command 8 3\n" in out
+        assert "das_send_command 10 1\n" in out  # 10 not touched by an "8" match
+
+    def test_inserts_before_das_reset_when_absent(self, ags):
+        text = "ds_enable\ndas_enable\ndas_reset\n"
+        out = ags.rewrite_startup(
+            text, ["das_set_threshold", "1"], "das_set_threshold 1 0.5")
+        lines = out.splitlines()
+        assert lines.index("das_set_threshold 1 0.5") < lines.index("das_reset")
+
+    def test_idempotent(self, ags):
+        once = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        twice = ags.rewrite_startup(
+            once, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        assert once == twice
+
+    def test_preserves_trailing_newline_absence(self, ags):
+        text = "ds_enable\ndas_reset"  # no trailing newline
+        out = ags.rewrite_startup(text, ["ds_enable"], "ds_enable")
+        assert not out.endswith("\n")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestRewriteStartup -v`
+Expected: FAIL — `module 'ags' has no attribute 'rewrite_startup'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/ags.py`, add:
+
+```python
+def rewrite_startup(text, match_tokens, new_line):
+    """Return startup-file text with the line matching match_tokens replaced.
+
+    Match is on leading whitespace-split tokens (so "8" never matches "80").
+    If no line matches, new_line is inserted before the first das_reset line,
+    or appended if there is no das_reset.
+    """
+    match_tokens = list(match_tokens)
+    n = len(match_tokens)
+    lines = text.splitlines()
+    out = []
+    replaced = False
+    for line in lines:
+        if line.split()[:n] == match_tokens:
+            out.append(new_line)
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        insert_at = None
+        for i, line in enumerate(out):
+            if line.split()[:1] == ["das_reset"]:
+                insert_at = i
+                break
+        if insert_at is None:
+            out.append(new_line)
+        else:
+            out.insert(insert_at, new_line)
+    result = "\n".join(out)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py::TestRewriteStartup -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): rewrite_startup pure line-replace for persistence"
+```
+
+---
+
+## Task 5: ags.py — parse_startup_state
+
+**Files:**
+- Modify: `scripts/ags.py`
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Consumes: `ags_to_mv`.
+- Produces: `parse_startup_state(text) -> dict` with keys `threshold_1_mv`, `threshold_2_mv` (rounded to 1 decimal), `gain_fast`, `gain_slow` (ints). Missing entries are simply absent from the dict.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`:
+
+```python
+class TestParseStartupState:
+    def test_parses_thresholds_and_gains(self, ags):
+        state = ags.parse_startup_state(STARTUP_SAMPLE)
+        assert state["threshold_1_mv"] == pytest.approx(83, abs=1.0)
+        assert state["threshold_2_mv"] == 0.0
+        assert state["gain_fast"] == 1
+        assert state["gain_slow"] == 1
+
+    def test_missing_lines_absent(self, ags):
+        state = ags.parse_startup_state("ds_enable\ndas_reset\n")
+        assert "threshold_1_mv" not in state
+        assert "gain_fast" not in state
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestParseStartupState -v`
+Expected: FAIL — `module 'ags' has no attribute 'parse_startup_state'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `scripts/ags.py`, add:
+
+```python
+def parse_startup_state(text):
+    """Parse persisted threshold (mV) and gain levels from startup-file text."""
+    state = {}
+    for line in text.splitlines():
+        toks = line.split()
+        if len(toks) >= 3 and toks[0] == "das_set_threshold":
+            channel = toks[1]
+            if channel in ("1", "2"):
+                state["threshold_{}_mv".format(channel)] = round(
+                    ags_to_mv(float(toks[2])), 1)
+        elif len(toks) >= 3 and toks[0] == "das_send_command":
+            if toks[1] == "8":
+                state["gain_fast"] = int(toks[2])
+            elif toks[1] == "10":
+                state["gain_slow"] = int(toks[2])
+    return state
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py::TestParseStartupState -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): parse_startup_state reads persisted threshold/gain"
+```
+
+---
+
+## Task 6: ags.py — persist_startup + wire persist into setters
+
+**Files:**
+- Modify: `scripts/ags.py`
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Consumes: `rewrite_startup`, `subprocess`, `set_threshold`, `set_gain`.
+- Produces: `AGS_SSH_HOST = "hamma"`; `STARTUP_PATH = "/ags/scripts/startup"`; `persist_startup(match_tokens, new_line, host=AGS_SSH_HOST) -> None` (reads the file via `ssh host cat`, rewrites, writes back atomically via temp+mv). `set_threshold`/`set_gain` now honor `persist=True` by calling `persist_startup` after the live command.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`. Add `import subprocess` to the test file's imports (top of file).
+
+```python
+class TestPersist:
+    def test_persist_startup_reads_then_writes(self, ags):
+        read_result = MagicMock(returncode=0, stdout=STARTUP_SAMPLE.encode())
+        write_result = MagicMock(returncode=0)
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.side_effect = [read_result, write_result]
+            ags.persist_startup(["das_set_threshold", "1"],
+                                "das_set_threshold 1 5")
+        # second call is the write; its input carries the rewritten file
+        write_call = mock_sub.run.call_args_list[1]
+        written = write_call.kwargs["input"].decode()
+        assert "das_set_threshold 1 5\n" in written
+        assert "das_set_threshold 2 0\n" in written
+
+    def test_persist_raises_on_read_failure(self, ags):
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=1, stdout=b"",
+                                                  stderr=b"no route")
+            with pytest.raises(RuntimeError):
+                ags.persist_startup(["ds_enable"], "ds_enable")
+
+    def test_set_threshold_persist_calls_persist_startup(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 830, persist=True)
+        match_tokens, new_line = mock_persist.call_args[0][0], mock_persist.call_args[0][1]
+        assert match_tokens == ["das_set_threshold", "1"]
+        assert new_line.split()[:2] == ["das_set_threshold", "1"]
+
+    def test_set_gain_persist_calls_persist_startup(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_gain("fast-e", 3, persist=True)
+        assert mock_persist.call_args[0][0] == ["das_send_command", "8"]
+        assert mock_persist.call_args[0][1] == "das_send_command 8 3"
+
+    def test_set_threshold_no_persist_skips(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 830, persist=False)
+            mock_persist.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestPersist -v`
+Expected: FAIL — `module 'ags' has no attribute 'persist_startup'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import subprocess` to the top of `scripts/ags.py` (with the other stdlib imports). Then add:
+
+```python
+AGS_SSH_HOST = "hamma"
+STARTUP_PATH = "/ags/scripts/startup"
+
+
+def persist_startup(match_tokens, new_line, host=AGS_SSH_HOST):
+    """Rewrite one line of the sensor's startup script via ssh, atomically."""
+    read = subprocess.run(
+        ["ssh", host, "cat {}".format(STARTUP_PATH)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+    if read.returncode != 0:
+        raise RuntimeError("could not read {}: {}".format(
+            STARTUP_PATH, read.stderr.decode(errors="replace")))
+    new_text = rewrite_startup(read.stdout.decode(), match_tokens, new_line)
+    write_cmd = "cat > {0}.tmp && mv {0}.tmp {0}".format(STARTUP_PATH)
+    write = subprocess.run(
+        ["ssh", host, write_cmd], input=new_text.encode(),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+    if write.returncode != 0:
+        raise RuntimeError("could not write {}: {}".format(
+            STARTUP_PATH, write.stderr.decode(errors="replace")))
+```
+
+Then update `set_threshold` — replace its `return send_ags_command(...)` line so it captures the reply, optionally persists, and returns:
+
+```python
+    reply = send_ags_command(command, host=host, port=port)
+    if persist:
+        persist_startup(["das_set_threshold", str(channel)],
+                        "das_set_threshold {} {}".format(channel, _format_ags(ags_value)))
+    return reply
+```
+
+And update `set_gain` similarly:
+
+```python
+    reply = send_ags_command(command, host=host, port=port)
+    if persist:
+        persist_startup(["das_send_command", register],
+                        "das_send_command {} {}".format(register, level))
+    return reply
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py -v`
+Expected: PASS (all ags tests, incl. earlier ones still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): --persist rewrites /ags/scripts/startup via ssh hamma"
+```
+
+---
+
+## Task 7: ags.py — CLI subcommands
+
+**Files:**
+- Modify: `scripts/ags.py` (rewrite `main()`)
+- Test: `tests/python/test_ags.py`
+
+**Interfaces:**
+- Consumes: `set_threshold`, `set_gain`, `parse_startup_state`, `send_ags_command`, `subprocess`.
+- Produces: `main(argv=None)` that branches on the first arg: `set-threshold <ch> <mv> [--persist]`, `set-gain <fast-e|slow-e> <level> [--persist]`, `get-state`, else the existing generic passthrough (`ags.py <command> [--host H] [--port P]`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_ags.py`:
+
+```python
+class TestCli:
+    def test_set_threshold_subcommand(self, ags):
+        with patch.object(ags, "set_threshold", return_value="OK") as mock_set:
+            ags.main(["set-threshold", "1", "830"])
+        assert mock_set.call_args.kwargs.get("persist", False) is False
+        args = mock_set.call_args[0]
+        assert int(args[0]) == 1 and float(args[1]) == 830
+
+    def test_set_threshold_persist_flag(self, ags):
+        with patch.object(ags, "set_threshold", return_value="OK") as mock_set:
+            ags.main(["set-threshold", "1", "830", "--persist"])
+        assert mock_set.call_args.kwargs["persist"] is True
+
+    def test_set_gain_subcommand(self, ags):
+        with patch.object(ags, "set_gain", return_value="OK") as mock_set:
+            ags.main(["set-gain", "fast-e", "2"])
+        args = mock_set.call_args[0]
+        assert args[0] == "fast-e" and int(args[1]) == 2
+
+    def test_get_state_subcommand(self, ags):
+        result = MagicMock(returncode=0, stdout=STARTUP_SAMPLE.encode())
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.return_value = result
+            ags.main(["get-state"])  # should not raise
+
+    def test_passthrough_preserved(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.main(["das_reset"])
+        assert mock_send.call_args[0][0] == "das_reset"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_ags.py::TestCli -v`
+Expected: FAIL — `main()` takes no argv / subcommands not handled (TypeError or send_ags_command called with "set-threshold")
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import sys` to the imports if not present. Replace the existing `main()` in `scripts/ags.py` with:
+
+```python
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv and argv[0] == "set-threshold":
+        parser = argparse.ArgumentParser(prog="ags.py set-threshold")
+        parser.add_argument("channel", type=int, help="threshold channel (1 or 2)")
+        parser.add_argument("millivolts", type=float,
+                            help="input-referred threshold in mV")
+        parser.add_argument("--persist", action="store_true",
+                            help="also write /ags/scripts/startup")
+        ns = parser.parse_args(argv[1:])
+        print(set_threshold(ns.channel, ns.millivolts, persist=ns.persist))
+        return
+
+    if argv and argv[0] == "set-gain":
+        parser = argparse.ArgumentParser(prog="ags.py set-gain")
+        parser.add_argument("channel", choices=sorted(GAIN_REGISTERS),
+                            help="gain channel")
+        parser.add_argument("level", type=int, help="gain level (0-3)")
+        parser.add_argument("--persist", action="store_true",
+                            help="also write /ags/scripts/startup")
+        ns = parser.parse_args(argv[1:])
+        print(set_gain(ns.channel, ns.level, persist=ns.persist))
+        return
+
+    if argv and argv[0] == "get-state":
+        read = subprocess.run(
+            ["ssh", AGS_SSH_HOST, "cat {}".format(STARTUP_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+        if read.returncode != 0:
+            print("[FAIL] could not read startup: "
+                  + read.stderr.decode(errors="replace"))
+            return
+        state = parse_startup_state(read.stdout.decode())
+        for key in ("threshold_1_mv", "threshold_2_mv", "gain_fast", "gain_slow"):
+            if key in state:
+                print("{}: {}".format(key, state[key]))
+        return
+
+    # Generic passthrough (original behaviour)
+    parser_main = argparse.ArgumentParser(
+        description=(
+            "Send an AGS command to a HAMMA2 sensor. "
+            "Subcommands: set-threshold, set-gain, get-state. "
+            "Otherwise send a raw command; send 'help' for the sensor's list."),
+        argument_default=argparse.SUPPRESS)
+    parser_main.add_argument("command", nargs="?", default="help",
+                             help="The AGS command to send.")
+    parser_main.add_argument("--host", help="Sensor host/IP (default 10.10.10.1)")
+    parser_main.add_argument("--port", help="AGS command port (default 8082)")
+    parsed_args = parser_main.parse_args(argv)
+    print(send_ags_command(**vars(parsed_args)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_ags.py -v`
+Expected: PASS (all ags tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ags.py tests/python/test_ags.py
+git commit -m "feat(ags): set-threshold/set-gain/get-state CLI subcommands"
+```
+
+---
+
+## Task 8: mjol_array.py — shared AGS exec helper + refactor trigger
+
+**Files:**
+- Modify: `server/mjol_array.py`
+- Test: `tests/python/test_mjol_array.py`
+
+**Interfaces:**
+- Produces: `MjolnirArray._run_ags_command(port, ags_args, action_label, quiet=False, timeout=30)` — checks the tunnel (`status`), runs `ags.py` with `ags_args` over `_pi_ssh_cmd(port)`, surfaces stdout/stderr, flags `[SKIP]`/`[FAIL]`. `trigger()` is refactored to call it (behaviour unchanged: same `ags.py <command>` invocation, 30s timeout, `[SKIP]` when down).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_mjol_array.py`:
+
+```python
+class TestRunAgsCommand:
+    def test_skips_when_tunnel_down(self, mjol, capsys):
+        with patch.object(mjol.MjolnirArray, "status", return_value=False):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mjol.MjolnirArray._run_ags_command(10002, ["das_reset"], "x")
+                mock_sub.run.assert_not_called()
+        assert "[SKIP]" in capsys.readouterr().out
+
+    def test_runs_ags_with_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"OK", stderr=b"")
+                mock_sub.TimeoutExpired = Exception
+                mjol.MjolnirArray._run_ags_command(
+                    10002, ["set-threshold", "1", "830"], "set thr")
+        cmd = mock_sub.run.call_args[0][0]
+        assert "/home/pi/dev/mjolnir-hamma/scripts/ags.py" in cmd
+        assert cmd[-3:] == ["set-threshold", "1", "830"]
+
+    def test_trigger_still_invokes_ags_command(self, mjol):
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"OK", stderr=b"")
+                mock_sub.TimeoutExpired = Exception
+                mjol.MjolnirArray.trigger(10002)
+        cmd = mock_sub.run.call_args[0][0]
+        assert "/home/pi/dev/mjolnir-hamma/scripts/ags.py" in cmd
+        assert "das_manual_trigger" in cmd
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_mjol_array.py::TestRunAgsCommand -v`
+Expected: FAIL — `_run_ags_command` does not exist
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `server/mjol_array.py`, add this static method to `MjolnirArray` (next to `trigger`):
+
+```python
+    @staticmethod
+    def _run_ags_command(port, ags_args, action_label, quiet=False, timeout=30):
+        # Run ags.py on the Pi over its autossh tunnel with the given args.
+        # port is fully qualified (10000 + unit number).
+        sensor_num = port - 10000
+
+        if not MjolnirArray.status(port):
+            if not quiet:
+                print(f"[SKIP] mj{sensor_num:02} (port {port}): tunnel down, "
+                      f"{action_label} not sent.")
+            return
+
+        cmd = MjolnirArray._pi_ssh_cmd(port)
+        cmd = cmd + ['/home/pi/dev/mjolnir-hamma/scripts/ags.py'] + list(ags_args)
+
+        if not quiet:
+            print(f"--- mj{sensor_num:02}: {action_label} ---")
+
+        try:
+            out = subprocess.run(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                timeout=timeout)
+        except subprocess.TimeoutExpired:
+            if not quiet:
+                print(f"[FAIL] mj{sensor_num:02}: ags.py did not complete "
+                      f"in {timeout}s.")
+            return
+        except Exception as e:
+            if not quiet:
+                print(f"[FAIL] mj{sensor_num:02}: error running ags.py: {e}")
+            return
+
+        if quiet:
+            return
+
+        stdout = out.stdout.decode(errors="replace") if out.stdout else ""
+        stderr = out.stderr.decode(errors="replace") if out.stderr else ""
+        if stdout:
+            print(stdout, end="" if stdout.endswith("\n") else "\n")
+        if stderr:
+            print(stderr, end="" if stderr.endswith("\n") else "\n")
+        if out.returncode != 0:
+            print(f"[FAIL] mj{sensor_num:02}: ags.py exited "
+                  f"with code {out.returncode}.")
+```
+
+Then replace the body of `trigger()` with a delegating call (keep the signature):
+
+```python
+    @staticmethod
+    def trigger(port, command="das_manual_trigger", quiet=False):
+        # Send an AGS command (default: a manual trigger) to a sensor.
+        MjolnirArray._run_ags_command(
+            port, [command], f"sending AGS '{command}'", quiet=quiet)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_mjol_array.py -v`
+Expected: PASS (new tests + existing trigger tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/mjol_array.py tests/python/test_mjol_array.py
+git commit -m "refactor(mjol_array): shared _run_ags_command, trigger delegates to it"
+```
+
+---
+
+## Task 9: mjol_array.py — set_threshold/set_gain methods + array wrappers
+
+**Files:**
+- Modify: `server/mjol_array.py`
+- Test: `tests/python/test_mjol_array.py`
+
+**Interfaces:**
+- Consumes: `_run_ags_command`.
+- Produces:
+  - `MjolnirArray.set_threshold(port, channel, millivolts, persist=False, quiet=False)`
+  - `MjolnirArray.set_gain(port, channel, level, persist=False, quiet=False)`
+  - `set_threshold_array(self, ports=None, channel=None, millivolts=None, persist=False)`
+  - `set_gain_array(self, ports=None, channel=None, level=None, persist=False)`
+  - Each builds the right `ags.py` args (appending `--persist` when set) and fans out like `trigger_array`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_mjol_array.py`:
+
+```python
+class TestSetThresholdGain:
+    def test_set_threshold_builds_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_threshold(10002, 1, 830)
+        port, ags_args = mock_run.call_args[0][0], mock_run.call_args[0][1]
+        assert port == 10002
+        assert ags_args == ["set-threshold", "1", "830"]
+
+    def test_set_threshold_persist_appends_flag(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_threshold(10002, 1, 830, persist=True)
+        assert "--persist" in mock_run.call_args[0][1]
+
+    def test_set_gain_builds_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_gain(10002, "fast-e", 2)
+        assert mock_run.call_args[0][1] == ["set-gain", "fast-e", "2"]
+
+    def test_set_threshold_array_fans_out(self, mjol):
+        arr = mjol.MjolnirArray(sensors=[2, 3])
+        with patch.object(mjol.MjolnirArray, "set_threshold") as mock_set:
+            arr.set_threshold_array(channel=1, millivolts=830)
+        called_ports = [c[0][0] for c in mock_set.call_args_list]
+        assert called_ports == [10002, 10003]
+
+    def test_set_gain_array_explicit_ports(self, mjol):
+        arr = mjol.MjolnirArray(sensors=[2, 3])
+        with patch.object(mjol.MjolnirArray, "set_gain") as mock_set:
+            arr.set_gain_array(ports=["2"], channel="slow-e", level=0)
+        assert mock_set.call_args_list[0][0][0] == 10002
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_mjol_array.py::TestSetThresholdGain -v`
+Expected: FAIL — methods do not exist
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `server/mjol_array.py`, add to `MjolnirArray` (after `trigger`):
+
+```python
+    @staticmethod
+    def set_threshold(port, channel, millivolts, persist=False, quiet=False):
+        ags_args = ["set-threshold", str(channel), str(millivolts)]
+        if persist:
+            ags_args.append("--persist")
+        MjolnirArray._run_ags_command(
+            port, ags_args,
+            f"set threshold ch{channel} = {millivolts} mV"
+            + (" (persist)" if persist else ""),
+            quiet=quiet)
+
+    @staticmethod
+    def set_gain(port, channel, level, persist=False, quiet=False):
+        ags_args = ["set-gain", str(channel), str(level)]
+        if persist:
+            ags_args.append("--persist")
+        MjolnirArray._run_ags_command(
+            port, ags_args,
+            f"set gain {channel} = {level}"
+            + (" (persist)" if persist else ""),
+            quiet=quiet)
+```
+
+And add the array wrappers (after `trigger_array`):
+
+```python
+    def set_threshold_array(self, ports=None, channel=None, millivolts=None,
+                            persist=False):
+        if ports is None:
+            ports = [10000 + i for i in self.sensors]
+        else:
+            ports = [10000 + int(p) for p in ports]
+        for p in ports:
+            MjolnirArray.set_threshold(p, channel, millivolts, persist=persist)
+
+    def set_gain_array(self, ports=None, channel=None, level=None,
+                       persist=False):
+        if ports is None:
+            ports = [10000 + i for i in self.sensors]
+        else:
+            ports = [10000 + int(p) for p in ports]
+        for p in ports:
+            MjolnirArray.set_gain(p, channel, level, persist=persist)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_mjol_array.py::TestSetThresholdGain -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/mjol_array.py tests/python/test_mjol_array.py
+git commit -m "feat(mjol_array): set_threshold/set_gain methods + array fan-out"
+```
+
+---
+
+## Task 10: mjol_array.py — CLI options + dispatch
+
+**Files:**
+- Modify: `server/mjol_array.py` (the `main()` argparse + dispatch)
+- Test: `tests/python/test_mjol_array.py`
+
+**Interfaces:**
+- Produces: CLI `--set-threshold CHANNEL MV` (nargs=2), `--set-gain CHANNEL LEVEL` (nargs=2), `--persist` (store_true); dispatched in `main()` to the array wrappers.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/python/test_mjol_array.py`:
+
+```python
+class TestCliDispatch:
+    def test_set_threshold_cli(self, mjol):
+        with patch.object(mjol.MjolnirArray, "set_threshold_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-threshold", "1", "830"])
+        kwargs = mock_arr.call_args.kwargs
+        assert kwargs["channel"] == "1" and kwargs["millivolts"] == "830"
+        assert kwargs["persist"] is False
+
+    def test_set_gain_cli_with_persist(self, mjol):
+        with patch.object(mjol.MjolnirArray, "set_gain_array") as mock_arr:
+            mjol.main(["-a", "hamma", "--set-gain", "fast-e", "2", "--persist"])
+        kwargs = mock_arr.call_args.kwargs
+        assert kwargs["channel"] == "fast-e" and kwargs["level"] == "2"
+        assert kwargs["persist"] is True
+```
+
+Note: this requires `main()` to accept `argv` (Step 3 makes `main(argv=None)` and passes it to `parse_args(argv)`), so the test drives args directly rather than patching `sys.argv` (argparse reads its own `sys` reference, so patching `mjol.sys.argv` would not work).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/python/test_mjol_array.py::TestCliDispatch -v`
+Expected: FAIL — unrecognized arguments `--set-threshold`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Change the `main()` signature to `def main(argv=None):` and its parse call to
+`parsed_args = arg_parser.parse_args(argv)` (argparse treats `argv=None` as "read
+`sys.argv`", so the `__main__` call `main()` is unchanged). In `main()`, add these
+arguments alongside `--trigger`:
+
+```python
+    arg_parser.add_argument("--set-threshold", nargs=2,
+                            metavar=("CHANNEL", "MV"), default=None,
+                            help="Set threshold: channel (1|2) and mV")
+    arg_parser.add_argument("--set-gain", nargs=2,
+                            metavar=("CHANNEL", "LEVEL"), default=None,
+                            help="Set gain: channel (fast-e|slow-e) and level (0-3)")
+    arg_parser.add_argument("--persist", action="store_true", default=False,
+                            help="Also persist to /ags/scripts/startup")
+```
+
+Extend the dispatch chain in `main()` (insert before the `--up/--down` branch):
+
+```python
+    if parsed_args.do_status:
+        _ = mj_array.status_array(ports=parsed_args.ports)
+    elif parsed_args.do_trigger:
+        mj_array.trigger_array(ports=parsed_args.ports)
+    elif parsed_args.set_threshold is not None:
+        channel, millivolts = parsed_args.set_threshold
+        mj_array.set_threshold_array(
+            ports=parsed_args.ports, channel=channel, millivolts=millivolts,
+            persist=parsed_args.persist)
+    elif parsed_args.set_gain is not None:
+        channel, level = parsed_args.set_gain
+        mj_array.set_gain_array(
+            ports=parsed_args.ports, channel=channel, level=level,
+            persist=parsed_args.persist)
+    elif parsed_args.bring_up | parsed_args.bring_down:
+        mj_array.updown_array(parsed_args.bring_up, ports=parsed_args.ports)
+    else:
+        pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/python/test_mjol_array.py -v`
+Expected: PASS (all mjol_array tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/mjol_array.py tests/python/test_mjol_array.py
+git commit -m "feat(mjol_array): --set-threshold/--set-gain/--persist CLI"
+```
+
+---
+
+## Task 11: Full suite + E2E on mj02 (gated)
+
+**Files:** none (verification + live test)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the whole Python suite**
+
+Run: `python -m pytest tests/python/test_ags.py tests/python/test_mjol_array.py -v`
+Expected: PASS (all). Also run `python -m pytest tests/python -q` to confirm no regressions elsewhere.
+
+- [ ] **Step 2: Lint check (match repo tooling)**
+
+Run: `python -m pyflakes scripts/ags.py server/mjol_array.py` (or the repo's configured linter). Expected: no errors.
+
+- [ ] **Step 3: STOP — get explicit operator go-ahead for the live E2E on mj02**
+
+E2E changes a live sensor's threshold/gain. Do NOT run until the user explicitly approves at this point. Record mj02's baseline first so it can be restored:
+- `das_set_threshold 1 0.5`, `das_set_threshold 2 0`, `das_send_command 8 1`, `das_send_command 10 1`.
+
+- [ ] **Step 4: E2E — live set + readback (after approval)**
+
+From the VPS (or via the ssh-fleet MCP to mjolnir02), exercise the real path:
+1. `ssh pi@localhost -p 10002 /home/pi/dev/mjolnir-hamma/scripts/ags.py set-threshold 1 100`
+2. Trigger a fresh header (`ags.py das_manual_trigger`) and read it back — `mjol_array.py -p 2 --status` shows the Threshold column; confirm it reflects ~100 mV (within rounding).
+3. `ags.py set-gain fast-e 2`; trigger; confirm header `threashold_3` (gain_fast) reads 2.
+4. `ags.py get-state` reflects live persisted values.
+
+- [ ] **Step 5: E2E — persist + inspect (after approval)**
+
+1. `ags.py set-threshold 1 100 --persist`
+2. `ssh hamma cat /ags/scripts/startup` — confirm ONLY the `das_set_threshold 1` line changed; all other lines byte-identical to baseline.
+3. Confirm `ags.py get-state` shows the persisted value.
+
+- [ ] **Step 6: E2E — server fan-out smoke (after approval)**
+
+`mjol_array.py -p 2 --set-threshold 1 100` end-to-end over the tunnel; confirm `[OK]`-style output and no `[FAIL]`/`[SKIP]`.
+
+- [ ] **Step 7: RESTORE mj02 baseline**
+
+Re-apply baseline live AND persisted:
+- `ags.py set-threshold 1 83 --persist` (0.5 ags), `ags.py set-threshold 2 0 --persist`
+- `ags.py set-gain fast-e 1 --persist`, `ags.py set-gain slow-e 1 --persist`
+- Verify `ags.py get-state` and `ssh hamma cat /ags/scripts/startup` match the recorded baseline.
+
+- [ ] **Step 8: File a sensor-log issue**
+
+`gh issue create -R hamma-dev/sensor-log` documenting the mj02 E2E touch (what changed, that baseline was restored). See the hamma-expert `sensor-log.md` protocol.
+
+- [ ] **Step 9: Final commit / push branch**
+
+```bash
+git push -u origin feature/server-threshold-gain-control
+```
+
+---
+
+## Deployment notes (post-merge, not part of TDD tasks)
+
+- `scripts/ags.py` is consumed on **sensors** (mjolnir-hamma 0.4.x; `git pull` on each Pi).
+- `server/mjol_array.py` is consumed on the **VPS** (`~/dev/mjolnir-hamma`). Confirm the VPS checkout's branch carries this change so both deployment lines pick it up.
+- Confirm `ssh hamma` from each target Pi logs in with write access to `/ags/scripts/startup` (root-owned) before relying on `--persist` there.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** threshold-in-mV + conversion (Tasks 1–2), gain level 0–3 (Task 3), no hard cap / silent high-mV (Task 2 `test_high_mv_sent_without_cap`), `--persist` startup rewrite (Tasks 4,6), get-state readback (Tasks 5,7), server fan-out one/many/all (Tasks 9–10), reuse of trigger pattern + liveness gate (Task 8), verification + E2E + restore + sensor-log (Task 11), dual-deployment note (Deployment notes). ✔ all spec sections mapped.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code. ✔
+- **Type consistency:** `set_threshold`/`set_gain` signatures match between `ags.py` (Tasks 2,3,6) and the `mjol_array` invocation strings (Task 9); `_run_ags_command(port, ags_args, action_label, ...)` arg order consistent across Tasks 8–9; `rewrite_startup`/`parse_startup_state`/`persist_startup` names consistent across Tasks 4–7. ✔

--- a/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
+++ b/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
@@ -68,10 +68,9 @@ The operator specifies the **input-referred threshold in mV**, and the script co
 ags_value = (mV / 1000) * 6.024
 ```
 
-- **No hard upper cap.** Validate only `mV >= 0`; the firmware enforces its real limit.
-  (For reference, the nominal full-scale point "5" corresponds to ~830 mV; mj02's
-  current `0.5` ags value = 83 mV. A value well above ~830 mV may warrant an operator
-  warning but is not rejected.)
+- **No hard upper cap.** Validate only `mV >= 0`, then convert and send; the firmware
+  enforces its real limit (no client-side warning). For reference, the nominal
+  full-scale point "5" corresponds to ~830 mV; mj02's current `0.5` ags value = 83 mV.
 - Readback: header raw `threashold_1/2` → input-referred volts = raw·(5/4096)/6.024 →
   display in mV.
 
@@ -122,8 +121,8 @@ New, clearly-named functions on top of the existing `send_ags_command()`:
 
 - `set_threshold(channel, millivolts, *, persist=False, host, port)`
   - `channel ∈ {1, 2}` (the firmware's threshold channel number). Reject 3–8.
-  - Validate `mV >= 0` (no hard upper cap); convert `ags = mV/1000·6.024`. Optionally
-    warn if mV exceeds the ~830 mV nominal full-scale, but still send.
+  - Validate `mV >= 0` (no hard upper cap); convert `ags = mV/1000·6.024` and send
+    (no client-side warning above nominal full-scale).
   - Send `das_set_threshold <channel> <ags>`; return firmware reply.
   - If `persist`: rewrite the matching `das_set_threshold <channel> ...` line in
     `/ags/scripts/startup`.
@@ -183,10 +182,10 @@ alongside `--status` / `--trigger` / `--up` / `--down`.
 
 - Reject clearly-invalid input up front (channel ∉ {1,2}, negative mV, gain level
   ∉ {0..3}) before touching the sensor. The mV threshold has **no hard upper cap** (the
-  "0–5" nominal range is not firmware-enforced); a value far above the ~830 mV nominal
-  full-scale may warrant a warning. Bad threshold can blind the sensor (too high →
-  misses lightning) or fill disk (too low → noise triggering), so the warning helps, but
-  the firmware is the final authority on range.
+  "0–5" nominal range is not firmware-enforced) and no client-side warning above nominal
+  full-scale — the firmware is the final authority on range. Bad threshold can blind the
+  sensor (too high → misses lightning) or fill disk (too low → noise triggering), which
+  is why the E2E test verifies the readback and restores mj02's baseline.
 - `--persist` writes are atomic and line-exact; never rewrite unrelated lines, never
   reorder relative to `das_reset`.
 - Tunnel-down → `[SKIP]`, consistent with `updown`/`trigger`.
@@ -197,7 +196,7 @@ alongside `--status` / `--trigger` / `--up` / `--down`.
 **Unit (pytest, mock socket + ssh subprocess):**
 - mV ↔ ags conversion (round-trip; e.g. 83 mV ↔ 0.5, 830 mV ↔ 5.0).
 - Validation rejects channel ∉ {1,2}, negative mV, gain channel name typos,
-  level ∉ {0..3}. mV above nominal full-scale is allowed (optionally warns), not rejected.
+  level ∉ {0..3}. mV above nominal full-scale is allowed (sent silently), not rejected.
 - Correct firmware command strings built (`das_set_threshold 1 <v>`,
   `das_send_command 8 <l>`, etc.).
 - `persist_startup` line replacement: replaces only the matching line, preserves all

--- a/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
+++ b/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
@@ -55,16 +55,23 @@ Notes grounding the design:
 
 ### Threshold unit conversion (operator works in mV)
 
-`das_set_threshold` takes a DAC-side "volts 0–5" value. The scientifically meaningful
-number is the **input-referred threshold = DAC_volts ÷ 6.024** (the fixed analog gain
-factor, per the `hamma` package: `version20.py` and `header/utilities.py`). The
-operator specifies the **input-referred threshold in mV**, and the script converts:
+`das_set_threshold` takes a unitless "ags" value (the firmware help labels it
+"volts 0–5", but that range is **nominal, not enforced** — the underlying header field
+is a uint16 and the scale is `5/4096`, so the value can exceed the point "5" maps to).
+The scientifically meaningful number is the **input-referred threshold = ags ÷ 6.024**
+(the fixed analog factor, per the `hamma` package: `version20.py:83` =
+`(5/4096)·thresh1/6.024`; `header/utilities.py` `ags_threshold_convert` = `ags/6.024`).
+
+The operator specifies the **input-referred threshold in mV**, and the script converts:
 
 ```
-das_volts = (mV / 1000) * 6.024
+ags_value = (mV / 1000) * 6.024
 ```
 
-- Valid `das_volts` ∈ [0, 5] → valid input-referred **mV ∈ [0, ~829.8]**.
+- **No hard upper cap.** Validate only `mV >= 0`; the firmware enforces its real limit.
+  (For reference, the nominal full-scale point "5" corresponds to ~830 mV; mj02's
+  current `0.5` ags value = 83 mV. A value well above ~830 mV may warrant an operator
+  warning but is not rejected.)
 - Readback: header raw `threashold_1/2` → input-referred volts = raw·(5/4096)/6.024 →
   display in mV.
 
@@ -115,8 +122,9 @@ New, clearly-named functions on top of the existing `send_ags_command()`:
 
 - `set_threshold(channel, millivolts, *, persist=False, host, port)`
   - `channel ∈ {1, 2}` (the firmware's threshold channel number). Reject 3–8.
-  - Convert mV → das_volts; validate das_volts ∈ [0, 5] (i.e. mV ∈ [0, 829.8]).
-  - Send `das_set_threshold <channel> <das_volts>`; return firmware reply.
+  - Validate `mV >= 0` (no hard upper cap); convert `ags = mV/1000·6.024`. Optionally
+    warn if mV exceeds the ~830 mV nominal full-scale, but still send.
+  - Send `das_set_threshold <channel> <ags>`; return firmware reply.
   - If `persist`: rewrite the matching `das_set_threshold <channel> ...` line in
     `/ags/scripts/startup`.
 - `set_gain(channel, level, *, persist=False, host, port)`
@@ -173,9 +181,12 @@ alongside `--status` / `--trigger` / `--up` / `--down`.
 
 ## Validation & safety
 
-- Reject out-of-range up front (channel, mV, gain level) before touching the sensor —
-  bad threshold can blind the sensor (too high → misses lightning) or fill disk (too
-  low → noise triggering).
+- Reject clearly-invalid input up front (channel ∉ {1,2}, negative mV, gain level
+  ∉ {0..3}) before touching the sensor. The mV threshold has **no hard upper cap** (the
+  "0–5" nominal range is not firmware-enforced); a value far above the ~830 mV nominal
+  full-scale may warrant a warning. Bad threshold can blind the sensor (too high →
+  misses lightning) or fill disk (too low → noise triggering), so the warning helps, but
+  the firmware is the final authority on range.
 - `--persist` writes are atomic and line-exact; never rewrite unrelated lines, never
   reorder relative to `das_reset`.
 - Tunnel-down → `[SKIP]`, consistent with `updown`/`trigger`.
@@ -184,9 +195,9 @@ alongside `--status` / `--trigger` / `--up` / `--down`.
 ## Testing
 
 **Unit (pytest, mock socket + ssh subprocess):**
-- mV ↔ das_volts conversion (round-trip, boundaries 0 and 829.8 mV).
-- Validation rejects channel ∉ {1,2}, mV out of [0, 829.8], gain channel name typos,
-  level ∉ {0..3}.
+- mV ↔ ags conversion (round-trip; e.g. 83 mV ↔ 0.5, 830 mV ↔ 5.0).
+- Validation rejects channel ∉ {1,2}, negative mV, gain channel name typos,
+  level ∉ {0..3}. mV above nominal full-scale is allowed (optionally warns), not rejected.
 - Correct firmware command strings built (`das_set_threshold 1 <v>`,
   `das_send_command 8 <l>`, etc.).
 - `persist_startup` line replacement: replaces only the matching line, preserves all

--- a/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
+++ b/docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md
@@ -1,0 +1,224 @@
+# Server-side threshold & gain control — design
+
+**Date:** 2026-06-29
+**Branch base:** `0.4.x` (feature branch `feature/server-threshold-gain-control`)
+**Status:** Design approved, pending written-spec review
+
+## Goal
+
+Let an operator change a HAMMA2 sensor's **trigger threshold** and **FCM gain** from
+the server (VPS `hamma.dev`), for one sensor, several, or a whole array in a single
+command — mirroring the existing "trigger a sensor" / "power on/off" tooling. A
+`--persist` flag makes a change survive a sensor (DAS/FPGA) reset; without it the
+change is live-only and is lost on the next DAS reset/power-cycle.
+
+A web UI is explicitly **out of scope** for this work (desired follow-on, phase 2).
+
+## Background: how the hardware exposes these
+
+The threshold and gain live in **volatile registers on the HAMMA2 sensor's DAS/FPGA**
+(`10.10.10.1`), not in any brokkr/sindri config. The only live command channel is the
+AGS command socket at `10.10.10.1:8082`, wrapped by `scripts/ags.py`
+(`send_ags_command()`). Two firmware verbs matter, confirmed live on mj02 via
+`ags.py help`:
+
+- `das_set_threshold <1-8> <volts 0-5>` — sets a DAC threshold (per channel).
+- `das_send_command <hex_reg> <hex_value>` — generic register write.
+
+The AGS register map (from the Confluence "ags packet" attachment, authoritative):
+
+| Function | Register | Value | How set |
+|---|---|---|---|
+| Threshold 1 (DAC threshold) | `0x02` | 12-bit | `das_set_threshold 1 <volts>` |
+| Threshold 2 (DAC threshold) | `0x04` | 12-bit | `das_set_threshold 2 <volts>` |
+| FCM **FAST-E gain** | `0x08` | low 2 bits | `das_send_command 8 <0-3>` |
+| FCM **SLOW-E gain** | `0x10` | low 2 bits | `das_send_command 10 <0-3>` |
+| Channels 5–8 | `0x20`–`0x100` | — | not used |
+
+The firmware labels the two threshold registers only "Threshold 1/2" (it does **not**
+say which is fast vs slow E-field); only the *gain* registers are explicitly labeled
+FAST-E (`0x08`) / SLOW-E (`0x10`). The threshold CLI therefore takes the **channel
+number** (1 or 2) directly, so the fast/slow labeling is irrelevant to its behavior;
+confirm the physical fast/slow correspondence during E2E if it matters for operator
+docs.
+
+Notes grounding the design:
+
+- **Gain is a 2-bit digital level (0–3), not a voltage** — 4 discrete FCM gain
+  settings. It is *not* expressible in mV.
+- The firmware reads the `das_send_command` register as **bare hex** (`8`, `10` mean
+  `0x08`, `0x10`) — matching what the live startup file already uses.
+- **Both threshold and gain are reported back in the science-packet header**: the
+  decoded header fields `threashold_1..4` carry threshold 1, threshold 2, FAST-E gain,
+  SLOW-E gain respectively. There is **no AGS "get" command**, so header readback is
+  the only confirmation channel.
+
+### Threshold unit conversion (operator works in mV)
+
+`das_set_threshold` takes a DAC-side "volts 0–5" value. The scientifically meaningful
+number is the **input-referred threshold = DAC_volts ÷ 6.024** (the fixed analog gain
+factor, per the `hamma` package: `version20.py` and `header/utilities.py`). The
+operator specifies the **input-referred threshold in mV**, and the script converts:
+
+```
+das_volts = (mV / 1000) * 6.024
+```
+
+- Valid `das_volts` ∈ [0, 5] → valid input-referred **mV ∈ [0, ~829.8]**.
+- Readback: header raw `threashold_1/2` → input-referred volts = raw·(5/4096)/6.024 →
+  display in mV.
+
+### Persistence: the sensor startup script
+
+The DAS restores its registers at boot from a single line-oriented script on the
+**AGS host**, `/ags/scripts/startup`, reached via `ssh hamma` from the brokkr Pi.
+Current mj02 contents (reference):
+
+```
+ds_enable
+hs_set_host 10.10.10.2
+hs_set_port 8084
+hs_enable
+das_enable
+das_set_threshold 1 0.5
+das_set_threshold 2 0
+das_send_command 8 1
+das_send_command 10 1
+das_set_interval 14400
+das_set_mask 3
+ds_set_period 1
+das_reset
+```
+
+The file uses the **same command syntax** as the live commands, so persisting a value
+means rewriting the one matching line (or inserting it before `das_reset` if absent).
+Today this is hand-edited.
+
+## Architecture
+
+Three layers, each reusing an existing pattern:
+
+```
+operator @ VPS
+  └─ server/mjol_array.py   (NEW actions: --set-threshold, --set-gain, --persist)
+       │  reuse: _pi_ssh_cmd, status() liveness gate, -a/-p fan-out, [OK]/[FAIL] relay
+       │  (near-clone of existing trigger()/trigger_array())
+       └─ ssh pi@localhost -p 1000N  scripts/ags.py set-threshold|set-gain ... [--persist]
+            └─ scripts/ags.py   (NEW named functions + subcommands)
+                 ├─ live set: send_ags_command() → 10.10.10.1:8082
+                 └─ --persist: ssh hamma → rewrite /ags/scripts/startup line
+```
+
+### 1. `scripts/ags.py` (runs on the brokkr Pi)
+
+New, clearly-named functions on top of the existing `send_ags_command()`:
+
+- `set_threshold(channel, millivolts, *, persist=False, host, port)`
+  - `channel ∈ {1, 2}` (the firmware's threshold channel number). Reject 3–8.
+  - Convert mV → das_volts; validate das_volts ∈ [0, 5] (i.e. mV ∈ [0, 829.8]).
+  - Send `das_set_threshold <channel> <das_volts>`; return firmware reply.
+  - If `persist`: rewrite the matching `das_set_threshold <channel> ...` line in
+    `/ags/scripts/startup`.
+- `set_gain(channel, level, *, persist=False, host, port)`
+  - `channel ∈ {"fast-e", "slow-e"}` → register `8` / `10`.
+  - `level ∈ {0, 1, 2, 3}`. Reject others.
+  - Send `das_send_command <reg> <level>`; return firmware reply.
+  - If `persist`: rewrite the matching `das_send_command <reg> ...` line.
+- `persist_startup(match_prefix, new_line)` — read `/ags/scripts/startup` via
+  `ssh hamma`, replace the unique line beginning with `match_prefix` (e.g.
+  `das_set_threshold 1` or `das_send_command 8`), preserving every other line; if no
+  match, insert `new_line` immediately before the trailing `das_reset`. Write back
+  atomically (temp file + move) so a failure never leaves a truncated startup script.
+  Idempotent.
+- `get_state()` — parse `/ags/scripts/startup` and report the *persisted* threshold
+  (in mV) and gain levels. (Live current values are already visible via
+  `mjol_array.py --status`, which reads the latest header threshold.)
+
+New CLI subcommands (argparse subparsers; the existing generic
+`ags.py <command>` passthrough is preserved):
+
+```
+ags.py set-threshold <channel 1|2> <millivolts> [--persist]
+ags.py set-gain <fast-e|slow-e> <level 0-3> [--persist]
+ags.py get-state
+```
+
+Constants added: `GAIN_FACTOR = 6.024`, register map for gain channels, startup-file
+path, and the `hamma` ssh alias for the AGS host.
+
+### 2. `server/mjol_array.py` (runs on the VPS)
+
+Add static methods mirroring the existing `trigger()` (same tunnel, liveness gate,
+timeout, reply-surfacing), plus array wrappers mirroring `trigger_array()`:
+
+- `set_threshold(port, channel, millivolts, persist=False, quiet=False)`
+- `set_gain(port, channel, level, persist=False, quiet=False)`
+- `set_threshold_array(ports, channel, millivolts, persist=False)`
+- `set_gain_array(ports, channel, level, persist=False)`
+
+Each builds `ags.py set-threshold|set-gain ... [--persist]` and runs it over
+`_pi_ssh_cmd(port)` with a 30s timeout (matching `trigger()`), relaying the Pi's
+output and flagging nonzero exit / tunnel-down `[SKIP]`.
+
+New CLI options, combined with the existing `-a {hamma,pamma,aumma}` / repeated `-p N`:
+
+```
+mjol_array.py -a hamma --set-threshold <channel> <mV> [--persist]
+mjol_array.py -p 2 -p 3 --set-gain <fast-e|slow-e> <level> [--persist]
+```
+
+`--set-threshold` takes two args (channel, mV); `--set-gain` takes two (channel,
+level); `--persist` is a shared boolean. Wire into the `main()` if/elif dispatch
+alongside `--status` / `--trigger` / `--up` / `--down`.
+
+## Validation & safety
+
+- Reject out-of-range up front (channel, mV, gain level) before touching the sensor —
+  bad threshold can blind the sensor (too high → misses lightning) or fill disk (too
+  low → noise triggering).
+- `--persist` writes are atomic and line-exact; never rewrite unrelated lines, never
+  reorder relative to `das_reset`.
+- Tunnel-down → `[SKIP]`, consistent with `updown`/`trigger`.
+- The change does **not** require a brokkr restart (brokkr only reads the header).
+
+## Testing
+
+**Unit (pytest, mock socket + ssh subprocess):**
+- mV ↔ das_volts conversion (round-trip, boundaries 0 and 829.8 mV).
+- Validation rejects channel ∉ {1,2}, mV out of [0, 829.8], gain channel name typos,
+  level ∉ {0..3}.
+- Correct firmware command strings built (`das_set_threshold 1 <v>`,
+  `das_send_command 8 <l>`, etc.).
+- `persist_startup` line replacement: replaces only the matching line, preserves all
+  others byte-for-byte, inserts before `das_reset` when absent, is idempotent.
+- `mjol_array` action methods build the right `ags.py` invocation and honor
+  `--persist`; array wrappers fan out over the right ports; tunnel-down → `[SKIP]`.
+
+**E2E on mj02 (requires explicit go-ahead at run time; restore originals after):**
+1. Record mj02 originals: `das_set_threshold 1 0.5`, `das_set_threshold 2 0`,
+   gains `8→1`, `10→1`.
+2. `ags.py set-threshold 1 <mV>` (live) → read back via `mjol_array.py --status`
+   (threshold column) / header `threashold_1` → confirm mV matches within rounding.
+3. `ags.py set-gain fast-e <level>` (live) → read back header `threashold_3` → confirm.
+4. `--persist` variant → inspect `/ags/scripts/startup`; confirm only the target line
+   changed.
+5. Fan-out smoke: `mjol_array.py -p 2 --set-threshold ...` end-to-end over the tunnel.
+6. **Restore** mj02 to recorded originals (live + persisted) and verify.
+
+Per project rule: file a `hamma-dev/sensor-log` issue for the mj02 config touch.
+
+## Deployment notes (for the plan, not this spec)
+
+- `scripts/ags.py` is consumed on the **sensors** (they run mjolnir-hamma 0.4.x; update
+  by `git pull`).
+- `server/mjol_array.py` is consumed on the **VPS** (`~/dev/mjolnir-hamma`). Confirm the
+  VPS checkout's branch contains this change (merge-forward / branch update) so both
+  deployment lines pick it up.
+
+## Out of scope / YAGNI
+
+- Web UI (phase 2).
+- Setting interval/mask/period or other startup-script lines.
+- Changing channels 5–8 (firmware "not used").
+- An automated set→trigger→readback verify loop inside the script (E2E covers
+  verification; `--status` already surfaces live threshold).

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -5,6 +5,7 @@
 # Standard library imports
 import argparse
 import socket
+import subprocess
 import time
 
 
@@ -75,11 +76,36 @@ def set_threshold(channel, millivolts, persist=False,
         raise ValueError("threshold channel must be 1 or 2")
     ags_value = mv_to_ags(millivolts)
     command = "das_set_threshold {} {}".format(channel, _format_ags(ags_value))
-    return send_ags_command(command, host=host, port=port)
+    reply = send_ags_command(command, host=host, port=port)
+    if persist:
+        persist_startup(["das_set_threshold", str(channel)],
+                        "das_set_threshold {} {}".format(channel, _format_ags(ags_value)))
+    return reply
 
 
 GAIN_REGISTERS = {"fast-e": "8", "slow-e": "10"}
 GAIN_LEVELS = (0, 1, 2, 3)
+
+AGS_SSH_HOST = "hamma"
+STARTUP_PATH = "/ags/scripts/startup"
+
+
+def persist_startup(match_tokens, new_line, host=AGS_SSH_HOST):
+    """Rewrite one line of the sensor's startup script via ssh, atomically."""
+    read = subprocess.run(
+        ["ssh", host, "cat {}".format(STARTUP_PATH)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+    if read.returncode != 0:
+        raise RuntimeError("could not read {}: {}".format(
+            STARTUP_PATH, read.stderr.decode(errors="replace")))
+    new_text = rewrite_startup(read.stdout.decode(), match_tokens, new_line)
+    write_cmd = "cat > {0}.tmp && mv {0}.tmp {0}".format(STARTUP_PATH)
+    write = subprocess.run(
+        ["ssh", host, write_cmd], input=new_text.encode(),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+    if write.returncode != 0:
+        raise RuntimeError("could not write {}: {}".format(
+            STARTUP_PATH, write.stderr.decode(errors="replace")))
 
 
 def set_gain(channel, level, persist=False,
@@ -93,7 +119,11 @@ def set_gain(channel, level, persist=False,
         raise ValueError("gain level must be 0, 1, 2, or 3")
     register = GAIN_REGISTERS[channel]
     command = "das_send_command {} {}".format(register, level)
-    return send_ags_command(command, host=host, port=port)
+    reply = send_ags_command(command, host=host, port=port)
+    if persist:
+        persist_startup(["das_send_command", register],
+                        "das_send_command {} {}".format(register, level))
+    return reply
 
 
 def rewrite_startup(text, match_tokens, new_line):

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -12,6 +12,21 @@ AGS_COMMAND_PORT = 8082
 SENSOR_IP = "10.10.10.1"
 SOCKET_BUFFER = 4096
 
+GAIN_FACTOR = 6.024  # fixed analog factor; input-referred volts = ags_value / GAIN_FACTOR
+
+
+def mv_to_ags(millivolts):
+    """Convert an input-referred threshold in mV to the AGS das value."""
+    millivolts = float(millivolts)
+    if millivolts < 0:
+        raise ValueError("threshold mV must be non-negative")
+    return millivolts / 1000.0 * GAIN_FACTOR
+
+
+def ags_to_mv(ags):
+    """Convert an AGS das value back to the input-referred threshold in mV."""
+    return float(ags) / GAIN_FACTOR * 1000.0
+
 
 def netcat(content, host, port, recieve_reply=True, timeout=1):
     recieved_data = None

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -72,7 +72,13 @@ def _format_ags(ags_value):
 
 
 def _reply_indicates_error(reply):
-    """True if any line of an AGS reply signals a firmware error."""
+    """True if an AGS reply is empty/missing or signals a firmware error.
+
+    An empty or whitespace-only reply means the sensor did not confirm the
+    command (e.g. socket timeout with no data), so it must NOT gate a persist.
+    """
+    if not reply or not reply.strip():
+        return True
     return any(line.strip().startswith("Error") for line in reply.splitlines())
 
 

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -6,6 +6,7 @@
 import argparse
 import socket
 import subprocess
+import sys
 import time
 
 
@@ -177,22 +178,58 @@ def parse_startup_state(text):
     return state
 
 
-def main():
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv and argv[0] == "set-threshold":
+        parser = argparse.ArgumentParser(prog="ags.py set-threshold")
+        parser.add_argument("channel", type=int, help="threshold channel (1 or 2)")
+        parser.add_argument("millivolts", type=float,
+                            help="input-referred threshold in mV")
+        parser.add_argument("--persist", action="store_true",
+                            help="also write /ags/scripts/startup")
+        ns = parser.parse_args(argv[1:])
+        print(set_threshold(ns.channel, ns.millivolts, persist=ns.persist))
+        return
+
+    if argv and argv[0] == "set-gain":
+        parser = argparse.ArgumentParser(prog="ags.py set-gain")
+        parser.add_argument("channel", choices=sorted(GAIN_REGISTERS),
+                            help="gain channel")
+        parser.add_argument("level", type=int, help="gain level (0-3)")
+        parser.add_argument("--persist", action="store_true",
+                            help="also write /ags/scripts/startup")
+        ns = parser.parse_args(argv[1:])
+        print(set_gain(ns.channel, ns.level, persist=ns.persist))
+        return
+
+    if argv and argv[0] == "get-state":
+        read = subprocess.run(
+            ["ssh", AGS_SSH_HOST, "cat {}".format(STARTUP_PATH)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+        if read.returncode != 0:
+            print("[FAIL] could not read startup: "
+                  + read.stderr.decode(errors="replace"))
+            return
+        state = parse_startup_state(read.stdout.decode())
+        for key in ("threshold_1_mv", "threshold_2_mv", "gain_fast", "gain_slow"):
+            if key in state:
+                print("{}: {}".format(key, state[key]))
+        return
+
+    # Generic passthrough (original behaviour)
     parser_main = argparse.ArgumentParser(
         description=(
-            "Send an AGS command to a HAMMA2 sensor."
-            "Send 'help' to list all commands supported by the sensor."),
+            "Send an AGS command to a HAMMA2 sensor. "
+            "Subcommands: set-threshold, set-gain, get-state. "
+            "Otherwise send a raw command; send 'help' for the sensor's list."),
         argument_default=argparse.SUPPRESS)
-
-    parser_main.add_argument(
-        "command", nargs="?", default="help",
-        help="The AGS command to send; send 'help' for a list.")
-    parser_main.add_argument(
-        "--host", help="The hostname/IP of the sensor (default 10.10.10.1)")
-    parser_main.add_argument(
-        "--port", help="The AGS command port of the sensor (default 8082)")
-
-    parsed_args = parser_main.parse_args()
+    parser_main.add_argument("command", nargs="?", default="help",
+                             help="The AGS command to send.")
+    parser_main.add_argument("--host", help="Sensor host/IP (default 10.10.10.1)")
+    parser_main.add_argument("--port", help="AGS command port (default 8082)")
+    parsed_args = parser_main.parse_args(argv)
     print(send_ags_command(**vars(parsed_args)))
 
 

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -12,6 +12,8 @@ import time
 AGS_COMMAND_PORT = 8082
 SENSOR_IP = "10.10.10.1"
 SOCKET_BUFFER = 4096
+AGS_SSH_HOST = "hamma"
+STARTUP_PATH = "/ags/scripts/startup"
 
 GAIN_FACTOR = 6.024  # fixed analog factor; input-referred volts = ags_value / GAIN_FACTOR
 
@@ -85,9 +87,6 @@ def set_threshold(channel, millivolts, persist=False,
 
 GAIN_REGISTERS = {"fast-e": "8", "slow-e": "10"}
 GAIN_LEVELS = (0, 1, 2, 3)
-
-AGS_SSH_HOST = "hamma"
-STARTUP_PATH = "/ags/scripts/startup"
 
 
 def persist_startup(match_tokens, new_line, host=AGS_SSH_HOST):

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -71,6 +71,11 @@ def _format_ags(ags_value):
     return "{:g}".format(ags_value)
 
 
+def _reply_indicates_error(reply):
+    """True if any line of an AGS reply signals a firmware error."""
+    return any(line.strip().startswith("Error") for line in reply.splitlines())
+
+
 def set_threshold(channel, millivolts, persist=False,
                   host=SENSOR_IP, port=AGS_COMMAND_PORT):
     """Set a DAC trigger threshold (input-referred mV) on a HAMMA2 sensor."""
@@ -80,12 +85,10 @@ def set_threshold(channel, millivolts, persist=False,
     ags_value = mv_to_ags(millivolts)
     command = "das_set_threshold {} {}".format(channel, _format_ags(ags_value))
     reply = send_ags_command(command, host=host, port=port)
-    # NOTE: persist writes the startup file regardless of the firmware's
-    # reply. send_ags_command only raises on transport failure, not on a
-    # firmware "out of range" reply, so --persist may store a value the
-    # sensor rejected. The firmware is the range authority; confirm via
-    # header readback (threashold_1..4) after setting.
-    if persist:
+    # Only persist if the sensor accepted the live value. The firmware
+    # replies with an "Error -" line when it rejects a value (e.g. out of
+    # range); persisting that would store a bad value in the startup script.
+    if persist and not _reply_indicates_error(reply):
         persist_startup(["das_set_threshold", str(channel)],
                         "das_set_threshold {} {}".format(channel, _format_ags(ags_value)))
     return reply
@@ -125,12 +128,8 @@ def set_gain(channel, level, persist=False,
     register = GAIN_REGISTERS[channel]
     command = "das_send_command {} {}".format(register, level)
     reply = send_ags_command(command, host=host, port=port)
-    # NOTE: persist writes the startup file regardless of the firmware's
-    # reply. send_ags_command only raises on transport failure, not on a
-    # firmware "out of range" reply, so --persist may store a value the
-    # sensor rejected. The firmware is the range authority; confirm via
-    # header readback (threashold_1..4) after setting.
-    if persist:
+    # Only persist if the sensor accepted the live value (see set_threshold).
+    if persist and not _reply_indicates_error(reply):
         persist_startup(["das_send_command", register],
                         "das_send_command {} {}".format(register, level))
     return reply

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -78,6 +78,24 @@ def set_threshold(channel, millivolts, persist=False,
     return send_ags_command(command, host=host, port=port)
 
 
+GAIN_REGISTERS = {"fast-e": "8", "slow-e": "10"}
+GAIN_LEVELS = (0, 1, 2, 3)
+
+
+def set_gain(channel, level, persist=False,
+             host=SENSOR_IP, port=AGS_COMMAND_PORT):
+    """Set an FCM gain level (0-3) on a HAMMA2 sensor."""
+    if channel not in GAIN_REGISTERS:
+        raise ValueError("gain channel must be one of: "
+                         + ", ".join(sorted(GAIN_REGISTERS)))
+    level = int(level)
+    if level not in GAIN_LEVELS:
+        raise ValueError("gain level must be 0, 1, 2, or 3")
+    register = GAIN_REGISTERS[channel]
+    command = "das_send_command {} {}".format(register, level)
+    return send_ags_command(command, host=host, port=port)
+
+
 def main():
     parser_main = argparse.ArgumentParser(
         description=(

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -80,6 +80,11 @@ def set_threshold(channel, millivolts, persist=False,
     ags_value = mv_to_ags(millivolts)
     command = "das_set_threshold {} {}".format(channel, _format_ags(ags_value))
     reply = send_ags_command(command, host=host, port=port)
+    # NOTE: persist writes the startup file regardless of the firmware's
+    # reply. send_ags_command only raises on transport failure, not on a
+    # firmware "out of range" reply, so --persist may store a value the
+    # sensor rejected. The firmware is the range authority; confirm via
+    # header readback (threashold_1..4) after setting.
     if persist:
         persist_startup(["das_set_threshold", str(channel)],
                         "das_set_threshold {} {}".format(channel, _format_ags(ags_value)))
@@ -120,6 +125,11 @@ def set_gain(channel, level, persist=False,
     register = GAIN_REGISTERS[channel]
     command = "das_send_command {} {}".format(register, level)
     reply = send_ags_command(command, host=host, port=port)
+    # NOTE: persist writes the startup file regardless of the firmware's
+    # reply. send_ags_command only raises on transport failure, not on a
+    # firmware "out of range" reply, so --persist may store a value the
+    # sensor rejected. The firmware is the range authority; confirm via
+    # header readback (threashold_1..4) after setting.
     if persist:
         persist_startup(["das_send_command", register],
                         "das_send_command {} {}".format(register, level))

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -96,6 +96,40 @@ def set_gain(channel, level, persist=False,
     return send_ags_command(command, host=host, port=port)
 
 
+def rewrite_startup(text, match_tokens, new_line):
+    """Return startup-file text with the line matching match_tokens replaced.
+
+    Match is on leading whitespace-split tokens (so "8" never matches "80").
+    If no line matches, new_line is inserted before the first das_reset line,
+    or appended if there is no das_reset.
+    """
+    match_tokens = list(match_tokens)
+    n = len(match_tokens)
+    lines = text.splitlines()
+    out = []
+    replaced = False
+    for line in lines:
+        if line.split()[:n] == match_tokens:
+            out.append(new_line)
+            replaced = True
+        else:
+            out.append(line)
+    if not replaced:
+        insert_at = None
+        for i, line in enumerate(out):
+            if line.split()[:1] == ["das_reset"]:
+                insert_at = i
+                break
+        if insert_at is None:
+            out.append(new_line)
+        else:
+            out.insert(insert_at, new_line)
+    result = "\n".join(out)
+    if text.endswith("\n"):
+        result += "\n"
+    return result
+
+
 def main():
     parser_main = argparse.ArgumentParser(
         description=(

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -130,6 +130,24 @@ def rewrite_startup(text, match_tokens, new_line):
     return result
 
 
+def parse_startup_state(text):
+    """Parse persisted threshold (mV) and gain levels from startup-file text."""
+    state = {}
+    for line in text.splitlines():
+        toks = line.split()
+        if len(toks) >= 3 and toks[0] == "das_set_threshold":
+            channel = toks[1]
+            if channel in ("1", "2"):
+                state["threshold_{}_mv".format(channel)] = round(
+                    ags_to_mv(float(toks[2])), 1)
+        elif len(toks) >= 3 and toks[0] == "das_send_command":
+            if toks[1] == "8":
+                state["gain_fast"] = int(toks[2])
+            elif toks[1] == "10":
+                state["gain_slow"] = int(toks[2])
+    return state
+
+
 def main():
     parser_main = argparse.ArgumentParser(
         description=(

--- a/scripts/ags.py
+++ b/scripts/ags.py
@@ -60,6 +60,24 @@ def send_ags_command(command, host=SENSOR_IP, port=AGS_COMMAND_PORT):
     return reply_text
 
 
+THRESHOLD_CHANNELS = (1, 2)
+
+
+def _format_ags(ags_value):
+    return "{:g}".format(ags_value)
+
+
+def set_threshold(channel, millivolts, persist=False,
+                  host=SENSOR_IP, port=AGS_COMMAND_PORT):
+    """Set a DAC trigger threshold (input-referred mV) on a HAMMA2 sensor."""
+    channel = int(channel)
+    if channel not in THRESHOLD_CHANNELS:
+        raise ValueError("threshold channel must be 1 or 2")
+    ags_value = mv_to_ags(millivolts)
+    command = "das_set_threshold {} {}".format(channel, _format_ags(ags_value))
+    return send_ags_command(command, host=host, port=port)
+
+
 def main():
     parser_main = argparse.ArgumentParser(
         description=(

--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -18,6 +18,12 @@ PAMMA_SENSORS = [50, 51, 52, 53, 54, 56]
 AUMMA_SENSORS = [41, 42, 43, ]
 
 
+# These deliberately re-check what ags.py validates on the Pi. mjol_array
+# runs on the VPS and ags.py on the sensor; they deploy as separate git
+# checkouts on different hosts and cannot share a module. Validating here
+# fails fast AND keeps unchecked operator input out of the ssh command line
+# (the values are interpolated into a remote shell command). ags.py remains
+# the authority on valid ranges; keep these in sync with it.
 def _validate_threshold_cli(channel, millivolts):
     if str(channel) not in ("1", "2"):
         raise ValueError("threshold channel must be 1 or 2")
@@ -269,33 +275,27 @@ class MjolnirArray():
         for p in ports:
             MjolnirArray.updown(p, bring_up)
 
+    def _resolve_ports(self, ports):
+        # Resolve sensor numbers (or None = all of this array's sensors) into
+        # fully-qualified tunnel ports (10000 + number).
+        if ports is None:
+            return [10000 + i for i in self.sensors]
+        return [10000 + int(p) for p in ports]
+
     def trigger_array(self, ports=None, command="das_manual_trigger"):
         # Send an AGS command (default: a manual trigger) to one or more sensors.
         # ports is mod 10000 (list). If None, use all of this array's sensors.
-        if ports is None:
-            ports = [10000 + i for i in self.sensors]
-        else:
-            ports = [10000 + int(p) for p in ports]  # Make this an integer
-
-        for p in ports:
+        for p in self._resolve_ports(ports):
             MjolnirArray.trigger(p, command=command)
 
     def set_threshold_array(self, ports=None, channel=None, millivolts=None,
                             persist=False):
-        if ports is None:
-            ports = [10000 + i for i in self.sensors]
-        else:
-            ports = [10000 + int(p) for p in ports]
-        for p in ports:
+        for p in self._resolve_ports(ports):
             MjolnirArray.set_threshold(p, channel, millivolts, persist=persist)
 
     def set_gain_array(self, ports=None, channel=None, level=None,
                        persist=False):
-        if ports is None:
-            ports = [10000 + i for i in self.sensors]
-        else:
-            ports = [10000 + int(p) for p in ports]
-        for p in ports:
+        for p in self._resolve_ports(ports):
             MjolnirArray.set_gain(p, channel, level, persist=persist)
 
     def status_array(self, ports=None, quiet=False):

--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -145,39 +145,31 @@ class MjolnirArray():
                   f"with code {out.returncode}.")
 
     @staticmethod
-    def trigger(port, command="das_manual_trigger", quiet=False):
-        # Send an AGS command (default: a manual trigger) to a sensor.
+    def _run_ags_command(port, ags_args, action_label, quiet=False, timeout=30):
+        # Run ags.py on the Pi over its autossh tunnel with the given args.
         # port is fully qualified (10000 + unit number).
-        # We reach the Pi over its autossh tunnel and run ags.py there; the
-        # AGS command port (10.10.10.1:8082) is only reachable from the Pi.
         sensor_num = port - 10000
 
-        # First, make sure the SSH tunnel for this Pi is reachable...
-        is_pi_up = MjolnirArray.status(port)
-
-        if not is_pi_up:
+        if not MjolnirArray.status(port):
             if not quiet:
                 print(f"[SKIP] mj{sensor_num:02} (port {port}): tunnel down, "
-                      f"not triggered.")
+                      f"{action_label} not sent.")
             return
 
         cmd = MjolnirArray._pi_ssh_cmd(port)
-        cmd = cmd + ['/home/pi/dev/mjolnir-hamma/scripts/ags.py', command]
+        cmd = cmd + ['/home/pi/dev/mjolnir-hamma/scripts/ags.py'] + list(ags_args)
 
         if not quiet:
-            print(f"--- mj{sensor_num:02}: sending AGS '{command}' ---")
+            print(f"--- mj{sensor_num:02}: {action_label} ---")
 
         try:
             out = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=30,
-            )
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                timeout=timeout)
         except subprocess.TimeoutExpired:
             if not quiet:
                 print(f"[FAIL] mj{sensor_num:02}: ags.py did not complete "
-                      f"in 30s.")
+                      f"in {timeout}s.")
             return
         except Exception as e:
             if not quiet:
@@ -187,7 +179,6 @@ class MjolnirArray():
         if quiet:
             return
 
-        # Surface the AGS reply so the operator sees the result.
         stdout = out.stdout.decode(errors="replace") if out.stdout else ""
         stderr = out.stderr.decode(errors="replace") if out.stderr else ""
         if stdout:
@@ -197,6 +188,12 @@ class MjolnirArray():
         if out.returncode != 0:
             print(f"[FAIL] mj{sensor_num:02}: ags.py exited "
                   f"with code {out.returncode}.")
+
+    @staticmethod
+    def trigger(port, command="das_manual_trigger", quiet=False):
+        # Send an AGS command (default: a manual trigger) to a sensor.
+        MjolnirArray._run_ags_command(
+            port, [command], f"sending AGS '{command}'", quiet=quiet)
 
     @staticmethod
     def status_fcm(port):

--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -196,6 +196,28 @@ class MjolnirArray():
             port, [command], f"sending AGS '{command}'", quiet=quiet)
 
     @staticmethod
+    def set_threshold(port, channel, millivolts, persist=False, quiet=False):
+        ags_args = ["set-threshold", str(channel), str(millivolts)]
+        if persist:
+            ags_args.append("--persist")
+        MjolnirArray._run_ags_command(
+            port, ags_args,
+            f"set threshold ch{channel} = {millivolts} mV"
+            + (" (persist)" if persist else ""),
+            quiet=quiet)
+
+    @staticmethod
+    def set_gain(port, channel, level, persist=False, quiet=False):
+        ags_args = ["set-gain", str(channel), str(level)]
+        if persist:
+            ags_args.append("--persist")
+        MjolnirArray._run_ags_command(
+            port, ags_args,
+            f"set gain {channel} = {level}"
+            + (" (persist)" if persist else ""),
+            quiet=quiet)
+
+    @staticmethod
     def status_fcm(port):
         # Return a boolean if the FCM sensor is up (True) or down (False)
         # port is fully qualified
@@ -243,6 +265,24 @@ class MjolnirArray():
 
         for p in ports:
             MjolnirArray.trigger(p, command=command)
+
+    def set_threshold_array(self, ports=None, channel=None, millivolts=None,
+                            persist=False):
+        if ports is None:
+            ports = [10000 + i for i in self.sensors]
+        else:
+            ports = [10000 + int(p) for p in ports]
+        for p in ports:
+            MjolnirArray.set_threshold(p, channel, millivolts, persist=persist)
+
+    def set_gain_array(self, ports=None, channel=None, level=None,
+                       persist=False):
+        if ports is None:
+            ports = [10000 + i for i in self.sensors]
+        else:
+            ports = [10000 + int(p) for p in ports]
+        for p in ports:
+            MjolnirArray.set_gain(p, channel, level, persist=persist)
 
     def status_array(self, ports=None, quiet=False):
         # Get status report for a number of sensors in an array

--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -385,7 +385,7 @@ class MjolnirArray():
         return df
 
 
-def main():
+def main(argv=None):
     arg_parser = argparse.ArgumentParser(description="Bring the array up or down")
 
     arg_parser.add_argument(
@@ -420,6 +420,15 @@ def main():
                             default=False,
                             )
 
+    arg_parser.add_argument("--set-threshold", nargs=2,
+                            metavar=("CHANNEL", "MV"), default=None,
+                            help="Set threshold: channel (1|2) and mV")
+    arg_parser.add_argument("--set-gain", nargs=2,
+                            metavar=("CHANNEL", "LEVEL"), default=None,
+                            help="Set gain: channel (fast-e|slow-e) and level (0-3)")
+    arg_parser.add_argument("--persist", action="store_true", default=False,
+                            help="Also persist to /ags/scripts/startup")
+
     grp = arg_parser.add_mutually_exclusive_group()
     grp.add_argument("--up",
                      dest='bring_up',
@@ -435,7 +444,7 @@ def main():
                      help="Bring array down",
                      )
 
-    parsed_args = arg_parser.parse_args()
+    parsed_args = arg_parser.parse_args(argv)
 
     if parsed_args.ports is None:
         if parsed_args.array == 'hamma':
@@ -457,6 +466,16 @@ def main():
         _ = mj_array.status_array(ports=parsed_args.ports)
     elif parsed_args.do_trigger:
         mj_array.trigger_array(ports=parsed_args.ports)
+    elif parsed_args.set_threshold is not None:
+        channel, millivolts = parsed_args.set_threshold
+        mj_array.set_threshold_array(
+            ports=parsed_args.ports, channel=channel, millivolts=millivolts,
+            persist=parsed_args.persist)
+    elif parsed_args.set_gain is not None:
+        channel, level = parsed_args.set_gain
+        mj_array.set_gain_array(
+            ports=parsed_args.ports, channel=channel, level=level,
+            persist=parsed_args.persist)
     elif parsed_args.bring_up | parsed_args.bring_down:
         # Is it up or down?
         # bring_up = parsed_args.bring_up

--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -18,6 +18,20 @@ PAMMA_SENSORS = [50, 51, 52, 53, 54, 56]
 AUMMA_SENSORS = [41, 42, 43, ]
 
 
+def _validate_threshold_cli(channel, millivolts):
+    if str(channel) not in ("1", "2"):
+        raise ValueError("threshold channel must be 1 or 2")
+    if float(millivolts) < 0:
+        raise ValueError("threshold mV must be non-negative")
+
+
+def _validate_gain_cli(channel, level):
+    if channel not in ("fast-e", "slow-e"):
+        raise ValueError("gain channel must be fast-e or slow-e")
+    if int(level) not in (0, 1, 2, 3):
+        raise ValueError("gain level must be 0, 1, 2, or 3")
+
+
 class MjolnirArray():
 
     def __init__(self, sensors, sensor_name='Mjolnir'):
@@ -468,11 +482,21 @@ def main(argv=None):
         mj_array.trigger_array(ports=parsed_args.ports)
     elif parsed_args.set_threshold is not None:
         channel, millivolts = parsed_args.set_threshold
+        try:
+            _validate_threshold_cli(channel, millivolts)
+        except ValueError as e:
+            print(f"[ERROR] {e}")
+            return
         mj_array.set_threshold_array(
             ports=parsed_args.ports, channel=channel, millivolts=millivolts,
             persist=parsed_args.persist)
     elif parsed_args.set_gain is not None:
         channel, level = parsed_args.set_gain
+        try:
+            _validate_gain_cli(channel, level)
+        except ValueError as e:
+            print(f"[ERROR] {e}")
+            return
         mj_array.set_gain_array(
             ports=parsed_args.ports, channel=channel, level=level,
             persist=parsed_args.persist)

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import pathlib
+import subprocess
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -152,3 +153,46 @@ class TestParseStartupState:
         state = ags.parse_startup_state("ds_enable\ndas_reset\n")
         assert "threshold_1_mv" not in state
         assert "gain_fast" not in state
+
+
+class TestPersist:
+    def test_persist_startup_reads_then_writes(self, ags):
+        read_result = MagicMock(returncode=0, stdout=STARTUP_SAMPLE.encode())
+        write_result = MagicMock(returncode=0)
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.side_effect = [read_result, write_result]
+            ags.persist_startup(["das_set_threshold", "1"],
+                                "das_set_threshold 1 5")
+        # second call is the write; its input carries the rewritten file
+        write_call = mock_sub.run.call_args_list[1]
+        written = write_call.kwargs["input"].decode()
+        assert "das_set_threshold 1 5\n" in written
+        assert "das_set_threshold 2 0\n" in written
+
+    def test_persist_raises_on_read_failure(self, ags):
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=1, stdout=b"",
+                                                  stderr=b"no route")
+            with pytest.raises(RuntimeError):
+                ags.persist_startup(["ds_enable"], "ds_enable")
+
+    def test_set_threshold_persist_calls_persist_startup(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 830, persist=True)
+        match_tokens, new_line = mock_persist.call_args[0][0], mock_persist.call_args[0][1]
+        assert match_tokens == ["das_set_threshold", "1"]
+        assert new_line.split()[:2] == ["das_set_threshold", "1"]
+
+    def test_set_gain_persist_calls_persist_startup(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_gain("fast-e", 3, persist=True)
+        assert mock_persist.call_args[0][0] == ["das_send_command", "8"]
+        assert mock_persist.call_args[0][1] == "das_send_command 8 3"
+
+    def test_set_threshold_no_persist_skips(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 830, persist=False)
+            mock_persist.assert_not_called()

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -212,6 +212,34 @@ class TestPersist:
             mock_persist.assert_not_called()
 
 
+class TestPersistGating:
+    def test_reply_indicates_error_detects_error_line(self, ags):
+        reply = ('Use "help" command to display a list of commands.\n'
+                 'Error - Invalid threshold value: 12.048')
+        assert ags._reply_indicates_error(reply) is True
+
+    def test_reply_indicates_error_false_on_success(self, ags):
+        reply = ('Use "help" command to display a list of commands.\n'
+                 'Set DAS Threshold 1 to 1.2048.')
+        assert ags._reply_indicates_error(reply) is False
+
+    def test_set_threshold_skips_persist_on_firmware_error(self, ags):
+        err = ('Use "help" command to display a list of commands.\n'
+               'Error - Invalid threshold value: 12.048')
+        with patch.object(ags, "send_ags_command", return_value=err):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 2000, persist=True)
+            mock_persist.assert_not_called()
+
+    def test_set_gain_skips_persist_on_firmware_error(self, ags):
+        err = ('Use "help" command to display a list of commands.\n'
+               'Error - bad gain')
+        with patch.object(ags, "send_ags_command", return_value=err):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_gain("fast-e", 2, persist=True)
+            mock_persist.assert_not_called()
+
+
 class TestCli:
     def test_set_threshold_subcommand(self, ags):
         with patch.object(ags, "set_threshold", return_value="OK") as mock_set:

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -90,3 +90,51 @@ class TestSetGain:
             with pytest.raises(ValueError):
                 ags.set_gain("fast-e", 4)
             mock_send.assert_not_called()
+
+
+STARTUP_SAMPLE = (
+    "ds_enable\n"
+    "das_enable\n"
+    "das_set_threshold 1 0.5\n"
+    "das_set_threshold 2 0\n"
+    "das_send_command 8 1\n"
+    "das_send_command 10 1\n"
+    "das_set_mask 3\n"
+    "das_reset\n"
+)
+
+
+class TestRewriteStartup:
+    def test_replaces_matching_threshold_line(self, ags):
+        out = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        assert "das_set_threshold 1 5\n" in out
+        assert "das_set_threshold 1 0.5" not in out
+        # other lines untouched
+        assert "das_set_threshold 2 0\n" in out
+        assert "das_send_command 8 1\n" in out
+
+    def test_replaces_only_exact_register(self, ags):
+        out = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_send_command", "8"], "das_send_command 8 3")
+        assert "das_send_command 8 3\n" in out
+        assert "das_send_command 10 1\n" in out  # 10 not touched by an "8" match
+
+    def test_inserts_before_das_reset_when_absent(self, ags):
+        text = "ds_enable\ndas_enable\ndas_reset\n"
+        out = ags.rewrite_startup(
+            text, ["das_set_threshold", "1"], "das_set_threshold 1 0.5")
+        lines = out.splitlines()
+        assert lines.index("das_set_threshold 1 0.5") < lines.index("das_reset")
+
+    def test_idempotent(self, ags):
+        once = ags.rewrite_startup(
+            STARTUP_SAMPLE, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        twice = ags.rewrite_startup(
+            once, ["das_set_threshold", "1"], "das_set_threshold 1 5")
+        assert once == twice
+
+    def test_preserves_trailing_newline_absence(self, ags):
+        text = "ds_enable\ndas_reset"  # no trailing newline
+        out = ags.rewrite_startup(text, ["ds_enable"], "ds_enable")
+        assert not out.endswith("\n")

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -2,7 +2,6 @@
 
 import importlib.util
 import pathlib
-import subprocess
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -195,4 +194,19 @@ class TestPersist:
         with patch.object(ags, "send_ags_command", return_value="OK"):
             with patch.object(ags, "persist_startup") as mock_persist:
                 ags.set_threshold(1, 830, persist=False)
+            mock_persist.assert_not_called()
+
+    def test_persist_raises_on_write_failure(self, ags):
+        read_result = MagicMock(returncode=0, stdout=STARTUP_SAMPLE.encode())
+        write_result = MagicMock(returncode=1, stdout=b"", stderr=b"permission denied")
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.side_effect = [read_result, write_result]
+            with pytest.raises(RuntimeError):
+                ags.persist_startup(["das_set_threshold", "1"],
+                                    "das_set_threshold 1 5")
+
+    def test_set_gain_no_persist_skips(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK"):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_gain("fast-e", 3, persist=False)
             mock_persist.assert_not_called()

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -210,3 +210,34 @@ class TestPersist:
             with patch.object(ags, "persist_startup") as mock_persist:
                 ags.set_gain("fast-e", 3, persist=False)
             mock_persist.assert_not_called()
+
+
+class TestCli:
+    def test_set_threshold_subcommand(self, ags):
+        with patch.object(ags, "set_threshold", return_value="OK") as mock_set:
+            ags.main(["set-threshold", "1", "830"])
+        assert mock_set.call_args.kwargs.get("persist", False) is False
+        args = mock_set.call_args[0]
+        assert int(args[0]) == 1 and float(args[1]) == 830
+
+    def test_set_threshold_persist_flag(self, ags):
+        with patch.object(ags, "set_threshold", return_value="OK") as mock_set:
+            ags.main(["set-threshold", "1", "830", "--persist"])
+        assert mock_set.call_args.kwargs["persist"] is True
+
+    def test_set_gain_subcommand(self, ags):
+        with patch.object(ags, "set_gain", return_value="OK") as mock_set:
+            ags.main(["set-gain", "fast-e", "2"])
+        args = mock_set.call_args[0]
+        assert args[0] == "fast-e" and int(args[1]) == 2
+
+    def test_get_state_subcommand(self, ags):
+        result = MagicMock(returncode=0, stdout=STARTUP_SAMPLE.encode())
+        with patch.object(ags, "subprocess") as mock_sub:
+            mock_sub.run.return_value = result
+            ags.main(["get-state"])  # should not raise
+
+    def test_passthrough_preserved(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.main(["das_reset"])
+        assert mock_send.call_args.kwargs["command"] == "das_reset"

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -35,3 +35,34 @@ class TestConversion:
     def test_negative_mv_rejected(self, ags):
         with pytest.raises(ValueError):
             ags.mv_to_ags(-1)
+
+
+class TestSetThreshold:
+    def test_sends_das_set_threshold(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            reply = ags.set_threshold(1, 830)
+        sent = mock_send.call_args[0][0]
+        toks = sent.split()
+        assert toks[0] == "das_set_threshold"
+        assert toks[1] == "1"
+        assert float(toks[2]) == pytest.approx(5.0, abs=1e-3)
+        assert reply == "OK"
+
+    def test_channel_2(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_threshold(2, 83)
+        toks = mock_send.call_args[0][0].split()
+        assert toks[1] == "2"
+        assert float(toks[2]) == pytest.approx(0.5, abs=1e-3)
+
+    def test_rejects_bad_channel(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_threshold(3, 83)
+            mock_send.assert_not_called()
+
+    def test_high_mv_sent_without_cap(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_threshold(1, 5000)  # far above nominal full-scale
+        toks = mock_send.call_args[0][0].split()
+        assert float(toks[2]) == pytest.approx(ags.mv_to_ags(5000), abs=1e-3)

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -66,3 +66,27 @@ class TestSetThreshold:
             ags.set_threshold(1, 5000)  # far above nominal full-scale
         toks = mock_send.call_args[0][0].split()
         assert float(toks[2]) == pytest.approx(ags.mv_to_ags(5000), abs=1e-3)
+
+
+class TestSetGain:
+    def test_fast_e_register(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_gain("fast-e", 2)
+        assert mock_send.call_args[0][0] == "das_send_command 8 2"
+
+    def test_slow_e_register(self, ags):
+        with patch.object(ags, "send_ags_command", return_value="OK") as mock_send:
+            ags.set_gain("slow-e", 0)
+        assert mock_send.call_args[0][0] == "das_send_command 10 0"
+
+    def test_rejects_bad_channel(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_gain("middle-e", 1)
+            mock_send.assert_not_called()
+
+    def test_rejects_bad_level(self, ags):
+        with patch.object(ags, "send_ags_command") as mock_send:
+            with pytest.raises(ValueError):
+                ags.set_gain("fast-e", 4)
+            mock_send.assert_not_called()

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -223,6 +223,17 @@ class TestPersistGating:
                  'Set DAS Threshold 1 to 1.2048.')
         assert ags._reply_indicates_error(reply) is False
 
+    def test_reply_indicates_error_true_on_empty(self, ags):
+        # An empty/whitespace reply means no confirmation from the sensor.
+        assert ags._reply_indicates_error("") is True
+        assert ags._reply_indicates_error("   \n  ") is True
+
+    def test_set_threshold_skips_persist_on_empty_reply(self, ags):
+        with patch.object(ags, "send_ags_command", return_value=""):
+            with patch.object(ags, "persist_startup") as mock_persist:
+                ags.set_threshold(1, 100, persist=True)
+            mock_persist.assert_not_called()
+
     def test_set_threshold_skips_persist_on_firmware_error(self, ags):
         err = ('Use "help" command to display a list of commands.\n'
                'Error - Invalid threshold value: 12.048')

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -138,3 +138,17 @@ class TestRewriteStartup:
         text = "ds_enable\ndas_reset"  # no trailing newline
         out = ags.rewrite_startup(text, ["ds_enable"], "ds_enable")
         assert not out.endswith("\n")
+
+
+class TestParseStartupState:
+    def test_parses_thresholds_and_gains(self, ags):
+        state = ags.parse_startup_state(STARTUP_SAMPLE)
+        assert state["threshold_1_mv"] == pytest.approx(83, abs=1.0)
+        assert state["threshold_2_mv"] == 0.0
+        assert state["gain_fast"] == 1
+        assert state["gain_slow"] == 1
+
+    def test_missing_lines_absent(self, ags):
+        state = ags.parse_startup_state("ds_enable\ndas_reset\n")
+        assert "threshold_1_mv" not in state
+        assert "gain_fast" not in state

--- a/tests/python/test_ags.py
+++ b/tests/python/test_ags.py
@@ -1,0 +1,37 @@
+"""Tests for ags.py — AGS command wrapper (threshold/gain control)."""
+
+import importlib.util
+import pathlib
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ags.py"
+
+
+def load_ags():
+    spec = importlib.util.spec_from_file_location("ags", str(SCRIPT_PATH))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def ags():
+    return load_ags()
+
+
+class TestConversion:
+    def test_mv_to_ags_known_points(self, ags):
+        assert ags.mv_to_ags(830) == pytest.approx(5.0, abs=1e-3)
+        assert ags.mv_to_ags(83) == pytest.approx(0.5, abs=1e-3)
+        assert ags.mv_to_ags(0) == 0.0
+
+    def test_ags_to_mv_is_inverse(self, ags):
+        assert ags.ags_to_mv(5.0) == pytest.approx(830, abs=1.0)
+        assert ags.ags_to_mv(0.5) == pytest.approx(83, abs=1.0)
+
+    def test_negative_mv_rejected(self, ags):
+        with pytest.raises(ValueError):
+            ags.mv_to_ags(-1)

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -198,6 +198,31 @@ class TestArgparse:
         assert mjol.AUMMA_SENSORS == [41, 42, 43]
 
 
+class TestCliValidation:
+    def test_bad_threshold_channel_rejected(self, mjol, capsys):
+        with patch.object(mjol.MjolnirArray, "set_threshold_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-threshold", "9", "830"])
+        mock_arr.assert_not_called()
+        assert "[ERROR]" in capsys.readouterr().out
+
+    def test_injection_attempt_rejected(self, mjol, capsys):
+        with patch.object(mjol.MjolnirArray, "set_threshold_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-threshold", "1", "8; rm -rf /"])
+        mock_arr.assert_not_called()
+        assert "[ERROR]" in capsys.readouterr().out
+
+    def test_bad_gain_level_rejected(self, mjol, capsys):
+        with patch.object(mjol.MjolnirArray, "set_gain_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-gain", "fast-e", "9"])
+        mock_arr.assert_not_called()
+        assert "[ERROR]" in capsys.readouterr().out
+
+    def test_valid_threshold_still_dispatches(self, mjol):
+        with patch.object(mjol.MjolnirArray, "set_threshold_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-threshold", "1", "830"])
+        mock_arr.assert_called_once()
+
+
 class TestStatusServices:
     """Tests for MjolnirArray.status_services()."""
 

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -314,6 +314,15 @@ class TestTrigger:
         mock_sub.run.assert_not_called()
         assert "tunnel down, sending AGS 'das_manual_trigger' not sent." in capsys.readouterr().out
 
+    def test_trigger_pi_down_skips_quiet(self, mjol, capsys):
+        """With quiet=True, a down tunnel skips silently (no subprocess, no print)."""
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            with patch.object(mjol.MjolnirArray, 'status', return_value=False):
+                mjol.MjolnirArray.trigger(10002, quiet=True)
+
+        mock_sub.run.assert_not_called()
+        assert capsys.readouterr().out == ""
+
     def test_trigger_timeout_catches_exception(self, mjol):
         """On timeout, trigger should catch the exception and not raise."""
         with patch.object(mjol, 'subprocess') as mock_sub:

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -354,3 +354,35 @@ class TestRunAgsCommand:
                 mock_sub.run.side_effect = RuntimeError("boom")
                 mjol.MjolnirArray._run_ags_command(10002, ["das_reset"], "x")
         assert "[FAIL]" in capsys.readouterr().out
+
+
+class TestSetThresholdGain:
+    def test_set_threshold_builds_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_threshold(10002, 1, 830)
+        port, ags_args = mock_run.call_args[0][0], mock_run.call_args[0][1]
+        assert port == 10002
+        assert ags_args == ["set-threshold", "1", "830"]
+
+    def test_set_threshold_persist_appends_flag(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_threshold(10002, 1, 830, persist=True)
+        assert "--persist" in mock_run.call_args[0][1]
+
+    def test_set_gain_builds_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "_run_ags_command") as mock_run:
+            mjol.MjolnirArray.set_gain(10002, "fast-e", 2)
+        assert mock_run.call_args[0][1] == ["set-gain", "fast-e", "2"]
+
+    def test_set_threshold_array_fans_out(self, mjol):
+        arr = mjol.MjolnirArray(sensors=[2, 3])
+        with patch.object(mjol.MjolnirArray, "set_threshold") as mock_set:
+            arr.set_threshold_array(channel=1, millivolts=830)
+        called_ports = [c[0][0] for c in mock_set.call_args_list]
+        assert called_ports == [10002, 10003]
+
+    def test_set_gain_array_explicit_ports(self, mjol):
+        arr = mjol.MjolnirArray(sensors=[2, 3])
+        with patch.object(mjol.MjolnirArray, "set_gain") as mock_set:
+            arr.set_gain_array(ports=["2"], channel="slow-e", level=0)
+        assert mock_set.call_args_list[0][0][0] == 10002

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -280,13 +280,14 @@ class TestTrigger:
         kwargs = mock_sub.run.call_args[1]
         assert kwargs.get('timeout') == 30
 
-    def test_trigger_pi_down_skips(self, mjol):
+    def test_trigger_pi_down_skips(self, mjol, capsys):
         """If the tunnel is down, trigger should not call subprocess."""
         with patch.object(mjol, 'subprocess') as mock_sub:
             with patch.object(mjol.MjolnirArray, 'status', return_value=False):
-                mjol.MjolnirArray.trigger(10002, quiet=True)
+                mjol.MjolnirArray.trigger(10002)
 
         mock_sub.run.assert_not_called()
+        assert "tunnel down, sending AGS 'das_manual_trigger' not sent." in capsys.readouterr().out
 
     def test_trigger_timeout_catches_exception(self, mjol):
         """On timeout, trigger should catch the exception and not raise."""
@@ -335,3 +336,21 @@ class TestRunAgsCommand:
         cmd = mock_sub.run.call_args[0][0]
         assert "/home/pi/dev/mjolnir-hamma/scripts/ags.py" in cmd
         assert "das_manual_trigger" in cmd
+
+    def test_timeout_prints_fail(self, mjol, capsys):
+        import subprocess as _sp
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = _sp.TimeoutExpired
+                mock_sub.run.side_effect = _sp.TimeoutExpired(cmd="ssh", timeout=30)
+                mjol.MjolnirArray._run_ags_command(10002, ["das_reset"], "x")
+        assert "[FAIL]" in capsys.readouterr().out
+
+    def test_exception_prints_fail(self, mjol, capsys):
+        import subprocess as _sp
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.TimeoutExpired = _sp.TimeoutExpired
+                mock_sub.run.side_effect = RuntimeError("boom")
+                mjol.MjolnirArray._run_ags_command(10002, ["das_reset"], "x")
+        assert "[FAIL]" in capsys.readouterr().out

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -305,3 +305,33 @@ class TestTrigger:
 
         called_ports = [c[0][0] for c in mock_trigger.call_args_list]
         assert called_ports == [10002, 10003]
+
+
+class TestRunAgsCommand:
+    def test_skips_when_tunnel_down(self, mjol, capsys):
+        with patch.object(mjol.MjolnirArray, "status", return_value=False):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mjol.MjolnirArray._run_ags_command(10002, ["das_reset"], "x")
+                mock_sub.run.assert_not_called()
+        assert "[SKIP]" in capsys.readouterr().out
+
+    def test_runs_ags_with_args(self, mjol):
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"OK", stderr=b"")
+                mock_sub.TimeoutExpired = Exception
+                mjol.MjolnirArray._run_ags_command(
+                    10002, ["set-threshold", "1", "830"], "set thr")
+        cmd = mock_sub.run.call_args[0][0]
+        assert "/home/pi/dev/mjolnir-hamma/scripts/ags.py" in cmd
+        assert cmd[-3:] == ["set-threshold", "1", "830"]
+
+    def test_trigger_still_invokes_ags_command(self, mjol):
+        with patch.object(mjol.MjolnirArray, "status", return_value=True):
+            with patch.object(mjol, "subprocess") as mock_sub:
+                mock_sub.run.return_value = MagicMock(returncode=0, stdout=b"OK", stderr=b"")
+                mock_sub.TimeoutExpired = Exception
+                mjol.MjolnirArray.trigger(10002)
+        cmd = mock_sub.run.call_args[0][0]
+        assert "/home/pi/dev/mjolnir-hamma/scripts/ags.py" in cmd
+        assert "das_manual_trigger" in cmd

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -386,3 +386,19 @@ class TestSetThresholdGain:
         with patch.object(mjol.MjolnirArray, "set_gain") as mock_set:
             arr.set_gain_array(ports=["2"], channel="slow-e", level=0)
         assert mock_set.call_args_list[0][0][0] == 10002
+
+
+class TestCliDispatch:
+    def test_set_threshold_cli(self, mjol):
+        with patch.object(mjol.MjolnirArray, "set_threshold_array") as mock_arr:
+            mjol.main(["-p", "2", "--set-threshold", "1", "830"])
+        kwargs = mock_arr.call_args.kwargs
+        assert kwargs["channel"] == "1" and kwargs["millivolts"] == "830"
+        assert kwargs["persist"] is False
+
+    def test_set_gain_cli_with_persist(self, mjol):
+        with patch.object(mjol.MjolnirArray, "set_gain_array") as mock_arr:
+            mjol.main(["-a", "hamma", "--set-gain", "fast-e", "2", "--persist"])
+        kwargs = mock_arr.call_args.kwargs
+        assert kwargs["channel"] == "fast-e" and kwargs["level"] == "2"
+        assert kwargs["persist"] is True


### PR DESCRIPTION
## Summary

Adds the ability to set a HAMMA2 sensor's **trigger threshold** (input-referred mV) and **FCM gain** (level 0–3) from the server, for one / several / all sensors in a single command — mirroring the existing `mjol_array.py --trigger` pattern. An optional `--persist` flag makes a change survive a DAS reset by rewriting the sensor's `/ags/scripts/startup` script.

Requested so operators can tune thresholds/gain from the VPS the same way they trigger sensors today, instead of hand-editing the startup script on each AGS host.

## What changed

**`scripts/ags.py` (runs on the sensor Pi)** — new clearly-named wrappers over the AGS command socket (`10.10.10.1:8082`):
- `set_threshold(channel, mV, persist=…)` → converts mV → AGS value (`ags = mV/1000·6.024`) and sends `das_set_threshold`. No hard upper cap (rejects only negative mV); the firmware is the range authority.
- `set_gain(channel, level, persist=…)` → sends `das_send_command 8|10 <0-3>` (FAST-E / SLOW-E gain registers).
- `--persist` rewrites only the matching line of `/ags/scripts/startup` over `ssh hamma`, atomically (temp file + `mv`), preserving every other line. **Persist is gated on firmware acceptance** — if the live command returns an `Error -` reply, the startup file is left untouched.
- New CLI subcommands `set-threshold`, `set-gain`, `get-state`; the original generic passthrough (`ags.py <cmd>`) is preserved unchanged.

**`server/mjol_array.py` (runs on the VPS)** — `--set-threshold <ch> <mV>`, `--set-gain <fast-e|slow-e> <level>`, `--persist`, combined with the existing `-a hamma|pamma|aumma` / `-p N` fan-out. Reuses the autossh tunnel, liveness gate, and `[OK]/[FAIL]` relay via a new shared `_run_ags_command` helper (`trigger()` was refactored onto it, behavior unchanged). Operator input is validated on the VPS before dispatch (closes a CLI→ssh argument-injection surface).

## Conversion / readback reference

- Threshold operator unit = **input-referred mV**; `ags = mV/1000·6.024`; readback via header `threashold_1/2`.
- Gain = digital level 0–3; readback via header `threashold_3` (FAST-E) / `threashold_4` (SLOW-E).

## Testing

**79 unit tests, all passing** (`tests/python/test_ags.py`, `tests/python/test_mjol_array.py`), via mocked sockets/ssh — no real I/O.

**End-to-end validated live on mj02** (Python 3.7.3):
- `get-state` → 83 mV / 0 / gain 1 / 1 (conversion correct).
- `set-threshold 1 200` → firmware `Set DAS Threshold 1 to 1.2048`, header readback **199.8 mV**.
- `set-gain fast-e 2` → firmware `Sending Command 0x8(3). Data: 0x2`, header `threashold_3 = 2`.
- Out-of-range value → firmware **rejects** (`Error - Invalid threshold value`), live value unchanged, and `--persist` correctly **skips** the startup write.
- `--persist` → only the target line in `/ags/scripts/startup` changed; all other lines byte-identical.
- mj02 fully restored to baseline afterward.

## How to test on the VPS

This change touches **two** deployment lines: `ags.py` on the **sensors** and `mjol_array.py` on the **VPS**. To exercise the full server→sensor path, both need this branch.

1. **On the VPS** (`~/dev/mjolnir-hamma`): `git fetch && git checkout feature/server-threshold-gain-control`
2. **On a test sensor** (e.g. mj02), update its checkout so `ags.py` has the new subcommands:
   `ssh mjolnir02 'cd /home/pi/dev/mjolnir-hamma && git fetch && git checkout feature/server-threshold-gain-control'`
   (Remember to return it to its normal branch afterward.)
3. **Read current state** (read-only): `ssh mjolnir02 /home/pi/dev/ltgenv/bin/python /home/pi/dev/mjolnir-hamma/scripts/ags.py get-state`
4. **Set on one sensor** from the VPS:
   - `python server/mjol_array.py -p 2 --set-threshold 1 100`
   - `python server/mjol_array.py -p 2 --set-gain fast-e 2`
   - add `--persist` to also write the startup script.
5. **Fleet-wide** (careful — affects every reachable unit): `python server/mjol_array.py -a hamma --set-threshold 1 100`
6. **Verify**: `python server/mjol_array.py -p 2 --status` (Threshold column) or `ags.py get-state` on the Pi; for a fresh live reading, trigger a header (`ags.py das_manual_trigger`) and read it back.
7. **Restore** the sensor's baseline threshold/gain (and `--persist` the restore if you persisted), then return its git checkout to the original branch.

Suggested quick check: set a clearly-different threshold (e.g. 100 mV vs the usual ~83 mV), confirm it reads back, then restore.

## Notes for review

- Deploys to two lines: **`ags.py` → sensors** (mjolnir-hamma 0.4.x; `git pull`), **`mjol_array.py` → VPS**. Confirm the VPS checkout's branch carries this change.
- The live **server fan-out** path was not exercised end-to-end during development (it would have required deploying this unmerged branch to the VPS + a sensor's canonical path); the underlying tunnel/fan-out mechanism is identical to the already-deployed `trigger()` and is unit-tested. The VPS test above is the place to confirm it.
- `--persist` requires `ssh hamma` from the Pi to have write access to the root-owned `/ags/scripts/startup`.

Spec and implementation plan are in `docs/superpowers/specs/2026-06-29-server-threshold-gain-control-design.md` and `docs/superpowers/plans/2026-06-29-server-threshold-gain-control.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
