### PR TITLE
fix(mjol_array): don't require numpy in status_latest_trigger (HAM-168)

### DIFF
--- a/server/mjol_array.py
+++ b/server/mjol_array.py
@@ -90,7 +90,28 @@ class MjolnirArray():
         # port is fully qualified
 
         import ast
-        import numpy as np
+
+        # numpy is only present under the ltgenv python (the brokkr plugin
+        # context). The VPS operator runs `mjol_array --status` under the
+        # system python, which has no numpy -- so degrade gracefully to
+        # stdlib equivalents. When numpy IS present the behaviour is
+        # byte-identical to before (np.datetime64 / np.nan), so the
+        # log.hamma.dev dashboard is unaffected.
+        try:
+            import numpy as np
+            _nan = np.nan
+
+            def _to_time(epoch_s):
+                return np.datetime64(int(epoch_s), 's')
+        except ImportError:
+            import datetime as _datetime
+            _nan = float('nan')
+
+            def _to_time(epoch_s):
+                # timezone.utc is available since 3.2 (unlike datetime.UTC,
+                # which is 3.11+); keeps this 3.6+ compatible and warning-free.
+                return _datetime.datetime.fromtimestamp(
+                    int(epoch_s), _datetime.timezone.utc)
 
         cmd = MjolnirArray._pi_ssh_cmd(port)
         cmd = cmd + ['/home/pi/dev/mjolnir-hamma/scripts/latest_trigger.py']
@@ -100,12 +121,12 @@ class MjolnirArray():
             if out.returncode:
                 raise Exception
             ret_val = ast.literal_eval(out.stdout)
-            ret_val['time'] = np.datetime64(int(ret_val['time']), 's')
+            ret_val['time'] = _to_time(ret_val['time'])
         except Exception:
             ret_val = dict()
-            ret_val['threshold'] = np.nan
-            ret_val['num_sat'] = np.nan
-            ret_val['time'] = np.nan
+            ret_val['threshold'] = _nan
+            ret_val['num_sat'] = _nan
+            ret_val['time'] = _nan
 
         return ret_val
 

--- a/tests/python/test_mjol_array.py
+++ b/tests/python/test_mjol_array.py
@@ -160,6 +160,38 @@ class TestStatusLatestTrigger:
         assert 'num_sat' in result
         assert 'time' in result
 
+    def test_works_without_numpy(self, mjol):
+        """Must not require numpy: the operator runs `mjol_array --status`
+        under the system python (/usr/bin/python), which has no numpy. Only
+        the brokkr plugin runs under the ltgenv python that has numpy.
+        """
+        import sys
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(
+                returncode=0,
+                stdout="{'threshold': 0.5, 'num_sat': 8, 'time': 1234567890}",
+            )
+            # Make `import numpy` raise ImportError, exactly as on the VPS
+            # system python, for the duration of the call.
+            with patch.dict(sys.modules, {'numpy': None}):
+                result = mjol.MjolnirArray.status_latest_trigger(10001)
+
+        assert result['threshold'] == 0.5
+        assert result['num_sat'] == 8
+        assert result['time'] is not None
+
+    def test_failure_path_works_without_numpy(self, mjol):
+        """The nan fallback path must also not reference numpy."""
+        import sys
+        import math
+        with patch.object(mjol, 'subprocess') as mock_sub:
+            mock_sub.run.return_value = MagicMock(returncode=1, stdout="")
+            with patch.dict(sys.modules, {'numpy': None}):
+                result = mjol.MjolnirArray.status_latest_trigger(10001)
+
+        assert math.isnan(result['threshold'])
+        assert math.isnan(result['num_sat'])
+
 
 class TestPiSshCmd:
     """Tests for MjolnirArray._pi_ssh_cmd()."""


### PR DESCRIPTION
## What

`mjol_array --status` on the VPS crashed with `ModuleNotFoundError: No module named 'numpy'`. The bare `mjol_array` runs under `#!/usr/bin/env python` → `/usr/bin/python` (3.8.10, no numpy); numpy is only present under the ltgenv python that the brokkr `array_status` plugin uses. `status_latest_trigger()` imported numpy unconditionally.

Fixes **HAM-168**. Surfaced during the 2026-07-09 threshold/gain fleet deployment.

## Change

Guard the numpy import in `status_latest_trigger()`; fall back to stdlib (`float('nan')`, `datetime.fromtimestamp(..., timezone.utc)`) when numpy is absent.

- **numpy-present path is byte-identical** (still `np.datetime64` / `np.nan`) → the log.hamma.dev dashboard (plugin runs under ltgenv python) is unaffected.
- Only the operator `--status` path (numpy absent) changes: it now works instead of crashing.
- 3.6+ compatible (`timezone.utc`, not the 3.11+ `datetime.UTC`).
- `--set-threshold` / `--set-gain` were already stdlib-only and unaffected.

## Tests (TDD)

Added `test_works_without_numpy` and `test_failure_path_works_without_numpy` — they block `numpy` in `sys.modules` (mimicking the VPS system python) and assert `status_latest_trigger()` still returns a valid dict. Watched both fail on the old code, pass on the fix.

```
48 passed in 0.06s   (tests/python/test_mjol_array.py)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)