### PR TITLE
Automate manual post-install steps + install hardening (HAM-120)

### DIFF
--- a/files/hamma-cleanup-stale-mountpoints.service
+++ b/files/hamma-cleanup-stale-mountpoints.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Remove stale udisks2 orphan mountpoint dirs for HAMMA DATA?? drives
+Documentation=https://github.com/hamma-dev/sensor-log
+# A dirty unmount (hard reset / brown-out) leaves an empty /media/pi/DATA?? dir.
+# On next boot udisks sees it and mounts the drive at a suffixed path
+# (/media/pi/DATA071) that brokkr's strict DATA?? glob misses, so science data
+# silently falls back to the SD card. Remove the empty orphan dirs before udisks
+# auto-mounts so the drive lands at its canonical mountpoint.
+After=local-fs.target
+Before=udisks2.service multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+# rmdir removes ONLY empty dirs; an active mountpoint is busy and is skipped,
+# so this is a safe no-op once drives are correctly mounted.
+ExecStart=/bin/sh -c 'for d in /media/pi/DATA??; do [ -d "$d" ] && rmdir "$d" 2>/dev/null; done; exit 0'
+
+[Install]
+WantedBy=multi-user.target

--- a/files/hamma-cleanup-stale-mountpoints.service
+++ b/files/hamma-cleanup-stale-mountpoints.service
@@ -2,12 +2,19 @@
 Description=Remove stale udisks2 orphan mountpoint dirs for HAMMA DATA?? drives
 Documentation=https://github.com/hamma-dev/sensor-log
 # A dirty unmount (hard reset / brown-out) leaves an empty /media/pi/DATA?? dir.
-# On next boot udisks sees it and mounts the drive at a suffixed path
-# (/media/pi/DATA071) that brokkr's strict DATA?? glob misses, so science data
-# silently falls back to the SD card. Remove the empty orphan dirs before udisks
-# auto-mounts so the drive lands at its canonical mountpoint.
+# On next boot the drive gets mounted at a suffixed path (/media/pi/DATA071)
+# that brokkr's strict DATA?? glob misses, so science data silently falls back
+# to the SD card. Remove the empty orphan dirs before the drive is mounted.
+#
+# Ordering note: brokkr (not udisks) is the actual mounter — it issues
+# `udisksctl mount` at runtime via mount_glob, and brokkr-hamma-default.service
+# starts as part of multi-user.target. So Before=multi-user.target /
+# Before=brokkr-hamma-default.service is the load-bearing guarantee that the
+# rmdir runs first; Before=udisks2.service is belt-and-suspenders (udisks2 is
+# D-Bus-activated, so that edge is not by itself sufficient). Do not drop the
+# multi-user.target / brokkr ordering.
 After=local-fs.target
-Before=udisks2.service multi-user.target
+Before=brokkr-hamma-default.service udisks2.service multi-user.target
 
 [Service]
 Type=oneshot

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -326,6 +326,31 @@ check_post_install_config() {
     else
         warn "datasync user missing — hamma_download.py cannot pull data (HAM-80)"
     fi
+
+    # pi-owned paths must not be root-owned (breaks git pull / pip). Recurring
+    # fallout from `sudo` without -H on older installs (sensor-log #78/#11/#33).
+    check_file_ownership "/home/pi/dev/mjolnir-hamma" "pi" "mjolnir-hamma repo owned by pi"
+    if [[ -e /home/pi/.ssh/config ]]; then
+        check_file_ownership "/home/pi/.ssh/config" "pi" "SSH config owned by pi"
+    fi
+}
+
+check_hamma_repo_access() {
+    print_section "HAMMA Repo Access (deploy key)"
+
+    if [[ ! -d /home/pi/dev/hamma/.git ]]; then
+        skip "hamma repo not present — cannot test deploy key"
+        return
+    fi
+
+    # The private pbitzer/hamma repo needs the ed25519 deploy key authorized on
+    # GitHub. Key generation is automated, but authorization is a manual step
+    # that gets missed (sensor-log #11). ls-remote exercises the key.
+    if sudo -H -u pi git -C /home/pi/dev/hamma ls-remote >/dev/null 2>&1; then
+        pass "hamma deploy key authorized (git ls-remote works)"
+    else
+        fail "hamma deploy key not working — add id_ed25519.pub to pbitzer/hamma deploy keys"
+    fi
 }
 
 check_server_connection() {
@@ -471,6 +496,7 @@ main() {
 
     if $full_check; then
         check_server_connection
+        check_hamma_repo_access
     else
         print_section "Server Connection"
         skip "Use --full to test server connection"

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -346,7 +346,8 @@ check_hamma_repo_access() {
     # The private pbitzer/hamma repo needs the ed25519 deploy key authorized on
     # GitHub. Key generation is automated, but authorization is a manual step
     # that gets missed (sensor-log #11). ls-remote exercises the key.
-    if sudo -H -u pi git -C /home/pi/dev/hamma ls-remote >/dev/null 2>&1; then
+    if sudo -H -u pi env GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' \
+            git -C /home/pi/dev/hamma ls-remote >/dev/null 2>&1; then
         pass "hamma deploy key authorized (git ls-remote works)"
     else
         fail "hamma deploy key not working — add id_ed25519.pub to pbitzer/hamma deploy keys"

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -286,6 +286,48 @@ check_brokkr_status() {
     fi
 }
 
+check_post_install_config() {
+    print_section "Post-Install Configuration"
+
+    # Timezone must be UTC — a local timezone silently costs the daily
+    # compression plugin hours of quiet-time each day (HAM-71).
+    local tz
+    tz=$(timedatectl show -p Timezone --value 2>/dev/null || cat /etc/timezone 2>/dev/null || echo "unknown")
+    if [[ "$tz" == "UTC" || "$tz" == "Etc/UTC" ]]; then
+        pass "Timezone is UTC"
+    else
+        fail "Timezone is '$tz' (expected UTC) — run: sudo timedatectl set-timezone UTC"
+    fi
+
+    # gpiozero must import in ltgenv — gpiozero 2.0 on Python 3.7 raises
+    # ModuleNotFoundError and breaks relay.py (HAM-84).
+    local ltgenv_py="/home/pi/dev/ltgenv/bin/python"
+    if [[ -x "$ltgenv_py" ]]; then
+        if "$ltgenv_py" -c "import gpiozero" 2>/dev/null; then
+            pass "gpiozero imports in ltgenv"
+        else
+            fail "gpiozero fails to import in ltgenv (pin gpiozero<2.0 on Python 3.7 — HAM-84)"
+        fi
+    else
+        skip "ltgenv python not found — cannot check gpiozero"
+    fi
+
+    # .googlechat key enables state_monitor notifications (HAM-118). Optional,
+    # so a miss is a warning, not a failure.
+    if [[ -f /home/pi/.googlechat ]]; then
+        pass ".googlechat notification key present"
+    else
+        warn ".googlechat key missing — state_monitor notifications disabled (HAM-118)"
+    fi
+
+    # datasync user enables hamma_download.py pulls (HAM-80).
+    if id datasync >/dev/null 2>&1; then
+        pass "datasync user exists"
+    else
+        warn "datasync user missing — hamma_download.py cannot pull data (HAM-80)"
+    fi
+}
+
 check_server_connection() {
     print_section "Server Connection"
 
@@ -425,6 +467,7 @@ main() {
     check_wifi_services
     check_file_setup
     check_brokkr_status
+    check_post_install_config
 
     if $full_check; then
         check_server_connection

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -1,15 +1,19 @@
 """
-Tests for the HAM-120 install-gap fixes.
+Tests for the HAM-120 install-gap fixes and follow-on install hardening.
 
-These run install.sh in --dry-run mode and assert the manifest contains the
-new post-install operations:
+Most tests run install.sh in --dry-run mode and assert the manifest contains the
+expected operations; TestBestEffortNonFatal instead sources the lib functions
+under `set -e` in a sandbox to prove the Phase 7 steps never abort the install.
 
-  - HAM-84:  gpiozero is installed, pinned <2.0 on Python 3.7
-  - HAM-118: .googlechat notification key is fetched from the server
-  - HAM-80:  datasync user is provisioned locally
-
-All assertions are against the dry-run manifest, matching the pattern in
-test_script_execution.py.
+Coverage:
+  - HAM-84:  gpiozero installed, pinned <2.0 on Python <=3.7 (auto-heal above)
+  - HAM-118: .googlechat notification key fetched from the server
+  - HAM-80:  datasync user provisioned locally
+  - HAM-158: notifiers installed editable
+  - legacy systemd unit cleanup, pi-ownership normalization
+  - stale-mountpoint cleanup oneshot (install + unit-file validity)
+  - --skip-postinstall gating (with positive control)
+  - best-effort / non-fatal behavior of every Phase 7 step under set -e
 """
 
 import json
@@ -200,7 +204,14 @@ class TestMountpointCleanup:
         unit = repo_root / "files" / "hamma-cleanup-stale-mountpoints.service"
         text = unit.read_text()
         assert "Type=oneshot" in text
-        assert "Before=udisks2.service" in text, "must run before udisks auto-mount"
+        # Load-bearing ordering: must run before the mounter (brokkr / multi-user).
+        assert "Before=multi-user.target" in text, "must be ordered before multi-user.target"
+        # [Install]/WantedBy is required or `systemctl enable` is a silent no-op
+        # and the whole feature is dead.
+        assert "[Install]" in text and "WantedBy=multi-user.target" in text, \
+            "unit needs [Install] WantedBy or enable does nothing"
+        # ExecStart must target the DATA?? glob — the actual thing being fixed.
+        assert "/media/pi/DATA??" in text, "ExecStart must target the /media/pi/DATA?? glob"
         assert "rmdir" in text and "rm -rf" not in text, \
             "cleanup must use rmdir (empty-only), never rm -rf"
 
@@ -215,7 +226,7 @@ class TestBestEffortNonFatal:
     function returned instead of aborting.
     """
 
-    def _harness(self, unified_install_dir, func_call):
+    def _harness(self, unified_install_dir, func_call, prelude=""):
         lib = unified_install_dir / "lib"
         script = f"""
             set -e
@@ -232,46 +243,62 @@ class TestBestEffortNonFatal:
             scp() {{ return 1; }}           # forced failure (guarded)
             systemctl() {{ return 1; }}     # forced failure (guarded)
             rm() {{ return 1; }}            # forced failure (guarded)
-            sudo() {{ "$@"; }}              # strip sudo, run the (stubbed) command
+            # Strip sudo's own flags (-H, -u <user>, ...) so the SHADOWED command
+            # is what actually runs — otherwise "sudo -H -u pi scp" would exec
+            # "-H" and never reach the scp shadow.
+            sudo() {{ while [[ "${{1:-}}" == -* ]]; do if [[ "$1" == "-u" ]]; then shift 2; else shift; fi; done; "$@"; }}
             DRY_RUN=false
+            {prelude}
             {func_call}
             echo "HARNESS_REACHED_END"
         """
         return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
 
-    def test_setup_datasync_local_never_aborts(self, unified_install_dir):
-        r = self._harness(unified_install_dir, "setup_datasync_local")
+    def _assert_reached_end(self, r, func):
         assert "HARNESS_REACHED_END" in r.stdout, (
-            "setup_datasync_local aborted under set -e when a command failed "
+            f"{func} aborted under set -e when a command failed "
             f"(best-effort contract violated).\nstdout: {r.stdout}\nstderr: {r.stderr}"
         )
-        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+        assert r.returncode == 0, f"non-zero exit: {r.returncode}\nstderr: {r.stderr}"
 
-    def test_fetch_notification_key_never_aborts(self, unified_install_dir, tmp_path):
-        # Point HOME at an empty tmp dir so the key_dst existence check is false
-        # and the scp path (forced-fail) is exercised.
+    def test_setup_datasync_local_never_aborts(self, unified_install_dir):
+        r = self._harness(unified_install_dir, "setup_datasync_local")
+        self._assert_reached_end(r, "setup_datasync_local")
+        # The forced-fail usermod guard must have fired (proves we reached the body).
+        assert "Could not add datasync to pi group" in r.stdout
+
+    def test_fetch_notification_key_never_aborts(self, unified_install_dir):
+        # /home/pi/.googlechat is absent on the test host, so the scp branch runs;
+        # the fixed sudo shim ensures the scp shadow (forced-fail) is exercised.
         r = self._harness(unified_install_dir, "fetch_notification_key")
-        assert "HARNESS_REACHED_END" in r.stdout, (
-            "fetch_notification_key aborted under set -e on scp failure.\n"
-            f"stdout: {r.stdout}\nstderr: {r.stderr}"
-        )
-        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+        self._assert_reached_end(r, "fetch_notification_key")
+        assert "Could not fetch .googlechat key" in r.stdout, \
+            "scp-failure guard not exercised (sudo shim may not reach the scp shadow)"
 
     def test_normalize_pi_ownership_never_aborts(self, unified_install_dir):
-        r = self._harness(unified_install_dir, "normalize_pi_ownership")
-        assert "HARNESS_REACHED_END" in r.stdout, (
-            "normalize_pi_ownership aborted under set -e on chown/chmod failure.\n"
-            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        # Point PI_OWN_PATHS at real tmp dirs so the per-path chown guard actually
+        # runs (with chown forced to fail), not just the trailing chmod.
+        # `command mkdir` bypasses the shadowed no-op mkdir so the dirs really exist.
+        prelude = (
+            'D=$(mktemp -d); command mkdir -p "$D/dev" "$D/.ssh"; '
+            'export PI_OWN_PATHS="$D/dev $D/.ssh"'
         )
-        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+        r = self._harness(unified_install_dir, "normalize_pi_ownership", prelude=prelude)
+        self._assert_reached_end(r, "normalize_pi_ownership")
+        assert "Could not normalize ownership" in r.stdout, \
+            "per-path chown guard not exercised"
 
     def test_cleanup_legacy_services_never_aborts(self, unified_install_dir):
-        r = self._harness(unified_install_dir, "cleanup_legacy_services")
-        assert "HARNESS_REACHED_END" in r.stdout, (
-            "cleanup_legacy_services aborted under set -e.\n"
-            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        # Point LEGACY_SYSTEMD_DIR at a tmp dir containing the legacy unit files
+        # so the loop body (systemctl/rm/reset-failed, all forced-fail) runs.
+        prelude = (
+            'D=$(mktemp -d); : > "$D/autossh-hamma.service"; : > "$D/brokkr-hamma.service"; '
+            'export LEGACY_SYSTEMD_DIR="$D"'
         )
-        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+        r = self._harness(unified_install_dir, "cleanup_legacy_services", prelude=prelude)
+        self._assert_reached_end(r, "cleanup_legacy_services")
+        assert "Could not remove" in r.stdout, \
+            "rm-failure guard not exercised (loop body did not run)"
 
 
 class TestSkipPostinstall:

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -1,0 +1,141 @@
+"""
+Tests for the HAM-120 install-gap fixes.
+
+These run install.sh in --dry-run mode and assert the manifest contains the
+new post-install operations:
+
+  - HAM-84:  gpiozero is installed, pinned <2.0 on Python 3.7
+  - HAM-118: .googlechat notification key is fetched from the server
+  - HAM-80:  datasync user is provisioned locally
+
+All assertions are against the dry-run manifest, matching the pattern in
+test_script_execution.py.
+"""
+
+import json
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+
+def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=None):
+    """Run install.sh --wifi --dry-run and return the parsed manifest.
+
+    By default brokkr and post-install run (only packages/hardware/extras are
+    skipped) so the gpiozero and Phase 7 operations land in the manifest.
+    """
+    work_dir.mkdir(parents=True, exist_ok=True)
+    manifest_file = work_dir / "manifest.json"
+    env = os.environ.copy()
+    env["MANIFEST_FILE"] = str(manifest_file)
+    env["HOME"] = str(work_dir)
+    env["FILES_DIR"] = str(unified_install_dir.parent / "files")
+    env["SCRIPTS_DIR"] = str(unified_install_dir.parent / "scripts")
+    if path_prepend:
+        env["PATH"] = f"{path_prepend}:{env['PATH']}"
+
+    args = ["01", "--wifi", "--dry-run",
+            "--skip-packages", "--skip-hardware", "--skip-extras"]
+    if extra_args:
+        args += extra_args
+
+    result = subprocess.run(
+        ["bash", str(unified_install_dir / "install.sh")] + args,
+        capture_output=True, text=True, env=env, cwd=str(unified_install_dir),
+    )
+    if not manifest_file.exists():
+        pytest.fail(f"Manifest not created.\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    return json.loads(manifest_file.read_text())
+
+
+def _pip_packages(manifest):
+    return [op.get("package", "") for op in manifest["operations"]
+            if op.get("type") == "pip_install"]
+
+
+class TestGpiozeroPin:
+    """HAM-84: gpiozero must be pinned <2.0 on Python 3.7."""
+
+    def test_gpiozero_still_installed(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "gpz")
+        assert any("gpiozero" in p for p in _pip_packages(manifest)), \
+            "gpiozero pip_install op missing from brokkr install"
+
+    def test_gpiozero_pinned_on_python37(self, unified_install_dir, tmp_path):
+        """With a Python 3.7 interpreter, gpiozero must be pinned <2.0."""
+        stub_dir = tmp_path / "stub"
+        stub_dir.mkdir()
+        stub = stub_dir / "python3"
+        stub.write_text(textwrap.dedent("""\
+            #!/bin/bash
+            # Report minor version 7 for the gpiozero detection query;
+            # delegate everything else to the real python3.
+            if [[ "$*" == *"version_info.minor"* ]]; then echo 7; exit 0; fi
+            exec /usr/bin/python3 "$@" 2>/dev/null || exec python3 "$@"
+        """))
+        stub.chmod(0o755)
+
+        manifest = _run_install(unified_install_dir, tmp_path / "gpz37",
+                                path_prepend=str(stub_dir))
+        assert any("gpiozero<2.0" in p for p in _pip_packages(manifest)), \
+            f"gpiozero not pinned <2.0 on Python 3.7. pip ops: {_pip_packages(manifest)}"
+
+    def test_gpiozero_unpinned_on_newer_python(self, unified_install_dir, tmp_path):
+        """On Python >=3.8 the pin must NOT be applied (auto-heals off Buster)."""
+        stub_dir = tmp_path / "stub311"
+        stub_dir.mkdir()
+        stub = stub_dir / "python3"
+        stub.write_text(textwrap.dedent("""\
+            #!/bin/bash
+            if [[ "$*" == *"version_info.minor"* ]]; then echo 11; exit 0; fi
+            exec /usr/bin/python3 "$@" 2>/dev/null || exec python3 "$@"
+        """))
+        stub.chmod(0o755)
+
+        manifest = _run_install(unified_install_dir, tmp_path / "gpz311",
+                                path_prepend=str(stub_dir))
+        gpz = [p for p in _pip_packages(manifest) if "gpiozero" in p]
+        assert gpz, "gpiozero op missing"
+        assert not any("<2.0" in p for p in gpz), \
+            f"gpiozero should be unpinned on Python 3.11, got: {gpz}"
+
+
+class TestNotificationKey:
+    """HAM-118: .googlechat key fetched from the server."""
+
+    def test_googlechat_fetch_present(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "gchat")
+        scp_ops = [op for op in manifest["operations"]
+                   if op.get("type") == "command" and ".googlechat" in op.get("cmd", "")]
+        assert len(scp_ops) >= 1, "No .googlechat fetch operation found"
+        assert "scp" in scp_ops[0]["cmd"], "googlechat fetch should use scp"
+        assert scp_ops[0].get("best_effort") == "true", \
+            "googlechat fetch must be marked best_effort (non-fatal)"
+
+
+class TestDatasyncUser:
+    """HAM-80: local datasync user provisioning."""
+
+    def test_datasync_user_created(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "ds")
+        cmds = [op.get("cmd", "") for op in manifest["operations"]
+                if op.get("type") == "command"]
+        assert any("useradd" in c and "datasync" in c for c in cmds), \
+            "No datasync useradd operation found"
+        assert any("usermod" in c and "datasync" in c for c in cmds), \
+            "datasync not added to pi group"
+        assert any("chmod o+rx /media/pi" in c for c in cmds), \
+            "/media/pi permission not set for datasync"
+
+
+class TestSkipPostinstall:
+    """--skip-postinstall must suppress the Phase 7 operations."""
+
+    def test_skip_postinstall_suppresses_ops(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "skip",
+                                extra_args=["--skip-postinstall"])
+        blob = json.dumps(manifest)
+        assert ".googlechat" not in blob, "googlechat op present despite --skip-postinstall"
+        assert "datasync" not in blob, "datasync op present despite --skip-postinstall"

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -21,7 +21,7 @@ import pytest
 
 
 def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=None,
-                 return_result=False):
+                 return_result=False, skip_hardware=True):
     """Run install.sh --wifi --dry-run and return the parsed manifest.
 
     By default brokkr and post-install run (only packages/hardware/extras are
@@ -39,8 +39,9 @@ def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=No
     if path_prepend:
         env["PATH"] = f"{path_prepend}:{env['PATH']}"
 
-    args = ["01", "--wifi", "--dry-run",
-            "--skip-packages", "--skip-hardware", "--skip-extras"]
+    args = ["01", "--wifi", "--dry-run", "--skip-packages", "--skip-extras"]
+    if skip_hardware:
+        args.append("--skip-hardware")
     if extra_args:
         args += extra_args
 
@@ -178,6 +179,30 @@ class TestOwnershipNormalize:
                 if op.get("type") == "command"]
         assert any("chown -R pi:pi /home/pi/dev" in c for c in cmds), \
             "pi ownership normalization of /home/pi/dev missing"
+
+
+class TestMountpointCleanup:
+    """sensor-log #52: stale-mountpoint cleanup oneshot installed + enabled."""
+
+    def test_cleanup_unit_installed_and_enabled(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "mp", skip_hardware=False)
+        unit = "hamma-cleanup-stale-mountpoints.service"
+        copies = [op for op in manifest["operations"]
+                  if op.get("type") == "copy" and unit in op.get("dst", "")]
+        assert copies, f"{unit} not copied into /etc/systemd/system"
+        enables = [op for op in manifest["operations"]
+                   if op.get("type") == "systemctl" and op.get("action") == "enable"
+                   and unit in op.get("service", "")]
+        assert enables, f"{unit} not enabled"
+
+    def test_cleanup_unit_file_is_valid(self, repo_root):
+        """The shipped unit must be well-formed and safe (rmdir-only)."""
+        unit = repo_root / "files" / "hamma-cleanup-stale-mountpoints.service"
+        text = unit.read_text()
+        assert "Type=oneshot" in text
+        assert "Before=udisks2.service" in text, "must run before udisks auto-mount"
+        assert "rmdir" in text and "rm -rf" not in text, \
+            "cleanup must use rmdir (empty-only), never rm -rf"
 
 
 class TestBestEffortNonFatal:

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -130,6 +130,57 @@ class TestDatasyncUser:
             "/media/pi permission not set for datasync"
 
 
+class TestBestEffortNonFatal:
+    """Phase 7 steps must never abort the install under set -e, even when their
+    privileged commands fail. Runtime (non-dry-run) coverage of the guards.
+
+    The harness sources software.sh under `set -e` and shadows every mutating
+    command with a shell function so nothing touches the real system; some are
+    forced to fail to exercise the guards. Reaching the END marker proves the
+    function returned instead of aborting.
+    """
+
+    def _harness(self, unified_install_dir, func_call):
+        lib = unified_install_dir / "lib"
+        script = f"""
+            set -e
+            source '{lib}/common.sh'
+            source '{lib}/software.sh'
+            # Sandbox: shadow all mutating commands; force the ones the guards
+            # must tolerate to FAIL, so an unguarded command would trip set -e.
+            id() {{ return 1; }}            # datasync user "absent" -> useradd path
+            useradd() {{ return 0; }}
+            usermod() {{ return 1; }}       # forced failure (guarded)
+            mkdir() {{ return 0; }}
+            chmod() {{ return 1; }}         # forced failure (guarded)
+            chown() {{ return 1; }}         # forced failure (guarded)
+            scp() {{ return 1; }}           # forced failure (guarded)
+            sudo() {{ "$@"; }}              # strip sudo, run the (stubbed) command
+            DRY_RUN=false
+            {func_call}
+            echo "HARNESS_REACHED_END"
+        """
+        return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+    def test_setup_datasync_local_never_aborts(self, unified_install_dir):
+        r = self._harness(unified_install_dir, "setup_datasync_local")
+        assert "HARNESS_REACHED_END" in r.stdout, (
+            "setup_datasync_local aborted under set -e when a command failed "
+            f"(best-effort contract violated).\nstdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+
+    def test_fetch_notification_key_never_aborts(self, unified_install_dir, tmp_path):
+        # Point HOME at an empty tmp dir so the key_dst existence check is false
+        # and the scp path (forced-fail) is exercised.
+        r = self._harness(unified_install_dir, "fetch_notification_key")
+        assert "HARNESS_REACHED_END" in r.stdout, (
+            "fetch_notification_key aborted under set -e on scp failure.\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+
+
 class TestSkipPostinstall:
     """--skip-postinstall must suppress the Phase 7 operations."""
 

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -134,6 +134,52 @@ class TestDatasyncUser:
             "/media/pi permission not set for datasync"
 
 
+class TestNotifiersEditable:
+    """HAM-158: notifiers installed editable so git-pulls deploy."""
+
+    def test_notifiers_editable(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "notif")
+        notif = [op for op in manifest["operations"]
+                 if op.get("type") == "pip_install" and "notifiers" in op.get("package", "")]
+        assert notif, "notifiers pip_install op missing"
+        assert notif[0].get("editable") == "true", \
+            f"notifiers should be installed editable, got: {notif[0]}"
+
+    def test_brokkr_and_sindri_stay_non_editable(self, unified_install_dir, tmp_path):
+        """Guard: only notifiers flips to editable, not brokkr/serviceinstaller."""
+        manifest = _run_install(unified_install_dir, tmp_path / "notif2")
+        for pkg in ("brokkr", "serviceinstaller"):
+            ops = [op for op in manifest["operations"]
+                   if op.get("type") == "pip_install"
+                   and op.get("package", "").endswith(pkg)]
+            assert ops, f"{pkg} pip_install op missing"
+            assert ops[0].get("editable") != "true", f"{pkg} should stay non-editable"
+
+
+class TestLegacyServiceCleanup:
+    """sensor-log #43/#9: retired pre-default units removed on install."""
+
+    def test_legacy_units_removed(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "legacy")
+        cmds = [op.get("cmd", "") for op in manifest["operations"]
+                if op.get("type") == "command"]
+        assert any("rm -f /etc/systemd/system/autossh-hamma.service" in c for c in cmds), \
+            "legacy autossh-hamma.service not scheduled for removal"
+        assert any("rm -f /etc/systemd/system/brokkr-hamma.service" in c for c in cmds), \
+            "legacy brokkr-hamma.service not scheduled for removal"
+
+
+class TestOwnershipNormalize:
+    """sensor-log #78/#11/#33: pi paths normalized to pi ownership."""
+
+    def test_ownership_normalized(self, unified_install_dir, tmp_path):
+        manifest = _run_install(unified_install_dir, tmp_path / "own")
+        cmds = [op.get("cmd", "") for op in manifest["operations"]
+                if op.get("type") == "command"]
+        assert any("chown -R pi:pi /home/pi/dev" in c for c in cmds), \
+            "pi ownership normalization of /home/pi/dev missing"
+
+
 class TestBestEffortNonFatal:
     """Phase 7 steps must never abort the install under set -e, even when their
     privileged commands fail. Runtime (non-dry-run) coverage of the guards.
@@ -159,6 +205,8 @@ class TestBestEffortNonFatal:
             chmod() {{ return 1; }}         # forced failure (guarded)
             chown() {{ return 1; }}         # forced failure (guarded)
             scp() {{ return 1; }}           # forced failure (guarded)
+            systemctl() {{ return 1; }}     # forced failure (guarded)
+            rm() {{ return 1; }}            # forced failure (guarded)
             sudo() {{ "$@"; }}              # strip sudo, run the (stubbed) command
             DRY_RUN=false
             {func_call}
@@ -180,6 +228,22 @@ class TestBestEffortNonFatal:
         r = self._harness(unified_install_dir, "fetch_notification_key")
         assert "HARNESS_REACHED_END" in r.stdout, (
             "fetch_notification_key aborted under set -e on scp failure.\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+
+    def test_normalize_pi_ownership_never_aborts(self, unified_install_dir):
+        r = self._harness(unified_install_dir, "normalize_pi_ownership")
+        assert "HARNESS_REACHED_END" in r.stdout, (
+            "normalize_pi_ownership aborted under set -e on chown/chmod failure.\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+        assert r.returncode == 0, f"non-zero exit: {r.returncode}"
+
+    def test_cleanup_legacy_services_never_aborts(self, unified_install_dir):
+        r = self._harness(unified_install_dir, "cleanup_legacy_services")
+        assert "HARNESS_REACHED_END" in r.stdout, (
+            "cleanup_legacy_services aborted under set -e.\n"
             f"stdout: {r.stdout}\nstderr: {r.stderr}"
         )
         assert r.returncode == 0, f"non-zero exit: {r.returncode}"

--- a/tests/unified/test_postinstall.py
+++ b/tests/unified/test_postinstall.py
@@ -20,11 +20,14 @@ import textwrap
 import pytest
 
 
-def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=None):
+def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=None,
+                 return_result=False):
     """Run install.sh --wifi --dry-run and return the parsed manifest.
 
     By default brokkr and post-install run (only packages/hardware/extras are
     skipped) so the gpiozero and Phase 7 operations land in the manifest.
+    With return_result=True, returns (manifest, CompletedProcess) so callers
+    can also assert on stdout.
     """
     work_dir.mkdir(parents=True, exist_ok=True)
     manifest_file = work_dir / "manifest.json"
@@ -47,7 +50,8 @@ def _run_install(unified_install_dir, work_dir, extra_args=None, path_prepend=No
     )
     if not manifest_file.exists():
         pytest.fail(f"Manifest not created.\nstdout: {result.stdout}\nstderr: {result.stderr}")
-    return json.loads(manifest_file.read_text())
+    manifest = json.loads(manifest_file.read_text())
+    return (manifest, result) if return_result else manifest
 
 
 def _pip_packages(manifest):
@@ -185,8 +189,20 @@ class TestSkipPostinstall:
     """--skip-postinstall must suppress the Phase 7 operations."""
 
     def test_skip_postinstall_suppresses_ops(self, unified_install_dir, tmp_path):
-        manifest = _run_install(unified_install_dir, tmp_path / "skip",
-                                extra_args=["--skip-postinstall"])
+        manifest, result = _run_install(unified_install_dir, tmp_path / "skip",
+                                        extra_args=["--skip-postinstall"],
+                                        return_result=True)
         blob = json.dumps(manifest)
         assert ".googlechat" not in blob, "googlechat op present despite --skip-postinstall"
         assert "datasync" not in blob, "datasync op present despite --skip-postinstall"
+        # Positively confirm the skip branch actually executed (not just that
+        # Phase 7 happens to emit nothing for some unrelated reason).
+        assert "Skipping post-install configuration" in result.stdout, \
+            f"skip branch did not run.\nstdout: {result.stdout}"
+
+    def test_postinstall_runs_by_default(self, unified_install_dir, tmp_path):
+        """Positive control: without the flag, Phase 7 ops ARE present."""
+        manifest = _run_install(unified_install_dir, tmp_path / "noskip")
+        blob = json.dumps(manifest)
+        assert ".googlechat" in blob, "googlechat op missing in a normal run"
+        assert "datasync" in blob, "datasync op missing in a normal run"

--- a/unified_install/install.sh
+++ b/unified_install/install.sh
@@ -395,8 +395,10 @@ echo ""
 
 if [[ "$SKIP_POSTINSTALL" != "true" ]]; then
     source "$SCRIPT_DIR/lib/software.sh"
+    cleanup_legacy_services     # sensor-log #43/#9: drop retired pre-default units
     fetch_notification_key      # HAM-118: .googlechat key for state_monitor
     setup_datasync_local        # HAM-80: datasync account for hamma_download.py
+    normalize_pi_ownership      # sensor-log #78/#11/#33: fix root-owned pi paths
 else
     log_info "Skipping post-install configuration (--skip-postinstall)"
 fi

--- a/unified_install/install.sh
+++ b/unified_install/install.sh
@@ -44,6 +44,7 @@ SKIP_BROKKR=false
 SKIP_HARDWARE=false
 SKIP_EXTRAS=false
 SKIP_HAMMA=false
+SKIP_POSTINSTALL=false
 CELLULAR_APN=""
 GENERATE_HAMMA_KEY=false
 HAMMA_ONLY=false
@@ -62,6 +63,7 @@ print_usage() {
     echo "  --skip-hardware     Skip hardware setup"
     echo "  --skip-extras       Skip sindri/pyltg/hamma installation"
     echo "  --skip-hamma        Skip HAMMA installation (requires SSH key for private repo)"
+    echo "  --skip-postinstall  Skip post-install config (.googlechat key, datasync user)"
     echo "  -h, --help          Show this help message"
     echo ""
     echo "Cellular options:"
@@ -100,6 +102,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-extras)
             SKIP_EXTRAS=true
+            shift
+            ;;
+        --skip-postinstall)
+            SKIP_POSTINSTALL=true
             shift
             ;;
         --skip-hamma)
@@ -372,6 +378,25 @@ if [[ "$SKIP_EXTRAS" != "true" ]]; then
     fi
 else
     log_info "Skipping additional software (--skip-extras)"
+fi
+
+echo ""
+
+# ============================================================================
+# PHASE 7: Post-install configuration
+# ============================================================================
+# Small, documented-but-previously-manual steps that kept getting skipped on
+# bring-up (HAM-120 umbrella). All best-effort — a failure here logs a warning
+# and never aborts the install.
+log_info "=== Phase 7: Post-install configuration ==="
+echo ""
+
+if [[ "$SKIP_POSTINSTALL" != "true" ]]; then
+    source "$SCRIPT_DIR/lib/software.sh"
+    fetch_notification_key      # HAM-118: .googlechat key for state_monitor
+    setup_datasync_local        # HAM-80: datasync account for hamma_download.py
+else
+    log_info "Skipping post-install configuration (--skip-postinstall)"
 fi
 
 echo ""

--- a/unified_install/install.sh
+++ b/unified_install/install.sh
@@ -278,8 +278,10 @@ log_step "Updating mjolnir-hamma repository..."
 
 REPO_PATH="/home/pi/dev/mjolnir-hamma"
 REPO_URL="https://github.com/hamma-dev/mjolnir-hamma.git"
-# TODO: Update this branch when releasing or changing version branches
-REPO_BRANCH="0.3.x"
+# Current mjolnir-hamma version branch. The self-update below only pulls when
+# the unit is already on this branch, so a stale value silently skips updates.
+# TODO: bump on each version-branch change (last: 0.3.x -> 0.4.x).
+REPO_BRANCH="0.4.x"
 
 if [[ "$DRY_RUN" == "true" ]]; then
     log_dry_run "git -C $REPO_PATH remote set-url origin $REPO_URL"

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -112,15 +112,27 @@ install_brokkr() {
     # --- Step 4: Install Python packages ---
     log_step "[Brokkr 4/4] Installing Python packages..."
 
+    # gpiozero 2.0 dropped Python 3.7 support (it imports importlib.metadata,
+    # which does not exist on 3.7), breaking `import gpiozero` and relay.py on
+    # Buster. Pin <2.0 on Python 3.7; newer Python can take the current release.
+    # (HAM-84 — mirrors the cartopy version-detection in install_pyltg.)
+    local python_minor
+    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)")
+    local gpiozero_spec="gpiozero"
+    if [[ "$python_minor" -le 7 ]]; then
+        gpiozero_spec="gpiozero<2.0"
+        log_info "Python 3.$python_minor detected, pinning $gpiozero_spec (HAM-84)"
+    fi
+
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "pip install $INSTALL_PATH/brokkr (as pi user)"
         log_dry_run "pip install $INSTALL_PATH/serviceinstaller (as pi user)"
         log_dry_run "pip install $INSTALL_PATH/notifiers (as pi user)"
-        log_dry_run "pip install gpiozero RPi.GPIO (as pi user)"
+        log_dry_run "pip install $gpiozero_spec RPi.GPIO (as pi user)"
         manifest_add "pip_install" "package" "$INSTALL_PATH/brokkr" "user" "pi"
         manifest_add "pip_install" "package" "$INSTALL_PATH/serviceinstaller" "user" "pi"
         manifest_add "pip_install" "package" "$INSTALL_PATH/notifiers" "user" "pi"
-        manifest_add "pip_install" "package" "gpiozero RPi.GPIO" "user" "pi"
+        manifest_add "pip_install" "package" "$gpiozero_spec RPi.GPIO" "user" "pi"
     else
         # Run as pi user to ensure correct ownership
         # Use non-editable installs to avoid .pth file issues with sudo
@@ -128,8 +140,8 @@ install_brokkr() {
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/serviceinstaller'"
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/notifiers'"
 
-        # GPIO packages for relay control
-        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install gpiozero RPi.GPIO"
+        # GPIO packages for relay control (gpiozero pinned per HAM-84 above)
+        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$gpiozero_spec' RPi.GPIO"
 
         log_success "Python packages installed"
     fi

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -127,18 +127,21 @@ install_brokkr() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "pip install $INSTALL_PATH/brokkr (as pi user)"
         log_dry_run "pip install $INSTALL_PATH/serviceinstaller (as pi user)"
-        log_dry_run "pip install $INSTALL_PATH/notifiers (as pi user)"
+        log_dry_run "pip install -e $INSTALL_PATH/notifiers (as pi user, editable)"
         log_dry_run "pip install $gpiozero_spec RPi.GPIO (as pi user)"
         manifest_add "pip_install" "package" "$INSTALL_PATH/brokkr" "user" "pi"
         manifest_add "pip_install" "package" "$INSTALL_PATH/serviceinstaller" "user" "pi"
-        manifest_add "pip_install" "package" "$INSTALL_PATH/notifiers" "user" "pi"
+        manifest_add "pip_install" "package" "$INSTALL_PATH/notifiers" "user" "pi" "editable" "true"
         manifest_add "pip_install" "package" "$gpiozero_spec RPi.GPIO" "user" "pi"
     else
         # Run as pi user to ensure correct ownership
         # Use non-editable installs to avoid .pth file issues with sudo
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/brokkr'"
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/serviceinstaller'"
-        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/notifiers'"
+        # notifiers editable so on-sensor `git pull` reaches brokkr (HAM-158).
+        # Safe: pip runs as pi into a pi-owned venv + pi-owned source (the
+        # "no editable with sudo" rule targets pip-as-root; see HAM-163).
+        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install -e '$INSTALL_PATH/notifiers'"
 
         # GPIO packages for relay control (gpiozero pinned per HAM-84 above)
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$gpiozero_spec' RPi.GPIO"

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -117,7 +117,9 @@ install_brokkr() {
     # Buster. Pin <2.0 on Python 3.7; newer Python can take the current release.
     # (HAM-84 — mirrors the cartopy version-detection in install_pyltg.)
     local python_minor
-    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)")
+    # Fall back to a high value if the probe yields nothing, so an empty result
+    # doesn't silently pin (bash treats "" as 0 in [[ -le ]]).
+    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo 99)
     local gpiozero_spec="gpiozero"
     if [[ "$python_minor" -le 7 ]]; then
         gpiozero_spec="gpiozero<2.0"

--- a/unified_install/lib/hardware.sh
+++ b/unified_install/lib/hardware.sh
@@ -89,9 +89,11 @@ setup_automount() {
     log_step "Setting up automount..."
 
     local mount_file="mount-udisks.pkla"
+    local cleanup_unit="hamma-cleanup-stale-mountpoints.service"
+    local systemd_path="/etc/systemd/system"
 
     # --- Step 1: Create polkit directory if needed ---
-    log_step "[Automount 1/2] Setting up polkit directory..."
+    log_step "[Automount 1/3] Setting up polkit directory..."
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "mkdir -p $POLKIT_PATH"
@@ -106,7 +108,7 @@ setup_automount() {
     fi
 
     # --- Step 2: Copy mount rules ---
-    log_step "[Automount 2/2] Installing mount rules..."
+    log_step "[Automount 2/3] Installing mount rules..."
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "cp $FILES_DIR/$mount_file $POLKIT_PATH/"
@@ -123,6 +125,28 @@ setup_automount() {
             log_success "Mount rules installed"
         else
             log_warn "Mount rules file not found at $FILES_DIR/$mount_file"
+        fi
+    fi
+
+    # --- Step 3: Install stale-mountpoint cleanup oneshot ---
+    # Removes orphan /media/pi/DATA?? dirs before udisks auto-mounts, so a dirty
+    # unmount can't push the drive to a suffixed path brokkr misses. (sensor-log
+    # #52; udisks orphan-mountpoint conflict)
+    log_step "[Automount 3/3] Installing stale-mountpoint cleanup service..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "cp $FILES_DIR/$cleanup_unit $systemd_path/"
+        log_dry_run "systemctl enable $cleanup_unit"
+        manifest_add "copy" "src" "$FILES_DIR/$cleanup_unit" "dst" "$systemd_path/$cleanup_unit" "sudo" "true"
+        manifest_add "systemctl" "action" "enable" "service" "$cleanup_unit"
+    else
+        if [[ -f "$FILES_DIR/$cleanup_unit" ]]; then
+            sudo cp "$FILES_DIR/$cleanup_unit" "$systemd_path/"
+            sudo systemctl enable "$cleanup_unit" 2>/dev/null || \
+                log_warn "Could not enable $cleanup_unit"
+            log_success "Stale-mountpoint cleanup service installed"
+        else
+            log_warn "Cleanup unit not found at $FILES_DIR/$cleanup_unit"
         fi
     fi
 

--- a/unified_install/lib/software.sh
+++ b/unified_install/lib/software.sh
@@ -449,3 +449,73 @@ setup_datasync_local() {
     log_warn "Install the pull-side public key into /home/datasync/.ssh/authorized_keys"
     log_warn "  (e.g. via scripts/setup_datasync.sh --key <pubkey> <sensor_num>)"
 }
+
+# --- Remove legacy systemd units ---
+# Pre-"-default" unit names get left behind when re-installing older units and
+# compete with the current -default units for the tunnel port / config. Remove
+# the known-legacy names. Best-effort, non-fatal. (sensor-log #43, #9)
+cleanup_legacy_services() {
+    log_step "Removing legacy systemd units..."
+
+    # Current names are autossh-hamma-default / brokkr-hamma-default; these
+    # bare names are the retired pre-default units, safe to remove.
+    local legacy=(autossh-hamma.service brokkr-hamma.service)
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        local svc
+        for svc in "${legacy[@]}"; do
+            log_dry_run "disable + rm + reset-failed $svc (if present)"
+            manifest_add "command" "cmd" "rm -f /etc/systemd/system/$svc" "sudo" "true" "best_effort" "true"
+        done
+        return 0
+    fi
+
+    local removed=0 svc unit
+    for svc in "${legacy[@]}"; do
+        unit="/etc/systemd/system/$svc"
+        [[ -f "$unit" ]] || continue
+        log_info "Removing legacy $svc"
+        systemctl disable --now "$svc" 2>/dev/null || true
+        rm -f "$unit" 2>/dev/null || log_warn "Could not remove $unit"
+        systemctl reset-failed "$svc" 2>/dev/null || true
+        removed=$((removed + 1))
+    done
+    if [[ "$removed" -gt 0 ]]; then
+        systemctl daemon-reload 2>/dev/null || true
+        log_success "Removed $removed legacy unit(s)"
+    else
+        log_info "No legacy units present"
+    fi
+}
+
+# --- Normalize ownership of pi-owned paths ---
+# Any step that ran `sudo` without -H (older installs) left repos, .ssh, and
+# venvs root-owned, which breaks `git pull` ("dubious ownership") and pip. A
+# best-effort belt-and-suspenders pass so that recurring breakage can't ship.
+# (sensor-log #78, #11, #33)
+normalize_pi_ownership() {
+    log_step "Normalizing pi ownership of home paths..."
+
+    local paths=(/home/pi/dev /home/pi/.ssh /home/pi/.config)
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        local p
+        for p in "${paths[@]}"; do
+            log_dry_run "chown -R pi:pi $p"
+            manifest_add "command" "cmd" "chown -R pi:pi $p" "sudo" "true" "best_effort" "true"
+        done
+        log_dry_run "chmod 755 /etc/systemd/system"
+        manifest_add "command" "cmd" "chmod 755 /etc/systemd/system" "sudo" "true" "best_effort" "true"
+        return 0
+    fi
+
+    local p
+    for p in "${paths[@]}"; do
+        [[ -e "$p" ]] || continue
+        chown -R pi:pi "$p" 2>/dev/null || log_warn "Could not normalize ownership of $p"
+    done
+    # /etc/systemd/system left mode 644 (no traverse bit) blocks unit reads.
+    chmod 755 /etc/systemd/system 2>/dev/null || log_warn "Could not set /etc/systemd/system mode"
+
+    log_success "Ownership normalized"
+}

--- a/unified_install/lib/software.sh
+++ b/unified_install/lib/software.sh
@@ -393,6 +393,7 @@ fetch_notification_key() {
     if scp_err=$(sudo -H -u pi scp -o BatchMode=yes -o ConnectTimeout=10 \
             -o StrictHostKeyChecking=no "$key_src" "$key_dst" 2>&1); then
         chown pi:pi "$key_dst" 2>/dev/null || true
+        chmod 600 "$key_dst" 2>/dev/null || true  # webhook token — keep it private
         log_success "Fetched .googlechat notification key"
     else
         log_warn "Could not fetch .googlechat key: ${scp_err:-unknown error}"
@@ -460,19 +461,21 @@ cleanup_legacy_services() {
     # Current names are autossh-hamma-default / brokkr-hamma-default; these
     # bare names are the retired pre-default units, safe to remove.
     local legacy=(autossh-hamma.service brokkr-hamma.service)
+    # Overridable for tests (defaults to the real path).
+    local systemd_dir="${LEGACY_SYSTEMD_DIR:-/etc/systemd/system}"
 
     if [[ "$DRY_RUN" == "true" ]]; then
         local svc
         for svc in "${legacy[@]}"; do
             log_dry_run "disable + rm + reset-failed $svc (if present)"
-            manifest_add "command" "cmd" "rm -f /etc/systemd/system/$svc" "sudo" "true" "best_effort" "true"
+            manifest_add "command" "cmd" "rm -f $systemd_dir/$svc" "sudo" "true" "best_effort" "true"
         done
         return 0
     fi
 
     local removed=0 svc unit
     for svc in "${legacy[@]}"; do
-        unit="/etc/systemd/system/$svc"
+        unit="$systemd_dir/$svc"
         [[ -f "$unit" ]] || continue
         log_info "Removing legacy $svc"
         systemctl disable --now "$svc" 2>/dev/null || true
@@ -496,7 +499,13 @@ cleanup_legacy_services() {
 normalize_pi_ownership() {
     log_step "Normalizing pi ownership of home paths..."
 
-    local paths=(/home/pi/dev /home/pi/.ssh /home/pi/.config)
+    # Overridable for tests (defaults to the real pi-owned paths).
+    local paths
+    if [[ -n "${PI_OWN_PATHS:-}" ]]; then
+        read -ra paths <<< "$PI_OWN_PATHS"
+    else
+        paths=(/home/pi/dev /home/pi/.ssh /home/pi/.config)
+    fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
         local p

--- a/unified_install/lib/software.sh
+++ b/unified_install/lib/software.sh
@@ -359,3 +359,86 @@ EOT
         log_success "HAMMA installation complete!"
     fi
 }
+
+# --- Fetch Google Chat notification key ---
+# The brokkr state_monitor plugin needs /home/pi/.googlechat to send
+# notifications (low-space, disconnect, low-power). Without it, state_monitor
+# throws FileNotFoundError every cycle and all notifications are silently off.
+# The key lives on the server; pull it here so the manual scp (documented in
+# README.md Step 6 but never invoked) is no longer needed. (HAM-118)
+#
+# Best-effort: needs pi's id_rsa authorized on hamma.dev first. If that isn't
+# set up yet, warn and continue — never abort the install over a missing key.
+fetch_notification_key() {
+    local key_src="pi@hamma.dev:/home/pi/.googlechat"
+    local key_dst="/home/pi/.googlechat"
+
+    log_step "Fetching Google Chat notification key..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "scp $key_src $key_dst (as pi user, best-effort)"
+        manifest_add "command" "cmd" "scp $key_src $key_dst" "user" "pi" "best_effort" "true"
+        return 0
+    fi
+
+    if [[ -f "$key_dst" ]]; then
+        log_info ".googlechat already present, skipping fetch"
+        return 0
+    fi
+
+    # Run as pi so the fetch uses pi's SSH identity and the file lands pi-owned.
+    if sudo -H -u pi scp -o BatchMode=yes -o ConnectTimeout=10 \
+            -o StrictHostKeyChecking=no "$key_src" "$key_dst" 2>/dev/null; then
+        chown pi:pi "$key_dst" 2>/dev/null || true
+        log_success "Fetched .googlechat notification key"
+    else
+        log_warn "Could not fetch .googlechat key (pi's key may not be authorized on hamma.dev yet)"
+        log_warn "state_monitor notifications stay disabled until you run manually:"
+        log_warn "  sudo -H -u pi scp $key_src $key_dst"
+    fi
+}
+
+# --- Set up local datasync user ---
+# The datasync user lets hamma_download.py pull data from this unit via rsync.
+# scripts/setup_datasync.sh does this remotely (from a workstation over the
+# jump host); this does the on-Pi plumbing during install so future units are
+# pre-provisioned. (HAM-80)
+#
+# Note: the login key (bitzer@matrix pubkey) is NOT available locally during
+# install, so authorized_keys is left for the operator / setup_datasync.sh to
+# populate. This step only creates the account, group membership, .ssh dir and
+# /media/pi permissions — the tedious part. Best-effort, non-fatal.
+setup_datasync_local() {
+    log_step "Setting up local datasync user..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "useradd -m -s /bin/bash datasync"
+        log_dry_run "usermod -a -G pi datasync"
+        log_dry_run "mkdir -p /home/datasync/.ssh (mode 700, owned datasync)"
+        log_dry_run "chmod o+rx /media/pi/"
+        manifest_add "command" "cmd" "useradd -m -s /bin/bash datasync" "sudo" "true"
+        manifest_add "command" "cmd" "usermod -a -G pi datasync" "sudo" "true"
+        manifest_add "mkdir" "path" "/home/datasync/.ssh"
+        manifest_add "command" "cmd" "chmod o+rx /media/pi/" "sudo" "true"
+        return 0
+    fi
+
+    if id datasync >/dev/null 2>&1; then
+        log_info "datasync user already exists, skipping creation"
+    else
+        useradd -m -s /bin/bash datasync || {
+            log_warn "Could not create datasync user (continuing)"
+            return 0
+        }
+    fi
+
+    usermod -a -G pi datasync || log_warn "Could not add datasync to pi group"
+    mkdir -p /home/datasync/.ssh && chmod 700 /home/datasync/.ssh
+    chown -R datasync:datasync /home/datasync/.ssh
+    # Let datasync traverse pi's removable-media mounts for rsync
+    chmod o+rx /media/pi/ 2>/dev/null || log_warn "/media/pi not present yet (set o+rx after drives mount)"
+
+    log_success "datasync account provisioned (local plumbing)"
+    log_warn "Install the pull-side public key into /home/datasync/.ssh/authorized_keys"
+    log_warn "  (e.g. via scripts/setup_datasync.sh --key <pubkey> <sensor_num>)"
+}

--- a/unified_install/lib/software.sh
+++ b/unified_install/lib/software.sh
@@ -370,8 +370,9 @@ EOT
 # Best-effort: needs pi's id_rsa authorized on hamma.dev first. If that isn't
 # set up yet, warn and continue — never abort the install over a missing key.
 fetch_notification_key() {
-    local key_src="pi@hamma.dev:/home/pi/.googlechat"
+    local key_src="pi@www.hamma.dev:/home/pi/.googlechat"
     local key_dst="/home/pi/.googlechat"
+    local scp_err
 
     log_step "Fetching Google Chat notification key..."
 
@@ -387,12 +388,14 @@ fetch_notification_key() {
     fi
 
     # Run as pi so the fetch uses pi's SSH identity and the file lands pi-owned.
-    if sudo -H -u pi scp -o BatchMode=yes -o ConnectTimeout=10 \
-            -o StrictHostKeyChecking=no "$key_src" "$key_dst" 2>/dev/null; then
+    # Capture stderr so the warning shows the real cause (auth vs DNS vs
+    # unreachable) — DNS on cellular units is a known recurring failure mode.
+    if scp_err=$(sudo -H -u pi scp -o BatchMode=yes -o ConnectTimeout=10 \
+            -o StrictHostKeyChecking=no "$key_src" "$key_dst" 2>&1); then
         chown pi:pi "$key_dst" 2>/dev/null || true
         log_success "Fetched .googlechat notification key"
     else
-        log_warn "Could not fetch .googlechat key (pi's key may not be authorized on hamma.dev yet)"
+        log_warn "Could not fetch .googlechat key: ${scp_err:-unknown error}"
         log_warn "state_monitor notifications stay disabled until you run manually:"
         log_warn "  sudo -H -u pi scp $key_src $key_dst"
     fi

--- a/unified_install/lib/software.sh
+++ b/unified_install/lib/software.sh
@@ -433,8 +433,12 @@ setup_datasync_local() {
     fi
 
     usermod -a -G pi datasync || log_warn "Could not add datasync to pi group"
-    mkdir -p /home/datasync/.ssh && chmod 700 /home/datasync/.ssh
-    chown -R datasync:datasync /home/datasync/.ssh
+    # Guard every command: this step is best-effort and must never abort the
+    # install under set -e (e.g. an odd /home/datasync state on a re-run).
+    { mkdir -p /home/datasync/.ssh && chmod 700 /home/datasync/.ssh; } \
+        || log_warn "Could not create /home/datasync/.ssh"
+    chown -R datasync:datasync /home/datasync/.ssh 2>/dev/null \
+        || log_warn "Could not set /home/datasync/.ssh ownership"
     # Let datasync traverse pi's removable-media mounts for rsync
     chmod o+rx /media/pi/ 2>/dev/null || log_warn "/media/pi not present yet (set o+rx after drives mount)"
 


### PR DESCRIPTION
## Summary

Automates the recurring **manual post-install steps** that keep getting missed on sensor bring-up (Epic **HAM-120**), plus a set of install-hardening fixes surfaced by a Jira + `sensor-log` audit. Every new install step is **best-effort / non-fatal** — a failure logs a warning and never aborts the install.

Base: `0.4.x`. 7 commits, +671 lines. **106 unit/dry-run tests passing.**

## What's in it

**Post-install automation (new `Phase 7`, `--skip-postinstall` to opt out):**
- **HAM-118** — fetch the `.googlechat` webhook key so `state_monitor` notifications work (now `chmod 600`)
- **HAM-80** — provision the local `datasync` account (user/group/`.ssh`/`/media` perms; the pull-side key is still installed separately)
- `cleanup_legacy_services` — remove retired pre-`-default` units (`autossh-hamma.service`, `brokkr-hamma.service`) that compete with the current units *(sensor-log #43/#9)*
- `normalize_pi_ownership` — best-effort `chown pi:pi` on `/home/pi/{dev,.ssh,.config}` + `/etc/systemd/system` mode, fixing the recurring root-owned-from-`sudo` breakage *(sensor-log #78/#11/#33)*

**brokkr install:**
- **HAM-84** — pin `gpiozero<2.0` on Python ≤3.7 (2.0 breaks `relay.py` on Buster); auto-heals on newer Python
- **HAM-158** — install `notifiers` **editable-as-pi** so on-sensor `git pull` deploys and brokkr survives reboot (same safe pattern as the sindri HAM-163 plan)

**hardware phase:**
- Package + enable a boot-time **stale-mountpoint cleanup oneshot** (`files/hamma-cleanup-stale-mountpoints.service`) that `rmdir`s empty `/media/pi/DATA??` orphans before the drive is mounted, so a dirty unmount can't push it to a suffixed path brokkr's `DATA??` glob misses *(sensor-log #52; previously hand-installed per unit)*. `rmdir` is empty-only → safe no-op once mounted.

**verify_deployment.sh:**
- New `check_post_install_config` (timezone/**HAM-71**, gpiozero import, `.googlechat`, datasync, pi-ownership) and a `--full` `check_hamma_repo_access` deploy-key check (bounded with `BatchMode`+`ConnectTimeout`).

**install.sh:**
- `REPO_BRANCH` `0.3.x` → `0.4.x` so the mjolnir-hamma self-update actually runs on 0.4.x units (it only pulls when already on that branch, so the stale value silently skipped updates).

## Jira sub-tickets

Closeable on merge: **HAM-71, HAM-84, HAM-118, HAM-158.**
Partially addressed (install hook only; per-sensor backfill remains): **HAM-80.**
Untracked audit items implemented here (will file under HAM-120): legacy-unit cleanup, ownership normalization, deploy-key verify, udisks oneshot.

## Testing

- `pytest tests/unified` → **106 passing** (new `tests/unified/test_postinstall.py`: dry-run manifest assertions + a sandboxed `set -e` non-fatal harness that is **mutation-verified** to fail if a guard is dropped).
- Full no-skip `install.sh --dry-run` → exit 0; **no new shellcheck** findings in any changed line.
- Read-only E2E on **mj02**: all new `verify_deployment` checks pass live; the oneshot unit passes `systemd-analyze verify` (`rc=0`) and is a correct no-op on that healthy unit; `rmdir`-only safety proven (removes empty, keeps non-empty/mounted).
- Two independent review rounds (incl. a Raspberry-Pi/systemd expert) — all confirmed findings addressed; the Pi expert's key catch (making the oneshot's real `Before=multi-user.target` / `brokkr` ordering explicit rather than relying on the non-load-bearing `Before=udisks2.service`) is in.

## Known follow-ups (not blocking)

- **Docker/systemd integration suite** (`tests/integration/test-with-systemd.sh`) not run here (no Docker on the dev host) — worth one real-Buster run before fleet rollout.
- **Boot-time E2E** of the oneshot (verifying it prevents the suffixed mountpoint on a unit with the hard-reset pattern, e.g. mj51) needs a reboot — deferred to avoid disrupting a live sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
