### PR TITLE
config: disable daily_compression by default (0.3.x)

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -291,7 +291,7 @@ config_version = 1
     # Daily compression of data files on /media/pi
     [pipelines.daily_compression]
         _builder = "pipeline"
-        _enabled = true
+        _enabled = false
         period_s = 3600  # Check every hour; actual compression controlled by step update_time
         name = "Daily Data Compression"
         input_steps = [


### PR DESCRIPTION
Disable the daily data-compression pipeline by default across the fleet, by flipping the shared default in `config/main.toml` (`[pipelines.daily_compression] _enabled = false`).

Compression is being turned off fleet-wide. Currently running units have it disabled via per-unit local overrides (`~/.config/brokkr/hamma/main.toml`); this change makes "off" the repo default so units inherit it on their next config update and no per-unit override is needed (covers units behind on config and the ones currently offline).

One-line config change; no plugin/code changes. Re-enable per-unit later with a local override if ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)