### PR TITLE
HAM-113: bound /var/log so log spam can't fill the SD card

### DIFF
--- a/files/journald-sensor-bounds.conf
+++ b/files/journald-sensor-bounds.conf
@@ -1,0 +1,10 @@
+# Managed by mjolnir-hamma (HAM-113) -> /etc/systemd/journald.conf.d/00-sensor-bounds.conf
+#
+# Bound systemd-journald disk use so a runaway log source (e.g. brokkr
+# science_ingest spamming when the AGS is down, HAM-112) cannot fill the SD
+# card. Do NOT edit on the sensor -- change files/journald-sensor-bounds.conf
+# in the repo and re-run install.sh (or scripts/apply_log_bounds.sh).
+[Journal]
+SystemMaxUse=500M
+SystemKeepFree=1G
+RuntimeMaxUse=100M

--- a/files/logrotate-hourly.sh
+++ b/files/logrotate-hourly.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Managed by mjolnir-hamma (HAM-113) -> /etc/cron.hourly/mjolnir-logrotate
+#
+# Run logrotate hourly so a log that exceeds `maxsize` (set on the rsyslog
+# stanza) is rotated within the hour instead of waiting for the daily run.
+# This is what bounds /var/log under sustained log spam.
+#
+# Safe/idempotent: `daily`/`weekly` stanzas still rotate on their normal
+# cadence; `maxsize` only forces an extra rotation when a log has grown past
+# the cap since the last run.
+/usr/sbin/logrotate /etc/logrotate.conf
+exit 0

--- a/scripts/apply_log_bounds.sh
+++ b/scripts/apply_log_bounds.sh
@@ -4,8 +4,13 @@
 #
 # Apply the /var/log size bounds to an ALREADY-DEPLOYED sensor, without a full
 # reinstall. Idempotent -- safe to run repeatedly. Run ON the sensor (needs
-# sudo). This is the fleet-remediation counterpart to configure_log_bounds() in
-# unified_install/lib/hardware.sh.
+# sudo).
+#
+# The work itself lives in unified_install/lib/log_bounds.sh, the single shared
+# implementation used by BOTH this script and configure_log_bounds() in
+# unified_install/lib/hardware.sh. This script adds only the two things the
+# installer does not need: --check reporting, and reclaiming overage that
+# accumulated before the bounds went on.
 #
 # Usage:
 #   sudo bash scripts/apply_log_bounds.sh            # apply the bounds
@@ -13,7 +18,7 @@
 #
 # Applies:
 #   1. journald SystemMaxUse cap (drop-in)
-#   2. maxsize 100M on the rsyslog logrotate stanzas (backup at .mjolnir-orig)
+#   2. maxsize 100M on the rsyslog logrotate stanzas (backup under /var/backups)
 #   3. hourly logrotate run so maxsize is enforced within the hour
 # and reclaims any current overage (journal vacuum + one logrotate pass).
 
@@ -29,14 +34,8 @@ elif [[ -n "${1:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FILES_DIR="$(cd "$SCRIPT_DIR/../files" && pwd)"
-
-JOURNALD_DST="/etc/systemd/journald.conf.d/00-sensor-bounds.conf"
-RSYSLOG_LR="/etc/logrotate.d/rsyslog"
-# Backup MUST live outside /etc/logrotate.d/ -- logrotate reads every file in
-# that dir, so a backup there causes "duplicate log entry" errors.
-RSYSLOG_BAK="/var/backups/logrotate-rsyslog.mjolnir-orig"
-CRON_DST="/etc/cron.hourly/mjolnir-logrotate"
+# shellcheck source=../unified_install/lib/log_bounds.sh
+source "$SCRIPT_DIR/../unified_install/lib/log_bounds.sh"
 
 log() { echo "[apply-log-bounds] $*"; }
 
@@ -46,41 +45,44 @@ df -h / | awk 'NR==1 || /\/$/ {print}'
 
 if [[ "$CHECK_ONLY" == "true" ]]; then
     log "Status (--check, no changes made):"
-    if [[ -f "$JOURNALD_DST" ]]; then log "  journald cap:      PRESENT"; else log "  journald cap:      MISSING"; fi
-    if grep -q "maxsize" "$RSYSLOG_LR" 2>/dev/null; then log "  rsyslog maxsize:   PRESENT"; else log "  rsyslog maxsize:   MISSING"; fi
-    if [[ -f "$CRON_DST" ]]; then log "  hourly logrotate:  PRESENT"; else log "  hourly logrotate:  MISSING"; fi
+    log "  journald cap:      $(log_bounds_status_journald)"
+    log "  rsyslog maxsize:   $(log_bounds_status_rsyslog)"
+    log "  hourly logrotate:  $(log_bounds_status_cron)"
+    if log_bounds_all_present; then
+        log "All bounds present."
+    else
+        log "One or more bounds MISSING -- re-run without --check to apply."
+    fi
     exit 0
 fi
 
 # --- 1. journald cap ---
-sudo mkdir -p "$(dirname "$JOURNALD_DST")"
-sudo cp "$FILES_DIR/journald-sensor-bounds.conf" "$JOURNALD_DST"
-sudo chmod 0644 "$JOURNALD_DST"
-sudo systemctl restart systemd-journald
-log "journald cap applied and journald restarted"
+result="$(log_bounds_apply_journald || true)"
+case "$result" in
+    APPLIED)     log "journald cap applied and journald restarted" ;;
+    MISSING_SRC) log "WARN: journald bounds file not found in $LOG_BOUNDS_FILES_DIR; skipping" ;;
+    *)           log "WARN: unexpected journald result: $result" ;;
+esac
 
 # --- 2. rsyslog logrotate maxsize (idempotent, with one-time backup) ---
-if [[ -f "$RSYSLOG_LR" ]]; then
-    if grep -q "maxsize" "$RSYSLOG_LR"; then
-        log "rsyslog logrotate already has a maxsize cap; leaving as-is"
-    else
-        sudo mkdir -p "$(dirname "$RSYSLOG_BAK")"
-        sudo cp -a "$RSYSLOG_LR" "$RSYSLOG_BAK"
-        sudo sed -i '/^{/a\    maxsize 100M' "$RSYSLOG_LR"
-        log "added 'maxsize 100M' to $RSYSLOG_LR (backup at $RSYSLOG_BAK)"
-    fi
-else
-    log "WARN: $RSYSLOG_LR not found; skipping rsyslog cap"
-fi
+result="$(log_bounds_apply_rsyslog || true)"
+case "$result" in
+    APPLIED)        log "added 'maxsize $LOG_BOUNDS_MAXSIZE' to $LOG_BOUNDS_RSYSLOG_LR (backup at $LOG_BOUNDS_RSYSLOG_BAK)" ;;
+    ALREADY)        log "rsyslog logrotate already has a maxsize cap; leaving as-is" ;;
+    MISSING_TARGET) log "WARN: $LOG_BOUNDS_RSYSLOG_LR not found; skipping rsyslog cap" ;;
+    *)              log "WARN: unexpected rsyslog result: $result" ;;
+esac
 
 # --- 3. hourly logrotate ---
-sudo cp "$FILES_DIR/logrotate-hourly.sh" "$CRON_DST"
-sudo chmod 0755 "$CRON_DST"
-log "hourly logrotate installed at $CRON_DST"
+result="$(log_bounds_apply_cron || true)"
+case "$result" in
+    APPLIED)     log "hourly logrotate installed at $LOG_BOUNDS_CRON_DST" ;;
+    MISSING_SRC) log "WARN: hourly logrotate file not found in $LOG_BOUNDS_FILES_DIR; skipping" ;;
+    *)           log "WARN: unexpected cron result: $result" ;;
+esac
 
 # --- 4. reclaim any current overage now ---
-sudo journalctl --vacuum-size=500M >/dev/null 2>&1 || true
-sudo /usr/sbin/logrotate /etc/logrotate.conf || true
+log_bounds_reclaim
 
 log "Done. New /var/log usage:"
 du -sh /var/log 2>/dev/null || true

--- a/scripts/apply_log_bounds.sh
+++ b/scripts/apply_log_bounds.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# apply_log_bounds.sh (HAM-113)
+#
+# Apply the /var/log size bounds to an ALREADY-DEPLOYED sensor, without a full
+# reinstall. Idempotent -- safe to run repeatedly. Run ON the sensor (needs
+# sudo). This is the fleet-remediation counterpart to configure_log_bounds() in
+# unified_install/lib/hardware.sh.
+#
+# Usage:
+#   sudo bash scripts/apply_log_bounds.sh            # apply the bounds
+#   sudo bash scripts/apply_log_bounds.sh --check    # report status, no changes
+#
+# Applies:
+#   1. journald SystemMaxUse cap (drop-in)
+#   2. maxsize 100M on the rsyslog logrotate stanzas (backup at .mjolnir-orig)
+#   3. hourly logrotate run so maxsize is enforced within the hour
+# and reclaims any current overage (journal vacuum + one logrotate pass).
+
+set -euo pipefail
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+    CHECK_ONLY=true
+elif [[ -n "${1:-}" ]]; then
+    echo "Unknown argument: $1" >&2
+    echo "Usage: $0 [--check]" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILES_DIR="$(cd "$SCRIPT_DIR/../files" && pwd)"
+
+JOURNALD_DST="/etc/systemd/journald.conf.d/00-sensor-bounds.conf"
+RSYSLOG_LR="/etc/logrotate.d/rsyslog"
+# Backup MUST live outside /etc/logrotate.d/ -- logrotate reads every file in
+# that dir, so a backup there causes "duplicate log entry" errors.
+RSYSLOG_BAK="/var/backups/logrotate-rsyslog.mjolnir-orig"
+CRON_DST="/etc/cron.hourly/mjolnir-logrotate"
+
+log() { echo "[apply-log-bounds] $*"; }
+
+log "Current /var/log usage:"
+du -sh /var/log 2>/dev/null || true
+df -h / | awk 'NR==1 || /\/$/ {print}'
+
+if [[ "$CHECK_ONLY" == "true" ]]; then
+    log "Status (--check, no changes made):"
+    if [[ -f "$JOURNALD_DST" ]]; then log "  journald cap:      PRESENT"; else log "  journald cap:      MISSING"; fi
+    if grep -q "maxsize" "$RSYSLOG_LR" 2>/dev/null; then log "  rsyslog maxsize:   PRESENT"; else log "  rsyslog maxsize:   MISSING"; fi
+    if [[ -f "$CRON_DST" ]]; then log "  hourly logrotate:  PRESENT"; else log "  hourly logrotate:  MISSING"; fi
+    exit 0
+fi
+
+# --- 1. journald cap ---
+sudo mkdir -p "$(dirname "$JOURNALD_DST")"
+sudo cp "$FILES_DIR/journald-sensor-bounds.conf" "$JOURNALD_DST"
+sudo chmod 0644 "$JOURNALD_DST"
+sudo systemctl restart systemd-journald
+log "journald cap applied and journald restarted"
+
+# --- 2. rsyslog logrotate maxsize (idempotent, with one-time backup) ---
+if [[ -f "$RSYSLOG_LR" ]]; then
+    if grep -q "maxsize" "$RSYSLOG_LR"; then
+        log "rsyslog logrotate already has a maxsize cap; leaving as-is"
+    else
+        sudo mkdir -p "$(dirname "$RSYSLOG_BAK")"
+        sudo cp -a "$RSYSLOG_LR" "$RSYSLOG_BAK"
+        sudo sed -i '/^{/a\    maxsize 100M' "$RSYSLOG_LR"
+        log "added 'maxsize 100M' to $RSYSLOG_LR (backup at $RSYSLOG_BAK)"
+    fi
+else
+    log "WARN: $RSYSLOG_LR not found; skipping rsyslog cap"
+fi
+
+# --- 3. hourly logrotate ---
+sudo cp "$FILES_DIR/logrotate-hourly.sh" "$CRON_DST"
+sudo chmod 0755 "$CRON_DST"
+log "hourly logrotate installed at $CRON_DST"
+
+# --- 4. reclaim any current overage now ---
+sudo journalctl --vacuum-size=500M >/dev/null 2>&1 || true
+sudo /usr/sbin/logrotate /etc/logrotate.conf || true
+
+log "Done. New /var/log usage:"
+du -sh /var/log 2>/dev/null || true

--- a/tests/unified/test_log_bounds.py
+++ b/tests/unified/test_log_bounds.py
@@ -1,0 +1,133 @@
+"""
+Tests for the HAM-113 log-size bounds feature.
+
+Covers the shipped config artifacts, the install-time wiring
+(configure_log_bounds in hardware.sh, called from install.sh Phase 4), the
+dry-run manifest operations, and the fleet-remediation script's --check mode.
+"""
+
+import os
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+FILES_DIR = REPO_ROOT / "files"
+UNIFIED_DIR = REPO_ROOT / "unified_install"
+
+
+class TestLogBoundsArtifacts:
+    """The shipped config files exist and contain the expected caps."""
+
+    def test_journald_dropin_present_and_bounded(self):
+        conf = (FILES_DIR / "journald-sensor-bounds.conf").read_text()
+        assert "[Journal]" in conf
+        assert "SystemMaxUse=" in conf, "journald drop-in must cap SystemMaxUse"
+
+    def test_hourly_logrotate_script_runs_logrotate(self):
+        script = (FILES_DIR / "logrotate-hourly.sh").read_text()
+        assert script.startswith("#!"), "cron script needs a shebang"
+        assert "logrotate" in script, "hourly job must invoke logrotate"
+
+
+class TestLogBoundsWiring:
+    """configure_log_bounds is defined and invoked in the install flow."""
+
+    def test_function_defined_in_hardware_lib(self):
+        hardware = (UNIFIED_DIR / "lib" / "hardware.sh").read_text()
+        assert "configure_log_bounds()" in hardware
+
+    def test_function_called_in_phase4(self):
+        install = (UNIFIED_DIR / "install.sh").read_text()
+        assert "configure_log_bounds" in install, \
+            "configure_log_bounds must be called from install.sh"
+
+
+class TestLogBoundsManifest:
+    """Running install.sh --dry-run through Phase 4 emits the log-bounds ops."""
+
+    def _run_install_with_hardware(self, tmp_path):
+        manifest_file = tmp_path / "manifest.json"
+        env = os.environ.copy()
+        env["MANIFEST_FILE"] = str(manifest_file)
+        env["HOME"] = str(tmp_path)
+        env["USB_PATH"] = str(tmp_path / "usb")
+        env["FILES_DIR"] = str(FILES_DIR)
+        (tmp_path / "usb").mkdir(exist_ok=True)
+
+        # Run the hardware phase (do NOT --skip-hardware) so configure_log_bounds runs.
+        result = subprocess.run(
+            ["bash", str(UNIFIED_DIR / "install.sh"),
+             "05", "--wifi", "--dry-run",
+             "--skip-packages", "--skip-brokkr", "--skip-extras"],
+            capture_output=True, text=True, env=env, cwd=str(UNIFIED_DIR),
+        )
+        if not manifest_file.exists():
+            pytest.fail(
+                f"Manifest not created.\nstdout: {result.stdout}\nstderr: {result.stderr}")
+        return json.loads(manifest_file.read_text())["operations"]
+
+    def test_manifest_caps_journald(self, tmp_path):
+        ops = self._run_install_with_hardware(tmp_path)
+        journald = [op for op in ops
+                    if op.get("type") == "copy"
+                    and op.get("dst", "").endswith("00-sensor-bounds.conf")]
+        assert journald, f"No journald cap copy op. Ops: {[o.get('type') for o in ops]}"
+
+    def test_manifest_adds_rsyslog_maxsize(self, tmp_path):
+        ops = self._run_install_with_hardware(tmp_path)
+        modify = [op for op in ops
+                  if op.get("type") == "modify"
+                  and op.get("path") == "/etc/logrotate.d/rsyslog"]
+        assert modify, f"No rsyslog maxsize modify op. Ops: {[o.get('type') for o in ops]}"
+
+    def test_manifest_installs_hourly_logrotate(self, tmp_path):
+        ops = self._run_install_with_hardware(tmp_path)
+        cron = [op for op in ops
+                if op.get("type") == "copy"
+                and op.get("dst", "").endswith("cron.hourly/mjolnir-logrotate")]
+        assert cron, f"No hourly logrotate cron op. Ops: {[o.get('type') for o in ops]}"
+
+
+class TestApplyLogBoundsCheck:
+    """The fleet-remediation script's --check mode is read-only and exits 0."""
+
+    def test_check_mode_runs_clean(self):
+        result = subprocess.run(
+            ["bash", str(REPO_ROOT / "scripts" / "apply_log_bounds.sh"), "--check"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"--check failed: {result.stderr}"
+        assert "apply-log-bounds" in result.stdout
+
+    def test_rejects_unknown_arg(self):
+        result = subprocess.run(
+            ["bash", str(REPO_ROOT / "scripts" / "apply_log_bounds.sh"), "--bogus"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2, "unknown arg should exit 2"
+
+
+class TestRsyslogBackupLocation:
+    """Regression, found during the mj05 E2E: the rsyslog backup must NOT be
+    written inside /etc/logrotate.d/ -- logrotate reads every file there, so a
+    backup copy triggers 'duplicate log entry' errors for every log path."""
+
+    def _sources(self):
+        return [
+            (UNIFIED_DIR / "lib" / "hardware.sh").read_text(),
+            (REPO_ROOT / "scripts" / "apply_log_bounds.sh").read_text(),
+        ]
+
+    def test_backup_not_written_into_logrotate_dir(self):
+        for text in self._sources():
+            # the old buggy forms appended .mjolnir-orig to the in-dir path
+            assert "${rsyslog_lr}.mjolnir-orig" not in text
+            assert "${RSYSLOG_LR}.mjolnir-orig" not in text
+            assert "/etc/logrotate.d/rsyslog.mjolnir-orig" not in text
+
+    def test_backup_uses_var_backups(self):
+        for text in self._sources():
+            assert "/var/backups/logrotate-rsyslog.mjolnir-orig" in text

--- a/tests/unified/test_log_bounds.py
+++ b/tests/unified/test_log_bounds.py
@@ -16,6 +16,7 @@ import pytest
 REPO_ROOT = Path(__file__).parent.parent.parent
 FILES_DIR = REPO_ROOT / "files"
 UNIFIED_DIR = REPO_ROOT / "unified_install"
+LIB_DIR = UNIFIED_DIR / "lib"
 
 
 class TestLogBoundsArtifacts:
@@ -117,6 +118,7 @@ class TestRsyslogBackupLocation:
 
     def _sources(self):
         return [
+            (LIB_DIR / "log_bounds.sh").read_text(),
             (UNIFIED_DIR / "lib" / "hardware.sh").read_text(),
             (REPO_ROOT / "scripts" / "apply_log_bounds.sh").read_text(),
         ]
@@ -129,5 +131,63 @@ class TestRsyslogBackupLocation:
             assert "/etc/logrotate.d/rsyslog.mjolnir-orig" not in text
 
     def test_backup_uses_var_backups(self):
-        for text in self._sources():
-            assert "/var/backups/logrotate-rsyslog.mjolnir-orig" in text
+        # The path is defined once, in the shared lib.
+        lib = (LIB_DIR / "log_bounds.sh").read_text()
+        assert "/var/backups/logrotate-rsyslog.mjolnir-orig" in lib
+
+
+class TestSingleImplementation:
+    """The apply logic must exist in exactly ONE place (lib/log_bounds.sh).
+
+    Before this refactor, configure_log_bounds() in hardware.sh and
+    scripts/apply_log_bounds.sh were parallel implementations of the same three
+    operations -- same paths, same sed, same backup logic, duplicated comments.
+    These tests fail if the duplication is reintroduced.
+    """
+
+    def _lib(self):
+        return (LIB_DIR / "log_bounds.sh").read_text()
+
+    def _callers(self):
+        return {
+            "hardware.sh": (UNIFIED_DIR / "lib" / "hardware.sh").read_text(),
+            "apply_log_bounds.sh": (REPO_ROOT / "scripts" / "apply_log_bounds.sh").read_text(),
+        }
+
+    def test_shared_lib_exists_and_defines_the_operations(self):
+        lib = self._lib()
+        for fn in ("log_bounds_apply_journald",
+                   "log_bounds_apply_rsyslog",
+                   "log_bounds_apply_cron"):
+            assert f"{fn}()" in lib, f"{fn} must be defined in lib/log_bounds.sh"
+
+    def test_both_callers_source_the_shared_lib(self):
+        for name, text in self._callers().items():
+            assert "log_bounds.sh" in text, f"{name} must source lib/log_bounds.sh"
+
+    def test_callers_do_not_reimplement_the_sed(self):
+        """The maxsize injection is the sharpest duplication marker."""
+        for name, text in self._callers().items():
+            assert "sed -i" not in text or "maxsize" not in text, (
+                f"{name} appears to reimplement the maxsize sed; "
+                "it must call log_bounds_apply_rsyslog instead")
+
+    def test_callers_do_not_hardcode_the_managed_paths(self):
+        """Paths are defined once in the lib and referenced by variable."""
+        managed = [
+            "/etc/systemd/journald.conf.d/00-sensor-bounds.conf",
+            "/etc/cron.hourly/mjolnir-logrotate",
+        ]
+        for name, text in self._callers().items():
+            for path in managed:
+                assert path not in text, (
+                    f"{name} hardcodes {path}; use the LOG_BOUNDS_* variable")
+
+    def test_status_helpers_available_for_verify_deployment(self):
+        """verify_deployment.sh needs a read-only check it can call."""
+        lib = self._lib()
+        assert "log_bounds_all_present()" in lib
+        for fn in ("log_bounds_status_journald",
+                   "log_bounds_status_rsyslog",
+                   "log_bounds_status_cron"):
+            assert f"{fn}()" in lib

--- a/unified_install/install.sh
+++ b/unified_install/install.sh
@@ -349,6 +349,7 @@ if [[ "$SKIP_HARDWARE" != "true" ]]; then
     source "$SCRIPT_DIR/lib/hardware.sh"
     setup_sensor_connection
     setup_automount
+    configure_log_bounds
 else
     log_info "Skipping hardware setup (--skip-hardware)"
 fi

--- a/unified_install/lib/hardware.sh
+++ b/unified_install/lib/hardware.sh
@@ -130,3 +130,87 @@ setup_automount() {
     echo ""
     log_info "Users in 'pi' group can now mount/unmount drives using udisksctl"
 }
+
+# --- Configure Log-Size Bounds (HAM-113) ---
+# Bounds /var/log so a runaway log source (brokkr science_ingest spamming when
+# the AGS is down, HAM-112) cannot fill the SD card. Three defenses:
+#   1. journald SystemMaxUse cap (drop-in)
+#   2. maxsize on the rsyslog logrotate stanzas
+#   3. hourly logrotate run so maxsize is enforced within the hour
+configure_log_bounds() {
+    log_step "Configuring log-size bounds (HAM-113)..."
+
+    local journald_dir="/etc/systemd/journald.conf.d"
+    local journald_src="journald-sensor-bounds.conf"
+    local journald_dst="$journald_dir/00-sensor-bounds.conf"
+    local rsyslog_lr="/etc/logrotate.d/rsyslog"
+    # Backup MUST live outside /etc/logrotate.d/ -- logrotate reads every file
+    # in that dir, so a backup there causes "duplicate log entry" errors.
+    local rsyslog_bak="/var/backups/logrotate-rsyslog.mjolnir-orig"
+    local cron_src="logrotate-hourly.sh"
+    local cron_dst="/etc/cron.hourly/mjolnir-logrotate"
+
+    # --- Step 1: Cap systemd-journald disk use ---
+    log_step "[Log bounds 1/3] Capping systemd-journald..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "mkdir -p $journald_dir"
+        log_dry_run "cp $FILES_DIR/$journald_src $journald_dst"
+        log_dry_run "systemctl restart systemd-journald"
+        manifest_add "mkdir" "path" "$journald_dir" "sudo" "true"
+        manifest_add "copy" "src" "$FILES_DIR/$journald_src" "dst" "$journald_dst" "sudo" "true"
+        manifest_add "service" "action" "restart" "unit" "systemd-journald" "sudo" "true"
+    else
+        if [[ -f "$FILES_DIR/$journald_src" ]]; then
+            sudo mkdir -p "$journald_dir"
+            sudo cp "$FILES_DIR/$journald_src" "$journald_dst"
+            sudo chmod 0644 "$journald_dst"
+            sudo systemctl restart systemd-journald
+            log_success "journald disk use capped ($journald_dst)"
+        else
+            log_warn "journald bounds file not found at $FILES_DIR/$journald_src"
+        fi
+    fi
+
+    # --- Step 2: Add maxsize cap to the rsyslog logrotate stanzas ---
+    log_step "[Log bounds 2/3] Adding maxsize cap to $rsyslog_lr..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "inject 'maxsize 100M' into $rsyslog_lr (idempotent; backup at $rsyslog_bak)"
+        manifest_add "modify" "path" "$rsyslog_lr" "change" "add maxsize 100M" "sudo" "true"
+    else
+        if [[ -f "$rsyslog_lr" ]]; then
+            if sudo grep -q "maxsize" "$rsyslog_lr"; then
+                log_info "rsyslog logrotate already has a maxsize cap; leaving as-is"
+            else
+                sudo mkdir -p "$(dirname "$rsyslog_bak")"
+                sudo cp -a "$rsyslog_lr" "$rsyslog_bak"
+                sudo sed -i '/^{/a\    maxsize 100M' "$rsyslog_lr"
+                log_success "Added 'maxsize 100M' to $rsyslog_lr (backup at $rsyslog_bak)"
+            fi
+        else
+            log_warn "rsyslog logrotate config not found at $rsyslog_lr"
+        fi
+    fi
+
+    # --- Step 3: Run logrotate hourly so maxsize is enforced within the hour ---
+    log_step "[Log bounds 3/3] Installing hourly logrotate job..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "cp $FILES_DIR/$cron_src $cron_dst"
+        log_dry_run "chmod 0755 $cron_dst"
+        manifest_add "copy" "src" "$FILES_DIR/$cron_src" "dst" "$cron_dst" "sudo" "true"
+        manifest_add "chmod" "path" "$cron_dst" "mode" "0755" "sudo" "true"
+    else
+        if [[ -f "$FILES_DIR/$cron_src" ]]; then
+            sudo cp "$FILES_DIR/$cron_src" "$cron_dst"
+            sudo chmod 0755 "$cron_dst"
+            log_success "Hourly logrotate job installed at $cron_dst"
+        else
+            log_warn "Hourly logrotate file not found at $FILES_DIR/$cron_src"
+        fi
+    fi
+
+    log_success "Log-size bounds configured!"
+    echo ""
+    log_info "  - journald: SystemMaxUse capped via $journald_dst"
+    log_info "  - rsyslog:  maxsize 100M per log, rotated hourly"
+    log_info "  - Keeps /var/log well under 2 GB even under sustained log spam"
+}

--- a/unified_install/lib/hardware.sh
+++ b/unified_install/lib/hardware.sh
@@ -137,80 +137,71 @@ setup_automount() {
 #   1. journald SystemMaxUse cap (drop-in)
 #   2. maxsize on the rsyslog logrotate stanzas
 #   3. hourly logrotate run so maxsize is enforced within the hour
+#
+# The operations themselves live in lib/log_bounds.sh, shared with
+# scripts/apply_log_bounds.sh so there is exactly one implementation. This
+# function contributes only the installer concerns: step logging, --dry-run,
+# and manifest entries for rollback.
 configure_log_bounds() {
     log_step "Configuring log-size bounds (HAM-113)..."
 
-    local journald_dir="/etc/systemd/journald.conf.d"
-    local journald_src="journald-sensor-bounds.conf"
-    local journald_dst="$journald_dir/00-sensor-bounds.conf"
-    local rsyslog_lr="/etc/logrotate.d/rsyslog"
-    # Backup MUST live outside /etc/logrotate.d/ -- logrotate reads every file
-    # in that dir, so a backup there causes "duplicate log entry" errors.
-    local rsyslog_bak="/var/backups/logrotate-rsyslog.mjolnir-orig"
-    local cron_src="logrotate-hourly.sh"
-    local cron_dst="/etc/cron.hourly/mjolnir-logrotate"
+    # shellcheck source=./log_bounds.sh
+    source "$(dirname "${BASH_SOURCE[0]}")/log_bounds.sh"
+
+    local result
 
     # --- Step 1: Cap systemd-journald disk use ---
     log_step "[Log bounds 1/3] Capping systemd-journald..."
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_dry_run "mkdir -p $journald_dir"
-        log_dry_run "cp $FILES_DIR/$journald_src $journald_dst"
+        log_dry_run "mkdir -p $LOG_BOUNDS_JOURNALD_DIR"
+        log_dry_run "cp $LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_JOURNALD_SRC $LOG_BOUNDS_JOURNALD_DST"
         log_dry_run "systemctl restart systemd-journald"
-        manifest_add "mkdir" "path" "$journald_dir" "sudo" "true"
-        manifest_add "copy" "src" "$FILES_DIR/$journald_src" "dst" "$journald_dst" "sudo" "true"
+        manifest_add "mkdir" "path" "$LOG_BOUNDS_JOURNALD_DIR" "sudo" "true"
+        manifest_add "copy" "src" "$LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_JOURNALD_SRC" "dst" "$LOG_BOUNDS_JOURNALD_DST" "sudo" "true"
         manifest_add "service" "action" "restart" "unit" "systemd-journald" "sudo" "true"
     else
-        if [[ -f "$FILES_DIR/$journald_src" ]]; then
-            sudo mkdir -p "$journald_dir"
-            sudo cp "$FILES_DIR/$journald_src" "$journald_dst"
-            sudo chmod 0644 "$journald_dst"
-            sudo systemctl restart systemd-journald
-            log_success "journald disk use capped ($journald_dst)"
-        else
-            log_warn "journald bounds file not found at $FILES_DIR/$journald_src"
-        fi
+        result="$(log_bounds_apply_journald || true)"
+        case "$result" in
+            APPLIED)     log_success "journald disk use capped ($LOG_BOUNDS_JOURNALD_DST)" ;;
+            MISSING_SRC) log_warn "journald bounds file not found at $LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_JOURNALD_SRC" ;;
+            *)           log_warn "unexpected journald result: $result" ;;
+        esac
     fi
 
     # --- Step 2: Add maxsize cap to the rsyslog logrotate stanzas ---
-    log_step "[Log bounds 2/3] Adding maxsize cap to $rsyslog_lr..."
+    log_step "[Log bounds 2/3] Adding maxsize cap to $LOG_BOUNDS_RSYSLOG_LR..."
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_dry_run "inject 'maxsize 100M' into $rsyslog_lr (idempotent; backup at $rsyslog_bak)"
-        manifest_add "modify" "path" "$rsyslog_lr" "change" "add maxsize 100M" "sudo" "true"
+        log_dry_run "inject 'maxsize $LOG_BOUNDS_MAXSIZE' into $LOG_BOUNDS_RSYSLOG_LR (idempotent; backup at $LOG_BOUNDS_RSYSLOG_BAK)"
+        manifest_add "modify" "path" "$LOG_BOUNDS_RSYSLOG_LR" "change" "add maxsize $LOG_BOUNDS_MAXSIZE" "sudo" "true"
     else
-        if [[ -f "$rsyslog_lr" ]]; then
-            if sudo grep -q "maxsize" "$rsyslog_lr"; then
-                log_info "rsyslog logrotate already has a maxsize cap; leaving as-is"
-            else
-                sudo mkdir -p "$(dirname "$rsyslog_bak")"
-                sudo cp -a "$rsyslog_lr" "$rsyslog_bak"
-                sudo sed -i '/^{/a\    maxsize 100M' "$rsyslog_lr"
-                log_success "Added 'maxsize 100M' to $rsyslog_lr (backup at $rsyslog_bak)"
-            fi
-        else
-            log_warn "rsyslog logrotate config not found at $rsyslog_lr"
-        fi
+        result="$(log_bounds_apply_rsyslog || true)"
+        case "$result" in
+            APPLIED)        log_success "Added 'maxsize $LOG_BOUNDS_MAXSIZE' to $LOG_BOUNDS_RSYSLOG_LR (backup at $LOG_BOUNDS_RSYSLOG_BAK)" ;;
+            ALREADY)        log_info "rsyslog logrotate already has a maxsize cap; leaving as-is" ;;
+            MISSING_TARGET) log_warn "rsyslog logrotate config not found at $LOG_BOUNDS_RSYSLOG_LR" ;;
+            *)              log_warn "unexpected rsyslog result: $result" ;;
+        esac
     fi
 
     # --- Step 3: Run logrotate hourly so maxsize is enforced within the hour ---
     log_step "[Log bounds 3/3] Installing hourly logrotate job..."
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_dry_run "cp $FILES_DIR/$cron_src $cron_dst"
-        log_dry_run "chmod 0755 $cron_dst"
-        manifest_add "copy" "src" "$FILES_DIR/$cron_src" "dst" "$cron_dst" "sudo" "true"
-        manifest_add "chmod" "path" "$cron_dst" "mode" "0755" "sudo" "true"
+        log_dry_run "cp $LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_CRON_SRC $LOG_BOUNDS_CRON_DST"
+        log_dry_run "chmod 0755 $LOG_BOUNDS_CRON_DST"
+        manifest_add "copy" "src" "$LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_CRON_SRC" "dst" "$LOG_BOUNDS_CRON_DST" "sudo" "true"
+        manifest_add "chmod" "path" "$LOG_BOUNDS_CRON_DST" "mode" "0755" "sudo" "true"
     else
-        if [[ -f "$FILES_DIR/$cron_src" ]]; then
-            sudo cp "$FILES_DIR/$cron_src" "$cron_dst"
-            sudo chmod 0755 "$cron_dst"
-            log_success "Hourly logrotate job installed at $cron_dst"
-        else
-            log_warn "Hourly logrotate file not found at $FILES_DIR/$cron_src"
-        fi
+        result="$(log_bounds_apply_cron || true)"
+        case "$result" in
+            APPLIED)     log_success "Hourly logrotate job installed at $LOG_BOUNDS_CRON_DST" ;;
+            MISSING_SRC) log_warn "Hourly logrotate file not found at $LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_CRON_SRC" ;;
+            *)           log_warn "unexpected cron result: $result" ;;
+        esac
     fi
 
     log_success "Log-size bounds configured!"
     echo ""
-    log_info "  - journald: SystemMaxUse capped via $journald_dst"
-    log_info "  - rsyslog:  maxsize 100M per log, rotated hourly"
+    log_info "  - journald: SystemMaxUse capped via $LOG_BOUNDS_JOURNALD_DST"
+    log_info "  - rsyslog:  maxsize $LOG_BOUNDS_MAXSIZE per log, rotated hourly"
     log_info "  - Keeps /var/log well under 2 GB even under sustained log spam"
 }

--- a/unified_install/lib/log_bounds.sh
+++ b/unified_install/lib/log_bounds.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Shared /var/log size-bound operations (HAM-113)
+#
+# SINGLE implementation of the three defences that keep a runaway log source
+# (brokkr science_ingest spamming a dead AGS, HAM-112, measured at 3 GB/hr)
+# from filling the SD card:
+#   1. journald SystemMaxUse cap (drop-in)
+#   2. maxsize on the rsyslog logrotate stanzas
+#   3. hourly logrotate run so maxsize is enforced within the hour
+#
+# Used by BOTH callers, so the logic exists in exactly one place:
+#   - configure_log_bounds() in unified_install/lib/hardware.sh  (install time)
+#   - scripts/apply_log_bounds.sh                                (fleet remediation)
+#
+# Deliberately free of any dependency on the installer framework -- no
+# common.sh logging, no $DRY_RUN, no manifest_add -- so the standalone script
+# can source it directly. Callers supply their own logging, dry-run handling
+# and manifest bookkeeping.
+#
+# Each apply function echoes ONE result token and returns 0 unless noted:
+#   APPLIED         the change was made
+#   ALREADY         already in place; idempotent no-op
+#   MISSING_SRC     the shipped asset is absent          (returns 1)
+#   MISSING_TARGET  the file to be modified is absent    (returns 1)
+
+# Resolve files/ the same way the other libs do, so this works whether sourced
+# by the installer (which exports FILES_DIR) or by the standalone script.
+LOG_BOUNDS_FILES_DIR="${FILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../files" && pwd 2>/dev/null || echo "/home/pi/dev/mjolnir-hamma/files")}"
+
+LOG_BOUNDS_JOURNALD_DIR="/etc/systemd/journald.conf.d"
+LOG_BOUNDS_JOURNALD_DST="$LOG_BOUNDS_JOURNALD_DIR/00-sensor-bounds.conf"
+LOG_BOUNDS_JOURNALD_SRC="journald-sensor-bounds.conf"
+
+LOG_BOUNDS_RSYSLOG_LR="/etc/logrotate.d/rsyslog"
+# Backup MUST live outside /etc/logrotate.d/ -- logrotate reads every file in
+# that directory, so a backup kept there triggers "duplicate log entry" errors
+# for every log path it covers. Regression found during the mj05 E2E.
+LOG_BOUNDS_RSYSLOG_BAK="/var/backups/logrotate-rsyslog.mjolnir-orig"
+
+LOG_BOUNDS_CRON_SRC="logrotate-hourly.sh"
+LOG_BOUNDS_CRON_DST="/etc/cron.hourly/mjolnir-logrotate"
+
+LOG_BOUNDS_MAXSIZE="100M"
+LOG_BOUNDS_JOURNAL_MAX="500M"
+
+# --- apply -------------------------------------------------------------------
+
+log_bounds_apply_journald() {
+    local src="$LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_JOURNALD_SRC"
+    if [[ ! -f "$src" ]]; then
+        echo "MISSING_SRC"
+        return 1
+    fi
+    sudo mkdir -p "$LOG_BOUNDS_JOURNALD_DIR"
+    sudo cp "$src" "$LOG_BOUNDS_JOURNALD_DST"
+    sudo chmod 0644 "$LOG_BOUNDS_JOURNALD_DST"
+    sudo systemctl restart systemd-journald
+    echo "APPLIED"
+}
+
+log_bounds_apply_rsyslog() {
+    if [[ ! -f "$LOG_BOUNDS_RSYSLOG_LR" ]]; then
+        echo "MISSING_TARGET"
+        return 1
+    fi
+    if sudo grep -q "maxsize" "$LOG_BOUNDS_RSYSLOG_LR"; then
+        echo "ALREADY"
+        return 0
+    fi
+    sudo mkdir -p "$(dirname "$LOG_BOUNDS_RSYSLOG_BAK")"
+    sudo cp -a "$LOG_BOUNDS_RSYSLOG_LR" "$LOG_BOUNDS_RSYSLOG_BAK"
+    sudo sed -i "/^{/a\\    maxsize $LOG_BOUNDS_MAXSIZE" "$LOG_BOUNDS_RSYSLOG_LR"
+    echo "APPLIED"
+}
+
+log_bounds_apply_cron() {
+    local src="$LOG_BOUNDS_FILES_DIR/$LOG_BOUNDS_CRON_SRC"
+    if [[ ! -f "$src" ]]; then
+        echo "MISSING_SRC"
+        return 1
+    fi
+    sudo cp "$src" "$LOG_BOUNDS_CRON_DST"
+    sudo chmod 0755 "$LOG_BOUNDS_CRON_DST"
+    echo "APPLIED"
+}
+
+# Reclaim any overage that accumulated before the bounds went on. Safe to call
+# when already within bounds; not needed on a fresh install.
+log_bounds_reclaim() {
+    sudo journalctl --vacuum-size="$LOG_BOUNDS_JOURNAL_MAX" >/dev/null 2>&1 || true
+    sudo /usr/sbin/logrotate /etc/logrotate.conf || true
+}
+
+# --- status (read-only) ------------------------------------------------------
+
+log_bounds_status_journald() {
+    [[ -f "$LOG_BOUNDS_JOURNALD_DST" ]] && echo "PRESENT" || echo "MISSING"
+}
+
+log_bounds_status_rsyslog() {
+    grep -q "maxsize" "$LOG_BOUNDS_RSYSLOG_LR" 2>/dev/null && echo "PRESENT" || echo "MISSING"
+}
+
+log_bounds_status_cron() {
+    [[ -f "$LOG_BOUNDS_CRON_DST" ]] && echo "PRESENT" || echo "MISSING"
+}
+
+# Returns 0 only when all three defences are in place. Intended for
+# verify_deployment.sh and for the --check path of the remediation script.
+log_bounds_all_present() {
+    [[ "$(log_bounds_status_journald)" == "PRESENT" ]] &&
+    [[ "$(log_bounds_status_rsyslog)" == "PRESENT" ]] &&
+    [[ "$(log_bounds_status_cron)" == "PRESENT" ]]
+}


### PR DESCRIPTION
## What
Caps `/var/log` growth so a runaway log source can't fill the SD card — the disk-fill that hit **mj42** (2026-04), **mj54** (2026-05), and **mj05** (2026-07).

Three defenses, independent of the spam source:
- **journald** `SystemMaxUse=500M` drop-in (`files/journald-sensor-bounds.conf`)
- **rsyslog** `maxsize 100M` injected into each `/etc/logrotate.d/rsyslog` stanza (idempotent; backs up the original to `/var/backups/`)
- **hourly logrotate** run (`files/logrotate-hourly.sh` → `/etc/cron.hourly/mjolnir-logrotate`) so `maxsize` is enforced within the hour, not once a day

Delivered as both a `unified_install` step (`configure_log_bounds` in `hardware.sh`, Phase 4) and an idempotent **fleet-remediation script** (`scripts/apply_log_bounds.sh`, with `--check`) for already-deployed units.

## Why
Defense-in-depth for HAM-112 (brokkr `science_ingest` retries with no backoff). Even after HAM-112 is fixed, this catches *any* future runaway log source. HAM-112 itself is deferred (modifying brokkr's untested core on the deployed fleet is too risky right now); this PR makes the disk-fill non-fatal in the meantime.

## Testing
- 11 new unit tests (`tests/unified/test_log_bounds.py`), incl. a real `install.sh --dry-run` through Phase 4 asserting the manifest ops.
- shellcheck-clean additions.
- **E2E validated on mj05**: applied via the remediation script, `logrotate -d` parses clean, `/var/log` bounded (journal 1.2G→536M), idempotent re-run, `--check` reports all present. mj05 is now remediated.
- The E2E caught a real bug — the rsyslog backup was written into `/etc/logrotate.d/`, causing logrotate "duplicate log entry" errors; fixed to `/var/backups/` with a regression test.

## Note
The repo's `tests/shell/test_shellcheck.py` is already red on `0.4.x` under shellcheck 0.11.0 (pre-existing SC2155/SC2046 in several libs). This PR adds zero new shellcheck warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)