### PR TITLE
fix(state_monitor): level-triggered, numeric-robust, observable auto-scrub

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -58,6 +58,8 @@ config_version = 1
         channel = "status"
         key_file = "/home/pi/.googlechat"
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
+        scrub_cooldown_s = 1800  # min seconds between auto-scrub launches while low (level-triggered retry)
+        scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub_auto.log"  # capture auto-scrub output (diagnose futile/failed scrubs)
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/docs/scrub-fix-assurance-report.md
+++ b/docs/scrub-fix-assurance-report.md
@@ -1,0 +1,117 @@
+# Assurance report — mj05 auto-scrub reliability fix
+
+**Date:** 2026-07-11 · **Branch:** `feature/scrub-trigger-fix` (off `0.4.x`)
+**Change:** `plugins/state_monitor.py` (+ `config/main.toml`, tests) — makes the
+auto-scrub trigger level-triggered, numeric-robust, cooldown-retried, and observable.
+
+## 1. What failed (established facts)
+
+mj05's AGS drive `/ags/data` (462 GB) filled to 0 bytes. The data was **real** —
+~20,446 legitimate 22 MB triggers for Jul 3–10; only 92 bad-GPS headers. brokkr's
+real-time ingest had already copied ~20,400 of them to `DATA56` (the recovery scrub found
+only **10** genuinely missing). The AGS then hit the disk-full backpressure reboot loop.
+The last *effective* drain of the AGS side was a **manual** scrub on Jul 6; the automated
+safety net did not keep the drive clear.
+
+**Honesty note on the trigger:** whether the automated trigger *fired-but-was-ineffective*
+or *never-fired* on Jul 9 is **not provable** — log rotation from the reboot-loop spam
+destroyed that day's `state_monitor` logs. My first root cause (NA-poisoned edge detector)
+was **refuted** by red team #1: the Jul 9 crossing was clean (`100.22 → 99.54`), so the
+edge *should* have fired. I am not claiming a mechanism the evidence can't support.
+
+## 2. What the fix changes (and why it's the right target)
+
+Independent of the unprovable Jul 9 detail, the auto-scrub had four real, code-visible
+weaknesses. The fix addresses three directly and makes the fourth diagnosable:
+
+| Weakness (before) | After |
+|---|---|
+| **One-shot edge trigger, no retry** — fires only on a high→low crossing; a single missed/ineffective scrub is never retried while the drive stays low. | **Level-triggered**: fires on *any* below-threshold sample, **cooldown-rate-limited** (`scrub_cooldown_s`, default 1800 s) so it retries but doesn't spam. |
+| **NA/nan fragility** — a nan sample poisons the edge; a `None`/string value raises `TypeError` that `run_checks` swallows, silently disabling the check. | **Numeric-robust**: `isinstance(x,(int,float)) and x==x` guard; non-numeric samples are skipped cleanly, never crash. `0` (full disk) still fires. |
+| **Silent scrub failure** — output → `/dev/null`, exit status ignored; a scrub that runs and frees nothing is invisible (this is *why* Jul 9 is unreconstructable). | **Observable**: scrub stdout/stderr appended to `scrub_log`. Alerts now escalate — on descent-entry **and** on each cooldown-gated respawn — instead of one message then silence. |
+| **Sole dependence on AGS-pushed `bytes_remaining`** — blind when the AGS is fully silent. | **Not fixed here** — documented residual (§5); needs a telemetry-independent check (follow-up). |
+
+## 3. Evidence of effectiveness
+
+- **Tests:** 34/34 state_monitor tests pass (`test_state_monitor.py` +
+  `test_state_monitor_scrub.py`). TDD: 6 new-contract tests were written and watched to
+  **fail** against the old code, then pass. Full suite: 446 passed; the only 3 failures
+  (`test_hamma_noise`) are pre-existing and unrelated (an installed-`hamma` version issue;
+  that module does not import `state_monitor`).
+- **Against the actual incident:** on Jul 9, `bytes_remaining` sat below 100 for *hours*.
+  At the ~1-4 min H&S cadence that is an estimated **tens-to-hundreds** of valid sub-100
+  samples (an inference — the state_monitor log for that day was rotated away, see §1). The
+  old edge trigger needed one specific high->low pair and then never retried. The level
+  trigger fires on the first valid sub-100 sample and **re-fires every 30 min while still
+  low** — converting the failure mode from "one shot, then silence" to "retry + escalate +
+  on the record."
+  **Caveat (honest completion):** this helps *only if* a triggered scrub actually frees
+  `/ags/data`. On this incident ~20,400/20,446 triggers were already on MJ and the real
+  drain was manual, and once the AGS entered its reboot loop it stops sending H&S — so a
+  perfectly reliable trigger here could have fired, run scrubs that freed little, then gone
+  blind. See residual risks §5.1 (telemetry blind spot) and §5.3 (futile scrub). The fix
+  makes mj05 **more reliably retried and diagnosable**, not provably rescued.
+- **Regression safety:** the change is confined to `state_monitor.py` (+tests, +2 config
+  lines). No other module touched.
+
+## 4. Peer review performed (adversarial)
+
+Three red-team reviewers attacked the analysis and the fix; a debugger adjudicated the
+root cause with live access. Dispositions (full table in
+`scrub-trigger-fix-analysis.md`):
+
+- **Caught 2 FATAL bugs in the draft** before implementation: missing `import time`
+  (would have thrown `NameError` and eaten scrub *and* alert), and a test helper missing
+  the new attrs. Both fixed and covered by tests.
+- **Caught the root-cause over-claim** (nan theory) — conceded; report re-scoped to
+  reliability+observability rather than a mechanism the evidence can't prove.
+- **Hardened details:** numeric guard vs `x!=x`-only; cooldown stamped only on successful
+  launch (a failed launch retries next cycle); alert escalation on respawn.
+
+## 5. Can I assure you this is the last time? — Honest answer: **partially. No, not on its own.**
+
+This fix makes the safety net **substantially more reliable and, critically, observable**
+— the next occurrence will retry and leave a diagnosable trail instead of failing
+silently. That is a real, tested improvement and it targets the mechanism that let a
+transient problem become a total fill.
+
+But a truthful "never again" requires more than this change, and the red team was right to
+say so. **Residual risks this fix does NOT close:**
+
+1. **Telemetry blind spot (MIGHT-RECUR):** the trigger still reads `bytes_remaining`,
+   which the AGS stops sending when it reboot-loops. mj05's H&S was intermittent (so the
+   level trigger catches it), but a tighter loop with *no* clean sub-threshold sample
+   would still be missed. **Follow-up:** a direct `df /ags/data` probe over SSH,
+   independent of AGS telemetry.
+2. **`/media/pi/DATA??` unmonitored (WILL-RECUR eventually):** nothing watches the mj-side
+   recovery-target drives' free space (`DATA55` is *also* at 100% now). If all DATA drives
+   fill, brokkr can't write and recovery has nowhere to land. **Follow-up:** a local
+   `shutil.disk_usage` check on `DATA??` (cheap, mirrors `check_pi_space`).
+3. **Firing-but-futile scrub:** if targets are full, scrubs run and free nothing. Now at
+   least **visible** in `scrub_log`, but not yet auto-detected. **Follow-up:** verify
+   freed-bytes after a scrub and escalate if zero.
+4. **The underlying driver** — a high sustained trigger rate that outpaces draining — is a
+   capacity/tuning question, not a bug this fix addresses.
+
+**Recommendation:** ship this fix (it's correct and net-positive), deploy to mj05 after
+AGS is restored, and track items 1–2 as the follow-ups that, together with this, constitute
+an honest "this shouldn't happen again." I would not close the incident on this change
+alone.
+
+## 6. Deployment notes (for whoever deploys this)
+
+- **Cooldown resets on brokkr restart.** `_last_scrub_time` is in-memory, so a brokkr/Pi
+  restart re-arms immediate scrubbing on the next low sample. This is the safe direction
+  (biases toward scrubbing), but during a reboot loop expect a scrub launch shortly after
+  each restart rather than strict 30-min spacing.
+- **`scrub_log` directory must exist and be pi-writable.** Config points it at
+  `/home/pi/brokkr/hamma/log/hamma_scrub_auto.log`. If the dir is missing or unwritable,
+  `_spawn_scrub` logs a warning and **silently falls back to DEVNULL** — i.e. the
+  observability feature no-ops. Confirm the path on each unit at deploy.
+- **flock still guards concurrency, independently of the cooldown.** If a prior scrub is
+  still running when the 30-min cooldown elapses, the new `flock -n` launch succeeds as a
+  process but the flocked child exits immediately (lock held). `_spawn_scrub` returns True
+  and stamps the cooldown, so you get one short-lived flock-rejected process per cooldown
+  while a long scrub runs — benign, and now visible in `scrub_log`.
+- **Numeric guard admits bool** (`isinstance(x,(int,float))`; `bool` subclasses `int`).
+  Harmless because `bytes_remaining` is never boolean; noted for completeness.

--- a/docs/scrub-trigger-fix-analysis.md
+++ b/docs/scrub-trigger-fix-analysis.md
@@ -1,0 +1,210 @@
+# Auto-scrub trigger failure on mj05 — root cause & fix
+
+Date: 2026-07-11. Branch: `feature/scrub-trigger-fix` off `0.4.x`.
+
+---
+## ⚠️ REVISION 2 (post red-team + dev-team) — read this first
+
+**My original root cause (NA-poisoned edge detector) was REFUTED by red team #1.**
+The Jul 9 threshold crossing was **clean**, not NA-poisoned:
+`20:55:11 = 100.22` (≥100) → `20:56:11 = 99.54` (<100) — a clean consecutive numeric
+pair, so `(99.54 < 100) and (100.22 >= 100)` is **True**; the edge *should* have fired.
+
+The dev-team debugger then ruled out every "it silently didn't run" hypothesis:
+TypeError (value decodes to a real `float`), pipeline-not-running (CSV written at the
+exact crossing timestamps), config override (none), and stale code (running commit has
+the correct check). **BUT** it found the wall: **log rotation driven by the FPGA-fault
+reboot spam destroyed all of Jul 9's `state_monitor` log output**, so whether the trigger
+*fired-and-was-ineffective* vs *never-fired* on Jul 9 is **not provable from surviving
+evidence.** The "0 alerts ever" datum is therefore unreliable.
+
+### What is actually established (evidence-based)
+1. The fill was **real data volume**: the recovery scrub found **20,446 legitimate
+   22 MB triggers** (~450 GB) for Jul 3–10; only **92** bad-GPS headers. Not junk.
+2. **Only 10 triggers were missing on MJ** — brokkr's real-time science ingest had
+   already written ~20,400 of them to `DATA56`. So the AGS drive was full of data that
+   was *already safely on MJ*. The last *effective* AGS drain was the **manual** scrub of
+   Jul 6.
+3. The auto-scrub is an **unreliable safety net**, independent of the Jul 9 mystery:
+   - **one-shot edge trigger, no retry** — fires at most once per crossing; if the drive
+     sits below threshold (or the one scrub is ineffective), it never re-fires;
+   - **fails silently** — `_spawn_scrub` sends child stdout/stderr to `DEVNULL` and never
+     checks exit status, so a scrub that runs and frees nothing is invisible (this is
+     *why* Jul 9 is unreconstructable);
+   - **sole dependence on AGS-pushed `bytes_remaining`** — blind when the AGS is silent;
+   - **no direct free-space monitor** on `/ags/data` or on the `/media/pi/DATA??` drives.
+
+### Consequence for the fix
+The exact Jul 9 trigger event is unprovable, but the architectural weaknesses are real
+and are the correct thing to fix (per systematic-debugging: when investigation hits an
+evidence wall, implement retry + observability). The fix below is **re-scoped** from
+"fix the nan bug" to **"make the safety net reliable and observable."** The NA-robustness
+is retained (cheap, strictly better) but is no longer claimed as *the* cause.
+
+---
+
+
+## Incident
+
+mj05's AGS data drive `/ags/data` (462 GB) filled to **100% / 0 bytes free**. A full
+`/ags/data` stalls the AGS write thread → backs up the read queue → the AGS "No data
+read" watchdog reboots the AGS Pi in a loop (documented mechanism; see hamma-expert
+`ags-fpga-reboot-loop.md`, cause #2 "disk-full backpressure"). The automated scrubber,
+whose entire job is to drain `/ags/data` by recovering triggers to the MJ `DATA??`
+drives and purging, **never fired**. Humans had to manually scrub (Jul 2, Jul 6); it
+refilled and hit 0 by Jul 11.
+
+## Evidence (all from the live unit)
+
+1. **`scrub_command` is correctly configured** on mj05 (`config/main.toml`):
+   `scrub_command = "python3 .../hamma_scrub.py --recover --purge --since auto"`,
+   `low_space = 100`, no local override. Not a config problem.
+2. **The low-space alert `"Remaining GB on drive is ..."` fired 0 times, ever** (0
+   matches across all brokkr log files); **0 "Spawned scrub" log lines**. The trigger
+   path never executed its body.
+3. **The telemetry proves why.** `bytes_remaining` (H&S "Disk Remaining", GB, UDP from
+   AGS) declined smoothly through the `low_space=100` threshold late on Jul 9, but the
+   H&S stream is **frequently NA** (54–80 NA samples/day). At the crossing the raw
+   samples **alternate NA / numeric**:
+
+   ```
+   21:03  NA
+   21:07  99.51   <- first sub-100 reading; its predecessor sample is NA
+   21:11  NA
+   21:15  99.51
+   21:19  NA
+   21:23  96.06   ... monotonic decline to 0 by Jul 11
+   ```
+
+## Root cause
+
+`StateMonitor.check_sensor_drive` (plugins/state_monitor.py) is a **falling-edge
+detector**:
+
+```python
+space_now, space_pre = self.now_then(input_data, 'bytes_remaining')
+if (space_now < self.low_space) and (space_pre >= self.low_space):
+    self._spawn_scrub()
+    return f"Remaining GB on drive is {space_now:.1f}"
+```
+
+`now_then` maps `'NA' → nan`. Firing requires a **consecutive numeric pair** straddling
+the threshold (`space_pre >= 100` AND `space_now < 100`). On mj05, every sub-100 reading
+was preceded by an NA sample, so `space_pre` was `nan`, and **`nan >= 100` is `False`**.
+No consecutive (>=100, <100) pair ever occurred → the edge was never seen → the scrub was
+never spawned → the disk filled to 0.
+
+The `>=` (vs `>`) already on 0.4.x fixed a *different* miss (mj07 exact-boundary
+`100.0→99.96`); it does **nothing** for the nan case.
+
+### Three compounding defects
+1. **NA-fragility (primary):** a single NA at the crossing permanently defeats the edge
+   detector, because `nan >= low_space` and `nan < low_space` are both `False`. NA is the
+   norm, not the exception, on this channel.
+2. **Edge-only, no re-arm:** even with clean data, it fires on one sample only. Once
+   below threshold it never retries, so any single missed crossing is unrecoverable until
+   the value climbs back above threshold and falls again.
+3. **Sole dependence on AGS-pushed telemetry:** the metric that gates the scrub is pushed
+   by the very component (AGS) that goes silent when the condition (disk full →
+   backpressure → reboot loop) occurs. Detection blinds itself exactly when it's needed.
+
+## Proposed fix (DRAFT — under review)
+
+Make `check_sensor_drive` **level-triggered, NA-robust, and cooldown-rate-limited**.
+
+```python
+def check_sensor_drive(self, input_data):
+    space_now, _ = self.now_then(input_data, 'bytes_remaining')
+
+    # NA-robust: nan means the AGS sent no H&S this cycle (silent/rebooting).
+    # We cannot assess free space; make no decision, leave prior state intact.
+    if space_now != space_now:  # nan
+        return None
+
+    if space_now >= self.low_space:
+        self._low_space_active = False   # healthy: re-arm the alert
+        return None
+
+    # Below threshold: level-triggered. Spawn a scrub, rate-limited so a
+    # persistently-low drive does not respawn every 60 s cycle.
+    self._maybe_spawn_scrub()
+
+    if not self._low_space_active:       # alert once per descent, not every cycle
+        self._low_space_active = True
+        return f"Remaining GB on drive is {space_now:.1f}"
+    return None
+
+def _maybe_spawn_scrub(self):
+    if not self.scrub_command or not self.scrub_command.strip():
+        return
+    now = time.monotonic()
+    if (self._last_scrub_time is not None
+            and (now - self._last_scrub_time) < self.scrub_cooldown_s):
+        return                            # within cooldown; flock also guards concurrency
+    self._last_scrub_time = now
+    self._spawn_scrub()
+```
+
+New `__init__` state: `scrub_cooldown_s=1800`, `self._last_scrub_time=None`,
+`self._low_space_active=False`. `_spawn_scrub` unchanged (flock + Popen).
+
+### Why this fixes mj05
+- **NA no longer poisons detection** — nan samples are skipped, and the decision uses
+  only `space_now`. Any single valid sub-100 reading (there were hundreds) now fires.
+- **Level + cooldown** re-arms: if a scrub fails or the drive stays low, the next valid
+  low sample past the cooldown tries again, instead of one-and-done.
+- flock still prevents concurrent scrubs; the cooldown prevents 60 s log/proc spam and
+  hammering the AGS over SSH.
+
+### Behavior change to flag
+The existing test `test_no_scrub_when_already_below` asserts the OLD edge-only behavior
+(no scrub when already below). Under the fix, a below-threshold sample **does** spawn
+(subject to cooldown). That test must be rewritten to the new intended contract.
+
+## Open questions for the red team
+1. Is level+cooldown the right shape, or should we also add a **telemetry-independent**
+   safety net (e.g. direct `df` of the drives, or a "no successful scrub in N hours"
+   watchdog) to cover total AGS silence (no H&S at all)? On mj05 H&S was intermittent,
+   not absent, so level-trigger suffices *here* — but defect #3 remains.
+2. Cooldown default 1800 s — too long (slow retry) or too short (AGS SSH hammering)?
+   Should it be config-driven (it is, via `scrub_cooldown_s`)?
+3. `time.monotonic()` for cooldown vs a sample-count counter — testability and
+   correctness across brokkr restarts (monotonic resets on reboot; is that acceptable?).
+4. Any risk from firing a `--purge` scrub more eagerly (level vs edge)? Purge only deletes
+   AGS files confirmed byte-identical on MJ, so more frequent runs are safe — confirm.
+
+---
+## Dev-team rebuttal of red-team findings + FINAL fix scope
+
+| # | Red-team finding | Disposition |
+|---|---|---|
+| RT2-1 | FATAL: missing `import time` → NameError | **ACCEPTED** — add `import time`. |
+| RT2-2 | FATAL: test helper omits new attrs → AttributeError | **ACCEPTED** — `make_monitor` sets all three; add real-`__init__` test. |
+| RT2-3 | SERIOUS: verify `__init__` wires all three attrs | **ACCEPTED** — wired in `__init__`; test asserts. |
+| RT2-4 | SERIOUS: `x != x` only catches float-nan; None/str → TypeError | **ACCEPTED** — use `not isinstance(x,(int,float)) or x!=x`. |
+| RT2-5 | SERIOUS: total-AGS-silence still blinds trigger | **ACCEPTED as residual** — documented; direct-df follow-up (RT3-A). |
+| RT2-6 | MINOR: cooldown stamped before launch success | **ACCEPTED** — stamp only on successful `Popen` (`_spawn_scrub` returns bool). |
+| RT2-7 | MINOR: monotonic reset on reboot | **ACKNOWLEDGED** — safe direction (biases toward scrubbing); comment added. |
+| RT2-8 | MINOR: re-alert churn on re-crossings | **ADDRESSED** — alert on descent-entry and on each (re)spawn only, not per cycle. |
+| RT2-9 | MINOR: replacement test contract unspecified | **ACCEPTED** — explicit new tests (below-with-cooldown-elapsed spawns; within-cooldown does not; nan skips). |
+| RT1-1..4 | Root-cause attribution underdetermined (nan not proven; evidence unreproducible; TypeError/spawned-failed not excluded) | **CONCEDED** — see REVISION 2. Debugger ruled out TypeError/pipeline/config/code; Jul 9 unprovable (logs rotated). Fix re-scoped to reliability+observability, not "the nan bug." |
+| RT3-R1 | Telemetry-dependence (MIGHT-RECUR) | **RESIDUAL** — level-trigger needs ≥1 valid sub-threshold sample; documented; direct-df follow-up. |
+| RT3-R2 | `/media/pi/DATA??` unmonitored (WILL-RECUR) | **FOLLOW-UP** — file issue for a local-`df` DATA?? check; out of scope for this trigger fix. |
+| RT3-R3 | Firing-but-futile scrub, silent (WILL-RECUR) | **PARTIALLY ADDRESSED** — scrub output now logged (not DEVNULL) so futile runs are visible; success-verification is follow-up. |
+| RT3-C  | One-shot alert, no escalation | **ADDRESSED** — re-alert on each cooldown-gated respawn while still low. |
+
+### Final fix (implemented on this branch)
+1. `check_sensor_drive`: **level-triggered + numeric-robust + cooldown-gated retry**, alert on
+   descent-entry and on each respawn. (`import time`; `isinstance` guard.)
+2. `_maybe_spawn_scrub`: cooldown via `time.monotonic()`, stamped **only on successful launch**.
+3. `_spawn_scrub`: returns bool; **redirects scrub output to a log** (configurable `scrub_log`,
+   defensive open, falls back to DEVNULL) so futile/failed scrubs are no longer invisible.
+4. `__init__`: new `scrub_cooldown_s` (default 1800) + `scrub_log`; init `_last_scrub_time=None`,
+   `_low_space_active=False`.
+5. Tests updated + added; `test_no_scrub_when_already_below` rewritten to the new contract.
+
+### Honestly out of scope here (tracked follow-ups — required for a true "never again")
+- **Direct `df` of `/ags/data` over SSH**, independent of AGS H&S (closes RT2-5/RT3-R1 blind spot).
+- **Local `df` monitor on `/media/pi/DATA??`** (closes RT3-R2).
+- **Scrub success verification** (freed-bytes check) (closes RT3-R3 fully).
+- **AGS-side policy for bad-GPS / unrecoverable files.**

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -6,6 +6,7 @@ from math import nan
 import shlex
 import shutil
 import subprocess
+import time
 
 # Third party imports
 from notifiers import Notifier
@@ -40,6 +41,8 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         low_pi_space=5,
         enable_drive_checks=True,
         scrub_command="",
+        scrub_cooldown_s=1800,
+        scrub_log="",
         **output_step_kwargs,
         ):
         """
@@ -73,6 +76,15 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_command : str, optional
             Shell command to run hamma_scrub.py when drive space is low.
             If empty (default), no scrub is spawned. Protected by flock.
+        scrub_cooldown_s : numeric, optional
+            Minimum seconds between successive auto-scrub launches while the
+            drive remains below `low_space`. The check is level-triggered (fires
+            whenever space is low, not only on the high->low edge), so this
+            cooldown rate-limits retries. Default 1800 (30 min).
+        scrub_log : str, optional
+            Path to append the spawned scrub's stdout/stderr to. If empty
+            (default), scrub output is discarded (DEVNULL). Set this so a scrub
+            that runs but frees nothing is diagnosable instead of silent.
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -92,6 +104,13 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.low_pi_space = low_pi_space*1000000000
         self.enable_drive_checks = enable_drive_checks
         self.scrub_command = scrub_command
+        self.scrub_cooldown_s = scrub_cooldown_s
+        self.scrub_log = scrub_log
+        # Level-trigger state: monotonic timestamp of the last successful scrub
+        # launch (for cooldown), and whether we are currently in the low-space
+        # state (so we alert on descent-entry and on each respawn, not every cycle).
+        self._last_scrub_time = None
+        self._low_space_active = False
 
         self.notifier = Notifier(
             method=method, key_file=key_file, channel=channel, logger=self.logger)
@@ -342,32 +361,95 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             Message to send depending on the check, or None if no message.
 
         """
-        space_now, space_pre = self.now_then(input_data, 'bytes_remaining')
-        # Use >= for `pre` so a previous sample sitting exactly on the
-        # threshold still counts as above it. Strict `>` silently misses
-        # the edge when pre lands on low_space (a real case on mj07:
-        # 100.0 -> 99.96 with low_space=100 never fired).
-        if (space_now < self.low_space) and (space_pre >= self.low_space):
-            self._spawn_scrub()
+        space_now, _space_pre = self.now_then(input_data, 'bytes_remaining')
+
+        # Numeric-robust: 'NA' becomes nan (now_then), and other non-numeric
+        # values (None, '', unexpected strings) cannot be assessed. Skip them
+        # rather than comparing -- a comparison would raise TypeError, which
+        # run_checks swallows as an error, silently leaving the drive
+        # unmonitored (the mj05 failure class).
+        if not isinstance(space_now, (int, float)) or space_now != space_now:
+            return None
+
+        if space_now >= self.low_space:
+            # Healthy: re-arm so the next descent below the threshold alerts.
+            self._low_space_active = False
+            return None
+
+        # Below threshold. LEVEL-TRIGGERED (not edge): spawn a scrub whenever
+        # space is low, rate-limited by a cooldown -- so a single missed or
+        # ineffective scrub no longer dooms the drive. (The mj05 incident was a
+        # one-shot high->low edge trigger with no retry.) Alert on descent-entry
+        # and on each (re)spawn, so a persistently full drive escalates instead
+        # of going silent after one message.
+        spawned = self._maybe_spawn_scrub()
+        first_entry = not self._low_space_active
+        self._low_space_active = True
+        if first_entry or spawned:
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
 
+    def _maybe_spawn_scrub(self):
+        """Spawn a scrub if configured and outside the cooldown window.
+
+        Returns True only if a scrub was actually launched this call.
+        (The empty/whitespace scrub_command guard lives in `_spawn_scrub`,
+        which returns False without launching.)
+        """
+        now = time.monotonic()
+        if (self._last_scrub_time is not None
+                and (now - self._last_scrub_time) < self.scrub_cooldown_s):
+            return False
+        # Stamp the cooldown only on a successful launch, so a failed launch
+        # (flock/OSError) is retried on the next low sample instead of blocked.
+        # _last_scrub_time is in-memory and resets on brokkr restart, which
+        # biases toward scrubbing (the safe direction) after a reboot loop.
+        if self._spawn_scrub():
+            self._last_scrub_time = now
+            return True
+        return False
+
     def _spawn_scrub(self):
-        """Spawn detached scrub process if scrub_command is configured."""
+        """Spawn a detached scrub process if scrub_command is configured.
+
+        Returns True on a successful launch, False otherwise. If `scrub_log` is
+        set, the scrub's combined stdout/stderr is appended there so a scrub
+        that runs but frees nothing is diagnosable instead of silently lost.
+        """
         if not self.scrub_command or not self.scrub_command.strip():
-            return
+            return False
         lock_file = "/tmp/hamma_scrub.lock"
+        log_fh = None
+        out = subprocess.DEVNULL
+        err = subprocess.DEVNULL
         try:
+            if self.scrub_log:
+                try:
+                    log_fh = open(self.scrub_log, "ab")
+                    out = log_fh
+                    err = subprocess.STDOUT
+                except OSError as e:
+                    self.logger.warning(
+                        "Could not open scrub_log %s (%s); discarding scrub output",
+                        self.scrub_log, e)
             cmd = ["flock", "-n", lock_file] + shlex.split(self.scrub_command)
             subprocess.Popen(
                 cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=out,
+                stderr=err,
                 start_new_session=True,
             )
             self.logger.info("Spawned scrub: %s", " ".join(cmd))
+            return True
         except (OSError, ValueError) as e:
             self.logger.error("Failed to spawn scrub: %s", e)
+            return False
+        finally:
+            if log_fh is not None:
+                try:
+                    log_fh.close()
+                except OSError:
+                    pass
 
     def check_battery_voltage(self, input_data):
         """

--- a/tests/python/test_state_monitor.py
+++ b/tests/python/test_state_monitor.py
@@ -115,16 +115,19 @@ def _make_monitor(**overrides):
 
 
 class TestCheckSensorDriveBoundary:
-    """check_sensor_drive must fire when pre lands exactly on low_space.
+    """check_sensor_drive fires whenever bytes_remaining is below low_space.
 
-    Real-world miss (mj07, 2026-05-28 15:25:03 UTC):
-    bytes_remaining went from 100.0 -> 99.96 GB. Strict `>` against
-    low_space=100 missed the edge. After that, bytes_remaining only
-    decreased, so no future edge could ever fire.
+    As of the mj05 fix (2026-07-11) the check is LEVEL-triggered, not edge-
+    triggered: it fires on any below-threshold sample (rate-limited by a
+    cooldown), so the old edge-only miss modes are moot. Historical context:
+    - mj07 (2026-05-28): 100.0 -> 99.96 GB missed by strict `>`.
+    - mj05 (2026-07-11): edge fired at most once; a single missed/ineffective
+      scrub let the drive fill to 0 with no retry.
+    Level-triggering removes both. `now == low_space` is still NOT below.
     """
 
     def test_pre_exactly_at_threshold_fires(self):
-        """pre = low_space exactly; now below -> fires."""
+        """pre = low_space exactly; now below -> fires (level-triggered)."""
         m = _make_monitor(low_space=100)
         m._previous_data = {"bytes_remaining": _dv(100.0)}
         with patch.object(m, "_spawn_scrub") as spawn:
@@ -142,14 +145,17 @@ class TestCheckSensorDriveBoundary:
         spawn.assert_called_once()
         assert msg is not None
 
-    def test_both_below_threshold_no_fire(self):
-        """No edge if already below: pre=50, now=45 -> no fire."""
+    def test_both_below_threshold_fires_level_triggered(self):
+        """Already below (pre=50, now=45) -> STILL fires. This is the mj05 fix:
+        the old edge-only check did NOT fire here, so a drive that sat below
+        threshold never got a retry. Level-triggering fires every low sample
+        (cooldown-gated)."""
         m = _make_monitor(low_space=100)
         m._previous_data = {"bytes_remaining": _dv(50.0)}
         with patch.object(m, "_spawn_scrub") as spawn:
             msg = m.check_sensor_drive({"bytes_remaining": _dv(45.0)})
-        spawn.assert_not_called()
-        assert msg is None
+        spawn.assert_called_once()
+        assert msg is not None
 
     def test_both_above_threshold_no_fire(self):
         """No edge if still above: pre=200, now=150 -> no fire."""

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -68,11 +68,17 @@ def make_input_data(bytes_remaining):
     return {"bytes_remaining": FakeDataValue(bytes_remaining)}
 
 
-def make_monitor(scrub_command="", low_space=100, space_previous=150):
+def make_monitor(scrub_command="", low_space=100, space_previous=150,
+                 scrub_cooldown_s=1800, last_scrub_time=None,
+                 low_space_active=False, scrub_log=""):
     """Create a StateMonitor instance with test defaults."""
     mon = StateMonitor.__new__(StateMonitor)
     mon.low_space = low_space
     mon.scrub_command = scrub_command
+    mon.scrub_cooldown_s = scrub_cooldown_s
+    mon.scrub_log = scrub_log
+    mon._last_scrub_time = last_scrub_time
+    mon._low_space_active = low_space_active
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)
     return mon
@@ -98,18 +104,20 @@ class TestScrubSpawning:
         popen_cmd = mock_popen.call_args[0][0]
         assert "flock" in popen_cmd[0]
 
-    def test_no_scrub_when_already_below(self):
-        """No scrub if space was already below threshold (not a crossing)."""
+    def test_scrub_spawns_when_already_below_level_triggered(self):
+        """NEW CONTRACT (was test_no_scrub_when_already_below): a below-threshold
+        sample spawns even without a fresh high->low crossing. The old edge-only
+        behavior is the mj05 bug (one-shot, no retry); level-triggering fixes it."""
         mon = make_monitor(
             scrub_command="python3 /path/to/scrub.py --recover --purge --since auto",
-            space_previous=80,
+            space_previous=80,  # already below last cycle -> old code would NOT fire
         )
 
         with patch("subprocess.Popen") as mock_popen:
             msg = mon.check_sensor_drive(make_input_data(70))
 
-        assert msg is None
-        mock_popen.assert_not_called()
+        assert msg is not None
+        mock_popen.assert_called_once()
 
     def test_no_scrub_when_command_empty(self):
         """No scrub if scrub_command is empty."""
@@ -177,3 +185,118 @@ class TestScrubConfig:
         """Default scrub_command is empty string (disabled)."""
         mon = make_monitor(scrub_command="")
         assert mon.scrub_command == ""
+
+
+SCRUB_CMD = "python3 /path/to/scrub.py --recover --purge --since auto"
+
+
+class TestLevelTriggerRobustness:
+    """New contract: level-triggered, numeric-robust, cooldown-gated retry,
+    observable scrub output. Regression guard for the mj05 fill incident."""
+
+    def test_nan_sample_makes_no_decision(self):
+        """An 'NA' (-> nan) H&S sample: cannot assess -> no spawn, no alert, no error."""
+        mon = make_monitor(scrub_command=SCRUB_CMD)
+        with patch("subprocess.Popen") as popen:
+            msg = mon.check_sensor_drive(make_input_data("NA"))
+        assert msg is None
+        popen.assert_not_called()
+        mon.logger.error.assert_not_called()
+
+    def test_none_value_makes_no_decision_no_typeerror(self):
+        """A None/non-numeric value must not raise TypeError; treated as unassessable."""
+        mon = make_monitor(scrub_command=SCRUB_CMD)
+        with patch("subprocess.Popen") as popen:
+            msg = mon.check_sensor_drive(make_input_data(None))
+        assert msg is None
+        popen.assert_not_called()
+        mon.logger.error.assert_not_called()
+
+    def test_full_disk_zero_still_fires(self):
+        """bytes_remaining == 0 (a legitimately full disk) must still spawn."""
+        mon = make_monitor(scrub_command=SCRUB_CMD)
+        with patch("subprocess.Popen") as popen, patch("time.monotonic", return_value=1.0):
+            msg = mon.check_sensor_drive(make_input_data(0))
+        assert msg is not None
+        popen.assert_called_once()
+
+    def test_cooldown_suppresses_second_spawn_and_alert(self):
+        """Two below samples within cooldown -> one spawn, one alert."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_cooldown_s=1800)
+        with patch("subprocess.Popen") as popen:
+            with patch("time.monotonic", return_value=1000.0):
+                msg1 = mon.check_sensor_drive(make_input_data(70))
+            with patch("time.monotonic", return_value=1600.0):  # +600s, within cooldown
+                msg2 = mon.check_sensor_drive(make_input_data(65))
+        popen.assert_called_once()
+        assert msg1 is not None
+        assert msg2 is None
+
+    def test_cooldown_elapsed_respawns_and_realerts(self):
+        """After cooldown elapses while still low -> respawn AND re-alert (escalation)."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_cooldown_s=1800)
+        with patch("subprocess.Popen") as popen:
+            with patch("time.monotonic", return_value=1000.0):
+                mon.check_sensor_drive(make_input_data(70))
+            with patch("time.monotonic", return_value=3000.0):  # +2000s, past cooldown
+                msg2 = mon.check_sensor_drive(make_input_data(65))
+        assert popen.call_count == 2
+        assert msg2 is not None
+
+    def test_cooldown_not_stamped_when_launch_fails(self):
+        """If the scrub launch fails, cooldown is NOT armed -> next low sample retries."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_cooldown_s=1800)
+        with patch("subprocess.Popen", side_effect=OSError("flock missing")), \
+                patch("time.monotonic", return_value=1000.0):
+            mon.check_sensor_drive(make_input_data(70))
+        assert mon._last_scrub_time is None
+        mon.logger.error.assert_called()
+
+    def test_realarm_above_then_below_realerts(self):
+        """below -> above (re-arm, no alert) -> below again -> alert again."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_cooldown_s=1800)
+        with patch("subprocess.Popen"):
+            with patch("time.monotonic", return_value=1000.0):
+                m1 = mon.check_sensor_drive(make_input_data(70))
+                m2 = mon.check_sensor_drive(make_input_data(150))
+            with patch("time.monotonic", return_value=5000.0):  # past cooldown
+                m3 = mon.check_sensor_drive(make_input_data(70))
+        assert m1 is not None
+        assert m2 is None
+        assert m3 is not None
+
+    def test_no_duplicate_alert_while_staying_low(self):
+        """Staying low across cycles within cooldown -> only the first alert."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_cooldown_s=1800)
+        with patch("subprocess.Popen"):
+            with patch("time.monotonic", return_value=1000.0):
+                m1 = mon.check_sensor_drive(make_input_data(70))
+            with patch("time.monotonic", return_value=1100.0):
+                m2 = mon.check_sensor_drive(make_input_data(69))
+        assert m1 is not None
+        assert m2 is None
+
+    def test_scrub_output_redirected_to_log_when_configured(self):
+        """Observability: when scrub_log is set, scrub output goes to that file
+        (append), not /dev/null -- so a futile/failed scrub is diagnosable."""
+        mon = make_monitor(scrub_command=SCRUB_CMD, scrub_log="/tmp/hamma_scrub_auto.log")
+        fake_fh = MagicMock()
+        with patch("subprocess.Popen") as popen, \
+                patch("builtins.open", return_value=fake_fh) as mopen, \
+                patch("time.monotonic", return_value=1.0):
+            mon.check_sensor_drive(make_input_data(70))
+        mopen.assert_called_once_with("/tmp/hamma_scrub_auto.log", "ab")
+        kwargs = popen.call_args[1]
+        assert kwargs["stdout"] is fake_fh
+        assert kwargs["stderr"] == subprocess.STDOUT
+
+
+class TestInitWiresNewState:
+    """The three new state attributes must be initialized by the real __init__."""
+
+    def test_init_wires_cooldown_and_flags(self):
+        with patch.object(MODULE, "Notifier", MagicMock(), create=True):
+            mon = StateMonitor(method="slack")
+        assert mon._last_scrub_time is None
+        assert mon._low_space_active is False
+        assert mon.scrub_cooldown_s == 1800


### PR DESCRIPTION
## Why
mj05's AGS drive `/ags/data` filled to 0 bytes (Jul 2026). The data was real (~20,446 legit 22 MB triggers; brokkr had already copied ~20,400 to MJ — only 10 were missing). The **automated** scrub safety net did not keep the AGS side clear; the last effective drain was a *manual* scrub.

The auto-scrub trigger (`StateMonitor.check_sensor_drive`) had three code-visible weaknesses (independent of the — unprovable, logs rotated — question of whether it fired on the key day):
- **one-shot falling-edge**: fires at most once per high→low crossing, **never retries** while the drive stays low;
- **NA/nan/non-numeric fragility**: a `None`/string value raises `TypeError` that `run_checks` swallows, silently disabling the check;
- **silent failure**: scrub output → `/dev/null`, exit status ignored — a scrub that runs and frees nothing is invisible.

## What
- `check_sensor_drive` is now **level-triggered** (fires on any below-threshold sample), **cooldown-gated** (`scrub_cooldown_s`, default 1800s) so it retries without spamming, and **numeric-robust** (skips NA/nan/non-numeric; `0` still fires).
- Alerts **escalate**: on descent-entry and on each cooldown-gated respawn (not one-message-then-silence).
- `_spawn_scrub` returns success; cooldown is stamped **only on a successful launch**; scrub output is appended to `scrub_log` (config) instead of `/dev/null`.
- Config: adds `scrub_cooldown_s` + `scrub_log` to `[steps.state_monitor]`.

## Tests
- 34/34 state_monitor tests pass. TDD: 6 new-contract tests were watched to fail on the old code, then pass. Full suite 446 passed (3 pre-existing `test_hamma_noise` failures are an installed-`hamma` version issue, unrelated).

## Review trail (in this PR)
- `docs/scrub-trigger-fix-analysis.md` — root cause + 3-way adversarial red-team + debugger adjudication (my first nan theory was **refuted** and the report re-scoped honestly).
- `docs/scrub-fix-assurance-report.md` — effectiveness + peer review. **Honest bottom line: this fix alone is not a guarantee of no recurrence.**

## Known residual (tracked follow-ups, NOT closed here)
1. Telemetry blind spot — trigger still depends on AGS-pushed `bytes_remaining`; needs a direct `df /ags/data` probe.
2. `/media/pi/DATA??` free space is unmonitored (DATA55 is also full) — needs a local `disk_usage` check.
3. Futile-scrub detection (freed-bytes verification).

Not deployed to any unit yet (deploy via normal `git pull` + brokkr restart after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)