### PR TITLE
feat(state_monitor): disk-safety monitors (recovery drives, H&S staleness, futile-scrub alert)

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -60,6 +60,9 @@ config_version = 1
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
         scrub_cooldown_s = 1800  # min seconds between auto-scrub launches while low (level-triggered retry)
         scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub_auto.log"  # capture auto-scrub output (diagnose futile/failed scrubs)
+        recovery_low_gb = 25  # alert if the roomiest /media/pi/DATA?? drive has less than this GB free
+        hs_stale_s = 900  # alert if no numeric bytes_remaining (H&S) from the AGS for this many seconds
+        futile_scrub_alert_after = 3  # alert if the auto-scrub re-fires this many times without clearing low space
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/docs/residual-risk-design-v1.md
+++ b/docs/residual-risk-design-v1.md
@@ -1,0 +1,147 @@
+# Residual-risk closure — synthesized design v1 (for Round-1 adversarial review)
+
+**Scope:** `plugins/state_monitor.py` + `config/main.toml` (+ optional `scripts/`) in
+**mjolnir-hamma only**. No brokkr/sindri code. New `check_*` methods slot into the
+existing `run_checks` list under the `enable_drive_checks` guard; new `__init__` kwargs +
+in-memory state, mirroring PR #78. Synthesized from a lean proposal (A) and a
+defense-in-depth proposal (B); this v1 commits to specific choices for review to attack.
+
+## The three risks (recap)
+1. **Telemetry blind spot** — scrub trigger reads AGS-pushed `bytes_remaining`; the AGS
+   stops sending H&S when `/ags/data` fills + reboot-loops → trigger blind when needed.
+2. **`/media/pi/DATA??` unmonitored** — no free-space check on the mj-side recovery
+   targets; if all fill, brokkr can't write and recovery has nowhere to land.
+3. **Firing-but-futile scrub** — a scrub can run and free nothing; undetected/unescalated.
+
+## Corrected metric (a flaw found in synthesis — reviewers verify)
+Futility (risk 3) must be judged on **`/ags/data` free space** (the drive the scrub's
+`--purge` is meant to free), NOT on the mj-side `DATA??` free space. A *working* scrub
+**recovers files onto** `DATA??` (decreasing its free space) while purging `/ags/data`, so
+a `DATA??` delta is the wrong signal. Design A had this backwards; corrected here.
+
+---
+
+## Layer 1 — `check_recovery_drives` (risk 2 keystone; both designs agree)
+Local, telemetry-independent. Cheapest and highest-certainty; anchors the shared
+free-space primitive.
+- Glob `/media/pi/DATA??` (`import glob`; `shutil` already imported). Per-path
+  `shutil.disk_usage` in a try/except (a drive unmounting mid-check raises `OSError` →
+  skip that path, don't abort).
+- Alert when the **roomiest** drive's free `< recovery_low_gb` (that's the real "nowhere
+  to recover to" condition; per-drive 100% is normal — DATA55 — and must not spam).
+  Message includes the per-drive-low count ("3/4 DATA drives below 5 GB").
+- **Alert-only, never spawns a scrub** — a full DATA drive is not fixed by scrubbing the
+  AGS; the fix is human (rotate/add a drive).
+- Empty glob → `None` (defer the "no drives" alert to the existing `check_drive`).
+- Debounce: `_recovery_low_active` descent-entry latch, mirroring `_low_space_active`.
+
+## Layer 2 — H&S staleness watchdog (risk 1a; from design B — high value, no SSH)
+Closes the "stream of NAs → total silence" gap with **zero external dependency**.
+- In `check_sensor_drive` (or a sibling), track `_last_numeric_hs_time` = monotonic time
+  of the last *numeric* `bytes_remaining`. When the current sample is numeric, update it.
+- If `now - _last_numeric_hs_time > hs_stale_s`, emit a distinct alert: "H&S from AGS
+  stale for N min — AGS may be silent / reboot-looping." Debounced (`_hs_stale_active`).
+- This fires *precisely when the value trigger can't* (AGS dark) and needs no network.
+
+## Layer 3 — direct SSH `df /ags/data` probe (risk 1b; both designs; DEFAULT-OFF)
+The only **automated** telemetry-independent detection of an actual `/ags/data` fill
+(layer 2 only alerts a human). Included but conservative because SSH-in-the-monitor-loop
+is untried here.
+- New `check_ags_space`: `subprocess.run(["ssh","-o","BatchMode=yes","-o",
+  f"ConnectTimeout={ags_ssh_timeout_s}", ags_host, "df","-B1","--output=avail",ags_path],
+  timeout=ags_ssh_timeout_s, capture_output=True, text=True)`. Parse avail bytes.
+- **Bounded:** gated to once per `ags_probe_interval_s` (default 300 s = every 5th cycle)
+  via a monotonic stamp; `BatchMode=yes` (never blocks on prompt) + `ConnectTimeout` +
+  `subprocess timeout` (belt-and-suspenders). `TimeoutExpired`/nonzero/unparseable →
+  `logger.warning` + return `None` (inconclusive ≠ full; unreachable is already covered by
+  `check_ping`, so don't double-alert).
+- On "reachable AND `/ags/data` free `< ags_low_gb`": alert **and** call the existing
+  `self._maybe_spawn_scrub()` (same cooldown, same flock, same lock file — no second scrub
+  path). Separate `_ags_low_active` latch for its alert lifecycle.
+- **`ags_probe_enabled = false` by default.** Dark-launch on mj05, enable fleet-wide only
+  after `verify_deployment.sh check_ags_connection` confirms pi→AGS SSH keys (MEMORY:
+  recurring missing keys → a missing key would make this a false "unreachable" every 300s,
+  which we handle as `None`/silent, so fail-safe, but the probe is then useless there).
+
+## Layer 4 — futile-scrub detection (risk 3; design B's correct metric, corrected)
+- On a real scrub launch (`_maybe_spawn_scrub` returns True), snapshot
+  `_scrub_baseline_ags_free` = current `/ags/data` free and `_scrub_baseline_time`.
+  "Current `/ags/data` free" = `bytes_remaining` if numeric this cycle, else the latest
+  `check_ags_space` df result if the probe is enabled+fresh, else `None` (can't measure).
+- After `scrub_effect_wait_s` (default 300 s, > typical scrub runtime) since launch, if
+  `/ags/data` free did **not** rise by `>= scrub_min_freed_gb` **AND** the drive is still
+  below `low_space` → classify **futile**. Require the verdict to persist **two**
+  consecutive post-wait cycles before escalating (so a single flock-rejected no-op, per
+  PR #78 §6, isn't misread as futile).
+- Escalate with a distinct message: "auto-scrub ran but freed <1 GB and `/ags/data` still
+  low — manual intervention needed." If baseline is `None` (post-restart, or no free-space
+  signal) → skip (no false alarm).
+- **Dependency (flagged):** if the AGS is fully silent (`bytes_remaining` NA) AND the df
+  probe is disabled, futility can't be measured — but that case is already covered by the
+  staleness alert (layer 2), which is the actionable signal ("AGS is dark").
+
+## Escalation policy (light; deliberately not a full tier ladder in v1)
+- Preserve PR #78 behavior: one descent-entry alert, then quiet while recovering.
+- **Distinct message strings** per condition (low-space / stale-H&S / no-landing-zone /
+  futile-scrub) so a human triaging chat reads the *diagnosis* directly.
+- A single **CRITICAL re-alert throttle** `critical_realert_s` (default 21600 = 6 h) for the
+  persistent conditions (futile / stale / no-landing-zone) so a multi-hour outage yields a
+  few messages/day, not one per cycle. (Full INFO/WARN/CRITICAL ladder from design B is
+  deferred as over-engineering for v1 — reviewers may argue it back in.)
+
+## Config keys (all in `[steps.state_monitor]`; constructor kwargs w/ same defaults)
+```
+recovery_low_gb      = 5      # GB free on roomiest /media/pi/DATA?? below which to alert
+hs_stale_s           = 900    # s without a numeric bytes_remaining -> stale-H&S alert
+ags_probe_enabled    = false  # enable the SSH df probe (dark-launch per-unit first)
+ags_host             = "hamma"      # ssh alias (matches scrubber default)
+ags_path             = "/ags/data"  # remote path (matches scrubber default)
+ags_probe_interval_s = 300    # s between SSH df probes
+ags_ssh_timeout_s    = 10     # subprocess + ssh ConnectTimeout, s
+ags_low_gb           = 20     # GB free on /ags/data below which to alert + scrub
+scrub_effect_wait_s  = 300    # s after a scrub launch before judging effect
+scrub_min_freed_gb   = 1      # min GB /ags/data must gain to count as effective
+critical_realert_s   = 21600  # s between re-alerts for persistent conditions (6 h)
+```
+New in-memory state: `_recovery_low_active`, `_hs_stale_active`, `_last_numeric_hs_time`,
+`_ags_low_active`, `_last_ags_probe_time`, `_last_ags_free_gb`, `_scrub_baseline_ags_free`,
+`_scrub_baseline_time`, `_futile_pending`, `_last_critical_alert` (all reset on restart —
+safe direction, per PR #78 §6).
+
+## Deliberately deferred (follow-ups, not in v1)
+- **Design B layer 3b** (parse a `SCRUB_RESULT` marker from `scrub_log`) — adds scrub
+  output-format coupling; the local `/ags/data`-free delta (layer 4) answers "did it help?"
+  without it. Defer.
+- Full 3-tier severity ladder + `escalate_after_n`.
+- udisks suffixed-mount gotcha (`DATA071`) — layer 1's glob inherits it; out of scope.
+
+## Test plan (mirrors `tests/python/test_state_monitor_scrub.py`; new file
+`test_state_monitor_drives.py`)
+- **Layer 1:** all-drives-low → alert; one-drive-has-room → None; empty glob → None (no
+  error); per-path OSError skipped, healthy path still evaluated; descent-entry debounce.
+- **Layer 2:** NA stream past `hs_stale_s` → stale alert; numeric sample resets the clock;
+  staleness fires with `scrub_command=""` (proves no shared path).
+- **Layer 3:** df parsed → drives decision; `TimeoutExpired` → None + warning, no alert;
+  nonzero/unparseable → None; interval-gated (run once per window); disabled by default
+  (subprocess.run never called); **blind-spot test** — `bytes_remaining`=NA but df low →
+  scrub still spawns via the df path; argv contains `BatchMode=yes`+`ConnectTimeout`+host+path.
+- **Layer 4:** `/ags/data` free flat after wait + still low → futile (after 2-cycle
+  debounce); free rose → no futile alert; single flat cycle (flock-reject) → no escalation;
+  baseline None → no alarm; **uses /ags/data free, not DATA free** (regression test for the
+  corrected metric).
+- **Escalation:** distinct message strings; `critical_realert_s` throttle (two criticals in
+  window → one message); recovering path stays quiet.
+- **Init wiring:** real `__init__` sets every new attr/config default.
+
+## Assumptions to verify before implementing (flagged)
+1. `ssh hamma df -B1 --output=avail /ags/data` works non-interactively from the mj Pi and
+   `--output=avail` (GNU df) exists on the AGS Pi. (Scrubber SSHes to `hamma`, so creds/path
+   exist; `--output` is GNU-coreutils.)
+2. `bytes_remaining` (GB) and `/ags/data` `df` describe the **same** volume (so `low_space`
+   and `ags_low_gb` are the same disk). Thresholds kept independent in case not.
+3. Typical scrub runtime `< scrub_effect_wait_s` (300 s) — else an in-progress scrub could
+   look futile; the 2-cycle debounce mitigates but may need per-fleet tuning.
+4. **Policy question for the user:** on the mj05 incident a correctly-firing scrub freed
+   little (data already on MJ; manual drain), so layer 4 would flag "futile" while the drive
+   was still full. That is arguably the *correct* alert ("scrubbing isn't freeing this drive
+   — intervene"), but confirm we want it, vs a softer "nothing to purge" classification.

--- a/docs/residual-risk-design-v2.md
+++ b/docs/residual-risk-design-v2.md
@@ -1,0 +1,141 @@
+# Residual-risk closure — design v2 (post Round-1; for Round-2 adversarial review)
+
+**Scope:** `plugins/state_monitor.py` + `config/main.toml` in **mjolnir-hamma only**. No
+brokkr/sindri. New `check_*` methods slot into `run_checks` under the existing
+`enable_drive_checks` guard; new `__init__` kwargs + in-memory state, mirroring PR #78.
+
+## What changed from v1 (Round-1 verdict was convergent)
+Both Round-1 reviewers independently said: **ship Layers 1+2, cut Layers 3+4.**
+- **CUT — Layer 3 (SSH `df` probe):** ships dark (`ags_probe_enabled=false`), needs a
+  per-unit deploy-check (pi→AGS keys, a recurring fleet gap), duplicates Layer 2's human
+  alert, and adds SSH-in-the-monitor-loop as a new failure class. Deferred.
+- **CUT — Layer 4 (futile-scrub auto-detection):** false-positives "futile" on healthy
+  nothing-to-purge scrubs (the still-below-`low_space` guard is nearly inert), is **blind
+  in the exact incident scenario** (needs the telemetry that's missing), depends on Layer 3,
+  and rests on an unresolved policy question. `scrub_log` visibility (already in PR #78) is
+  the proportionate answer. Deferred.
+These are recorded as tracked follow-ups (below), not lost.
+
+## v2 ships exactly two checks
+
+### Layer 1 — `check_recovery_drives` (closes risk 2: `/media/pi/DATA??` unmonitored)
+Local, telemetry-independent; the one risk rated **WILL-RECUR** (DATA55 is already 100%).
+- `glob.glob("/media/pi/DATA??")` (`import glob`; `shutil` already imported). Per-path
+  `shutil.disk_usage(path)` in try/except — a drive unmounting mid-check raises
+  `OSError`/`FileNotFoundError` → skip that path, don't abort the check.
+- Alert when the **roomiest** resolved drive has free `< recovery_low_gb`. That is the real
+  "nowhere left to recover to / brokkr can't write" condition. A single drive at 100% is
+  **normal** (rotation; DATA55) and must not alert. Message: `"Recovery drives low: best
+  DATA?? has N GB free (M/K drives below X GB)"`.
+- **Alert-only — never spawns a scrub.** A full DATA drive is not fixed by scrubbing the
+  AGS; the remedy is human (rotate/add a drive).
+- Empty glob → `None` (leave the "no drives" alert to the existing `check_drive`).
+- Debounce: `_recovery_low_active` descent-entry latch (mirrors `_low_space_active`); alert
+  once on entry, re-arm when the roomiest drive climbs back above threshold.
+- **Documented limitation (Round-1 #7):** this catches the *all-drives-full* case, not a
+  "brokkr's current write-target drive fills while another sits empty" case. `select_target_
+  drive` in `hamma_scrub.py` picks the most-recent-hour dir with ≥100 MB, not the roomiest.
+  Watching the roomiest is the correct signal for "recovery has nowhere to land," which is
+  the catastrophic risk; per-drive rotation is normal. Accepted for v2; a per-write-target
+  check is a possible later refinement.
+
+### Layer 2 — H&S staleness watchdog (closes the actionable half of risk 1)
+Zero external dependency; fires precisely when the value trigger is blind (AGS dark).
+- Track `_last_numeric_hs_time` = monotonic time of the last **numeric** `bytes_remaining`.
+  **Lazy-init:** on the first `check_sensor_drive`/staleness call, if `None`, set it to
+  `time.monotonic()` (same lazy-init idiom as `_previous_data` in `execute`). So a
+  never-yet-seen-numeric state measures from process start rather than staying silent.
+- Each cycle: if the current `bytes_remaining` is numeric → update `_last_numeric_hs_time`
+  and clear the latch. If NOT numeric (NA/nan) and `now - _last_numeric_hs_time >
+  hs_stale_s` → alert `"H&S from AGS stale for N min — AGS may be silent/reboot-looping"`,
+  debounced via `_hs_stale_active`.
+- Lives as a small sibling method `check_hs_staleness` (kept separate from the scrub logic
+  so its clock never entangles with the scrub cooldown), added to `run_checks`.
+- **Restart note (Round-1 #6, assessed):** `_last_numeric_hs_time` resets on brokkr
+  restart. In THIS architecture that's benign — brokkr runs on the mj Pi, which stays up
+  through an AGS reboot loop (verified up 5+ days across the mj05 incident); it does **not**
+  flap with the AGS. So the "restart defeats the clock" concern (which assumed brokkr
+  co-flapping) does not apply. Lazy-init-to-now is correct and simple; no state file needed.
+
+## Config keys (only 2; in `[steps.state_monitor]` + matching `__init__` kwargs)
+```
+recovery_low_gb = 25    # GB free on the roomiest /media/pi/DATA?? below which to alert
+hs_stale_s      = 900    # s without a numeric bytes_remaining -> stale-H&S alert (~2-15x cadence)
+```
+`recovery_low_gb` default raised from v1's 5 (Round-1: 5 GB ≈ minutes of runway at 22 MB/
+trigger; 25 GB gives real early-warning lead). `hs_stale_s=900` = ~4–15 missed samples at
+the 1–4 min H&S cadence.
+
+New in-memory state (3 flags): `_recovery_low_active=False`, `_hs_stale_active=False`,
+`_last_numeric_hs_time=None`. All reset on restart (safe direction; see restart note).
+
+## Alerting
+Distinct message strings per condition (low-space / no-landing-zone / stale-H&S), each
+descent-entry latched (alert once, quiet while persisting, re-arm on recovery). No CRITICAL
+throttle, no severity ladder — with only these conditions, distinct strings are triage-
+adequate (Round-1 #6/#7), and latched conditions don't spam.
+
+## Deferred (tracked follow-ups — file as issues, not built in v2)
+1. **Direct `df /ags/data` over SSH** (telemetry-independent *automated* fill detection) —
+   revisit only if a truly-silent-AGS fill is shown to recur; consider a cron/external probe
+   rather than SSH inside the monitor pipeline step.
+2. **Futile-scrub auto-detection** — resolve the policy question ("nothing purgeable" vs
+   "purged but still full") and pull the scrub's own purged/retained counts (a `scripts/
+   hamma_scrub.py` summary line) before building it; `scrub_log` visibility suffices for now.
+3. **Per-write-target DATA drive check** (Layer-1 limitation above).
+
+## Test plan (new file `tests/python/test_state_monitor_drives.py`, PR #78 harness)
+`load_state_monitor_module()` mocks; `StateMonitor.__new__`; patch `glob.glob` /
+`shutil.disk_usage` / `time.monotonic`.
+- **Layer 1:** all-drives-low → alert (+ count in msg); one-drive-has-room → None
+  (per-drive-full is normal); empty glob → None (no error, no double "no drives");
+  per-path `OSError` skipped, healthy path still evaluated; descent-entry debounce (two low
+  cycles → one alert; recover-above then below → re-alert); alert-only (never calls Popen).
+- **Layer 2:** NA past `hs_stale_s` → stale alert; numeric sample resets the clock (no
+  alert); lazy-init measures from first call (AGS-dark-from-start → alert after `hs_stale_s`);
+  fires with `scrub_command=""` (proves no shared path with the scrub); debounce (one alert
+  while persisting).
+- **Init wiring:** real `__init__` sets the 3 new attrs + 2 config defaults.
+
+## Assumptions to verify before/at implementation
+1. `bytes_remaining` reaches `check_sensor_drive`/staleness as the same value used today
+   (numeric float or `'NA'`) — confirmed in PR #78 (`now_then`; float via `_convert_custom`).
+2. `/media/pi/DATA??` is the correct recovery-target glob (matches `drive_glob="DATA??"`,
+   `main.toml`). udisks suffixed-mount gotcha (`DATA071`) is a pre-existing blind spot in the
+   glob, out of scope.
+
+---
+## v2-FINAL (post Round-2) — implemented
+
+Both Round-2 reviewers cleared the scope ("YES, v2 is the right scope"). Changes folded in:
+
+**Layer 2 non-redundancy with `check_ping` (verified, now recorded):** `ping` targets the AGS
+Pi ICMP at `10.10.10.1`, which comes up every ~60 s boot during the reboot loop → `bad_ping`
+resets below `ping_max=3` → `check_ping` does **not** reliably fire. H&S needs the AGS *app*
+(never stays up) → `bytes_remaining` continuously NA. Layer 2 catches "AGS pingable but not
+sending data" — the gap ping leaves open (the mj05 FPGA-missing variant ran a reboot loop
+**~5.5 days** unnoticed *because* ping stayed green). This is Layer 2's core justification.
+
+**ADD-NEW — Layer 3: repeating-futile-scrub ALERT** (Round-2 scope finding #4). In
+`check_sensor_drive`, count consecutive low-state scrub respawns (`_scrub_respawn_count`,
+incremented when `_maybe_spawn_scrub` actually launches; reset to 0 when space recovers ≥
+`low_space`). After `futile_scrub_alert_after` (default 3 ≈ 3×30 min cooldown ≈ 1.5 h) with
+no recovery, emit a distinct one-shot alert (`_futile_scrub_alerted` latch): "auto-scrub
+re-fired Nx without clearing low space — manual intervention needed." A **symptom** alert —
+sidesteps the "nothing-purgeable vs purged-but-full" policy question that killed old Layer 4,
+needs no SSH/`df`/log-parsing. Complements Layer 2 (covers the AGS-sending-data case).
+
+**Correctness fixes (Round-2 correctness BLOCKERs/mechanical):**
+1. Layer 1: accumulate resolved `disk_usage().free` into a list; `if not frees: return None`
+   (guards `max([])` when every DATA path raises OSError — non-empty glob, all skipped).
+2. Layer 2: exact body — lazy-init `_last_numeric_hs_time` to now; on numeric sample reset
+   clock + clear latch BEFORE measuring; numeric guard is PR#78's
+   `isinstance(x,(int,float)) and x == x`.
+3. GB threshold uses `* 2**30` (binary GiB, matches `check_pi_space` display).
+4. Boundary: alert on `best_free < threshold` (strict), re-arm on `>=`.
+5. Tests: NEW file `test_state_monitor_drives.py` with its own `make_drive_monitor` helper
+   (does not reuse/break PR#78's `make_monitor`); add "all-paths-OSError → None" test.
+
+**Final config keys (3):** `recovery_low_gb=25`, `hs_stale_s=900`, `futile_scrub_alert_after=3`.
+**Final new state (5 flags):** `_recovery_low_active`, `_hs_stale_active`,
+`_last_numeric_hs_time`, `_scrub_respawn_count`, `_futile_scrub_alerted`.

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -3,6 +3,7 @@ Plugin to monitor state variables from the charge controller.
 """
 
 from math import nan
+import glob
 import shlex
 import shutil
 import subprocess
@@ -43,6 +44,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_command="",
         scrub_cooldown_s=1800,
         scrub_log="",
+        recovery_low_gb=25,
+        hs_stale_s=900,
+        futile_scrub_alert_after=3,
         **output_step_kwargs,
         ):
         """
@@ -85,6 +89,19 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             Path to append the spawned scrub's stdout/stderr to. If empty
             (default), scrub output is discarded (DEVNULL). Set this so a scrub
             that runs but frees nothing is diagnosable instead of silent.
+        recovery_low_gb : numeric, optional
+            Alert when the roomiest `/media/pi/DATA??` recovery-target drive has
+            less than this many GB free (the "nowhere left to recover to"
+            condition). Default 25. Alert-only; never spawns a scrub.
+        hs_stale_s : numeric, optional
+            Alert when no numeric `bytes_remaining` (Health & Status) has been
+            seen from the AGS for this many seconds (the AGS is silent /
+            reboot-looping). Default 900. Independent of AGS-pushed telemetry
+            value; catches the gap `check_ping` misses.
+        futile_scrub_alert_after : int, optional
+            Alert when the auto-scrub has re-fired this many consecutive times
+            while the drive stays below `low_space` without clearing (scrubbing
+            isn't working; a human should intervene). Default 3.
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -111,6 +128,15 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         # state (so we alert on descent-entry and on each respawn, not every cycle).
         self._last_scrub_time = None
         self._low_space_active = False
+        # v2 disk-safety monitors
+        self.recovery_low_gb = recovery_low_gb
+        self.hs_stale_s = hs_stale_s
+        self.futile_scrub_alert_after = futile_scrub_alert_after
+        self._recovery_low_active = False   # Layer 1 alert latch
+        self._hs_stale_active = False       # Layer 2 alert latch
+        self._last_numeric_hs_time = None   # Layer 2 staleness clock (lazy-init)
+        self._scrub_respawn_count = 0       # Layer 3 consecutive low-state respawns
+        self._futile_scrub_alerted = False  # Layer 3 one-shot latch
 
         self.notifier = Notifier(
             method=method, key_file=key_file, channel=channel, logger=self.logger)
@@ -225,6 +251,8 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         if self.enable_drive_checks:
             checks.insert(0, self.check_drive)
             checks.append(self.check_sensor_drive)
+            checks.append(self.check_recovery_drives)
+            checks.append(self.check_hs_staleness)
 
         for check_fn in checks:
             try:
@@ -372,8 +400,11 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return None
 
         if space_now >= self.low_space:
-            # Healthy: re-arm so the next descent below the threshold alerts.
+            # Healthy: re-arm so the next descent below the threshold alerts, and
+            # reset the futile-scrub-loop tracking (the scrub cleared the drive).
             self._low_space_active = False
+            self._scrub_respawn_count = 0
+            self._futile_scrub_alerted = False
             return None
 
         # Below threshold. LEVEL-TRIGGERED (not edge): spawn a scrub whenever
@@ -383,8 +414,22 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         # and on each (re)spawn, so a persistently full drive escalates instead
         # of going silent after one message.
         spawned = self._maybe_spawn_scrub()
+        if spawned:
+            self._scrub_respawn_count += 1
         first_entry = not self._low_space_active
         self._low_space_active = True
+
+        # Futile-scrub-loop escalation: the scrub keeps re-firing but the drive
+        # is not clearing. A symptom alert -- it does not classify *why* (nothing
+        # purgeable vs purged-but-still-full), only that scrubbing isn't working,
+        # so a human should intervene. One-shot until the drive recovers.
+        if (self._scrub_respawn_count >= self.futile_scrub_alert_after
+                and not self._futile_scrub_alerted):
+            self._futile_scrub_alerted = True
+            return (f"Auto-scrub re-fired {self._scrub_respawn_count}x without "
+                    f"clearing low space ({space_now:.1f} GB) -- manual "
+                    f"intervention needed")
+
         if first_entry or spawned:
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
@@ -450,6 +495,85 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
                     log_fh.close()
                 except OSError:
                     pass
+
+    def check_recovery_drives(self, input_data):
+        """
+        Check free space on the mj-side recovery-target drives (/media/pi/DATA??).
+
+        These are where brokkr writes live science data AND where the scrubber
+        recovers AGS triggers. If they all fill, brokkr can't write and recovery
+        has nowhere to land. A single drive at 100% is normal (rotation), so we
+        alert only when the *roomiest* drive is low. Local and telemetry-
+        independent (no AGS dependency). Alert-only -- a full DATA drive is not
+        fixed by scrubbing the AGS.
+
+        Returns
+        -------
+        str | None
+            Message if the roomiest drive is below `recovery_low_gb`, else None.
+        """
+        paths = glob.glob("/media/pi/DATA??")
+        if not paths:
+            # No DATA drives resolved -- leave the "no drives" alert to check_drive.
+            return None
+        frees = []
+        for path in paths:
+            try:
+                frees.append(shutil.disk_usage(path).free)
+            except OSError:
+                # Drive unmounted mid-check; skip it rather than aborting.
+                continue
+        if not frees:
+            # Non-empty glob but every path errored -- avoid max([]) ValueError.
+            return None
+
+        threshold = self.recovery_low_gb * (2 ** 30)
+        best_free = max(frees)
+        if best_free >= threshold:
+            self._recovery_low_active = False  # re-arm
+            return None
+        if self._recovery_low_active:
+            return None  # already alerted this descent
+        self._recovery_low_active = True
+        below = sum(1 for f in frees if f < threshold)
+        return (f"Recovery drives low: best DATA?? has {best_free / (2 ** 30):.1f} GB "
+                f"free ({below}/{len(frees)} below {self.recovery_low_gb} GB)")
+
+    def check_hs_staleness(self, input_data):
+        """
+        Alert if the AGS has stopped sending Health & Status (`bytes_remaining`).
+
+        This is telemetry-*presence* monitoring, independent of the value. It
+        fires precisely when the value-based `check_sensor_drive` goes blind: the
+        AGS app crashed / is reboot-looping, so `bytes_remaining` is continuously
+        NA. It is NOT redundant with `check_ping` -- ping hits the AGS Pi kernel
+        (which comes up every ~60 s boot in a reboot loop, so `bad_ping` resets
+        below `ping_max`), whereas this catches "AGS pingable but not sending
+        data" (the gap that let a prior reboot loop run ~5.5 days unnoticed).
+
+        Returns
+        -------
+        str | None
+            Message if H&S has been stale longer than `hs_stale_s`, else None.
+        """
+        now = time.monotonic()
+        if self._last_numeric_hs_time is None:
+            self._last_numeric_hs_time = now  # lazy-init from first call
+        hs_now, _ = self.now_then(input_data, 'bytes_remaining')
+
+        # Same numeric guard as check_sensor_drive: 'NA' -> nan, and None/''
+        # /unexpected values are non-numeric. A numeric sample = H&S is flowing.
+        if isinstance(hs_now, (int, float)) and hs_now == hs_now:
+            self._last_numeric_hs_time = now  # reset clock BEFORE measuring
+            self._hs_stale_active = False
+            return None
+
+        gap = now - self._last_numeric_hs_time
+        if gap > self.hs_stale_s and not self._hs_stale_active:
+            self._hs_stale_active = True
+            return (f"H&S from AGS stale for {gap / 60:.0f} min -- AGS may be "
+                    f"silent / reboot-looping")
+        return None
 
     def check_battery_voltage(self, input_data):
         """

--- a/tests/python/test_state_monitor_drives.py
+++ b/tests/python/test_state_monitor_drives.py
@@ -1,0 +1,287 @@
+"""Tests for the v2 disk-safety monitors:
+- check_recovery_drives (Layer 1: /media/pi/DATA?? free space)
+- check_hs_staleness   (Layer 2: H&S bytes_remaining staleness)
+- futile-scrub-loop alert in check_sensor_drive (Layer 3)
+"""
+
+import importlib.util
+from collections import namedtuple
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PLUGIN_PATH = REPO_ROOT / "plugins" / "state_monitor.py"
+
+
+class MockOutputStep:
+    def __init__(self, **kwargs):
+        self.logger = MagicMock()
+        self.name = kwargs.get("name", "test_step")
+
+
+def load_state_monitor_module():
+    mock_base = MagicMock()
+    mock_base.OutputStep = MockOutputStep
+    mock_pipeline = MagicMock()
+    mock_pipeline.base = mock_base
+    mock_brokkr = MagicMock()
+    mock_brokkr.pipeline = mock_pipeline
+    mock_brokkr.pipeline.base = mock_base
+    with patch.dict("sys.modules", {
+        "brokkr": mock_brokkr,
+        "brokkr.pipeline": mock_pipeline,
+        "brokkr.pipeline.base": mock_base,
+        "brokkr.pipeline.decode": MagicMock(),
+        "brokkr.utils": MagicMock(),
+        "brokkr.utils.output": MagicMock(),
+        "notifiers": MagicMock(),
+    }):
+        spec = importlib.util.spec_from_file_location("state_monitor", str(PLUGIN_PATH))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load_state_monitor_module()
+StateMonitor = MODULE.StateMonitor
+
+DU = namedtuple("DU", ["total", "used", "free"])
+GB = 2 ** 30
+
+
+def du(free_gb):
+    return DU(2000 * GB, 0, int(free_gb * GB))
+
+
+class FakeDataValue:
+    def __init__(self, value):
+        self.value = value
+
+
+def make_input_data(bytes_remaining):
+    return {"bytes_remaining": FakeDataValue(bytes_remaining)}
+
+
+def make_drive_monitor(low_space=100, scrub_command="", recovery_low_gb=25,
+                       hs_stale_s=900, futile_scrub_alert_after=3,
+                       scrub_cooldown_s=1800, space_previous=150):
+    """Build a StateMonitor with ALL scrub-era + v2 attrs set (bypasses __init__)."""
+    mon = StateMonitor.__new__(StateMonitor)
+    mon.logger = MagicMock()
+    mon._previous_data = make_input_data(space_previous)
+    # scrub-era (PR#78)
+    mon.low_space = low_space
+    mon.scrub_command = scrub_command
+    mon.scrub_cooldown_s = scrub_cooldown_s
+    mon.scrub_log = ""
+    mon._last_scrub_time = None
+    mon._low_space_active = False
+    # v2 config
+    mon.recovery_low_gb = recovery_low_gb
+    mon.hs_stale_s = hs_stale_s
+    mon.futile_scrub_alert_after = futile_scrub_alert_after
+    # v2 state
+    mon._recovery_low_active = False
+    mon._hs_stale_active = False
+    mon._last_numeric_hs_time = None
+    mon._scrub_respawn_count = 0
+    mon._futile_scrub_alerted = False
+    return mon
+
+
+# --- Layer 1: check_recovery_drives ---
+
+class TestRecoveryDrives:
+    def test_alert_when_all_drives_low(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with patch("glob.glob", return_value=["/media/pi/DATA55", "/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=[du(2), du(10)]):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is not None
+        assert "GB" in msg
+
+    def test_no_alert_when_one_drive_has_room(self):
+        """DATA55 at 0 (normal rotation), DATA56 has room -> no alert."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with patch("glob.glob", return_value=["/media/pi/DATA55", "/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=[du(0), du(800)]):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+
+    def test_empty_glob_returns_none(self):
+        mon = make_drive_monitor()
+        with patch("glob.glob", return_value=[]), patch("shutil.disk_usage") as usage:
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+        usage.assert_not_called()
+
+    def test_all_paths_oserror_returns_none(self):
+        """Non-empty glob but every path raises -> None, NOT ValueError from max([])."""
+        mon = make_drive_monitor()
+        with patch("glob.glob", return_value=["/media/pi/DATA55", "/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=OSError("unmounted")):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+        mon.logger.error.assert_not_called()
+
+    def test_per_path_oserror_skipped_healthy_evaluated(self):
+        """One path errors, the other is low -> still alerts on the good one."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+
+        def side(p):
+            if "DATA55" in p:
+                raise OSError("unmounted")
+            return du(3)
+        with patch("glob.glob", return_value=["/media/pi/DATA55", "/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=side):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is not None
+
+    def test_debounce_and_rearm(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with patch("glob.glob", return_value=["/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(2)]):
+                m1 = mon.check_recovery_drives(make_input_data(100))
+            with patch("shutil.disk_usage", side_effect=[du(1)]):
+                m2 = mon.check_recovery_drives(make_input_data(100))  # still low
+            with patch("shutil.disk_usage", side_effect=[du(500)]):
+                m3 = mon.check_recovery_drives(make_input_data(100))  # recovered
+            with patch("shutil.disk_usage", side_effect=[du(1)]):
+                m4 = mon.check_recovery_drives(make_input_data(100))  # low again
+        assert m1 is not None
+        assert m2 is None       # debounced
+        assert m3 is None       # recovery is silent
+        assert m4 is not None   # re-armed -> re-alert
+
+    def test_boundary_equal_threshold_no_alert(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with patch("glob.glob", return_value=["/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=[du(25)]):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None  # free == threshold is NOT below
+
+    def test_alert_only_never_spawns(self):
+        mon = make_drive_monitor(recovery_low_gb=25,
+                                 scrub_command="python3 scrub.py")
+        with patch("glob.glob", return_value=["/media/pi/DATA56"]), \
+                patch("shutil.disk_usage", side_effect=[du(1)]), \
+                patch("subprocess.Popen") as popen:
+            mon.check_recovery_drives(make_input_data(100))
+        popen.assert_not_called()
+
+
+# --- Layer 2: check_hs_staleness ---
+
+class TestHsStaleness:
+    def test_na_past_threshold_alerts(self):
+        mon = make_drive_monitor(hs_stale_s=900)
+        with patch("time.monotonic", return_value=1000.0):
+            mon.check_hs_staleness(make_input_data(150))  # numeric -> sets clock
+        with patch("time.monotonic", return_value=1000.0 + 901):
+            msg = mon.check_hs_staleness(make_input_data("NA"))
+        assert msg is not None
+
+    def test_numeric_resets_clock(self):
+        mon = make_drive_monitor(hs_stale_s=900)
+        with patch("time.monotonic", return_value=1000.0):
+            mon.check_hs_staleness(make_input_data(150))
+        with patch("time.monotonic", return_value=1000.0 + 800):
+            mon.check_hs_staleness(make_input_data(120))  # numeric, resets
+        with patch("time.monotonic", return_value=1000.0 + 900 + 1):  # <900 since reset
+            msg = mon.check_hs_staleness(make_input_data("NA"))
+        assert msg is None
+
+    def test_lazy_init_from_first_call(self):
+        """AGS dark from the very first sample -> alerts hs_stale_s after first call."""
+        mon = make_drive_monitor(hs_stale_s=900)
+        with patch("time.monotonic", return_value=500.0):
+            m0 = mon.check_hs_staleness(make_input_data("NA"))  # lazy-init to 500
+        with patch("time.monotonic", return_value=500.0 + 901):
+            m1 = mon.check_hs_staleness(make_input_data("NA"))
+        assert m0 is None
+        assert m1 is not None
+
+    def test_none_value_is_not_numeric(self):
+        """A None value must be treated as non-numeric (not reset the clock)."""
+        mon = make_drive_monitor(hs_stale_s=900)
+        with patch("time.monotonic", return_value=1000.0):
+            mon.check_hs_staleness(make_input_data(150))
+        with patch("time.monotonic", return_value=1000.0 + 901):
+            msg = mon.check_hs_staleness(make_input_data(None))
+        assert msg is not None
+
+    def test_fires_with_empty_scrub_command(self):
+        mon = make_drive_monitor(hs_stale_s=900, scrub_command="")
+        with patch("time.monotonic", return_value=1000.0):
+            mon.check_hs_staleness(make_input_data(150))
+        with patch("time.monotonic", return_value=1000.0 + 901):
+            msg = mon.check_hs_staleness(make_input_data("NA"))
+        assert msg is not None
+
+    def test_debounce_one_alert_while_persisting(self):
+        mon = make_drive_monitor(hs_stale_s=900)
+        with patch("time.monotonic", return_value=1000.0):
+            mon.check_hs_staleness(make_input_data(150))
+        with patch("time.monotonic", return_value=1000.0 + 901):
+            m1 = mon.check_hs_staleness(make_input_data("NA"))
+        with patch("time.monotonic", return_value=1000.0 + 1000):
+            m2 = mon.check_hs_staleness(make_input_data("NA"))
+        assert m1 is not None
+        assert m2 is None
+
+
+# --- Layer 3: futile-scrub-loop alert in check_sensor_drive ---
+
+class TestFutileScrubLoop:
+    def _below(self, mon, val, t):
+        with patch("subprocess.Popen"), patch("time.monotonic", return_value=t):
+            return mon.check_sensor_drive(make_input_data(val))
+
+    def test_futile_alert_after_n_respawns(self):
+        mon = make_drive_monitor(low_space=100, scrub_command="python3 scrub.py",
+                                 futile_scrub_alert_after=3, scrub_cooldown_s=1800)
+        msgs = []
+        # 3 respawns, each past the cooldown, drive never recovers
+        for i in range(3):
+            msgs.append(self._below(mon, 70, 1000.0 + i * 2000))
+        assert mon._scrub_respawn_count == 3
+        assert any("re-fired" in (m or "") or "manual intervention" in (m or "")
+                   for m in msgs)
+
+    def test_no_futile_alert_if_recovers(self):
+        mon = make_drive_monitor(low_space=100, scrub_command="python3 scrub.py",
+                                 futile_scrub_alert_after=3, scrub_cooldown_s=1800)
+        self._below(mon, 70, 1000.0)          # respawn 1
+        self._below(mon, 70, 3000.0)          # respawn 2
+        self._below(mon, 150, 5000.0)         # recovered -> counter resets
+        assert mon._scrub_respawn_count == 0
+        m = self._below(mon, 70, 7000.0)      # respawn 1 again
+        assert "manual intervention" not in (m or "")
+
+    def test_futile_alert_only_once(self):
+        mon = make_drive_monitor(low_space=100, scrub_command="python3 scrub.py",
+                                 futile_scrub_alert_after=2, scrub_cooldown_s=1800)
+        m1 = self._below(mon, 70, 1000.0)     # respawn 1
+        m2 = self._below(mon, 70, 3000.0)     # respawn 2 -> futile alert
+        m3 = self._below(mon, 70, 5000.0)     # respawn 3 -> already alerted, no repeat
+        assert "manual intervention" in (m2 or "")
+        assert "manual intervention" not in (m3 or "")
+
+
+# --- Init wiring ---
+
+class TestInitWiresV2:
+    def test_init_sets_new_attrs_and_defaults(self):
+        with patch.object(MODULE, "Notifier", MagicMock(), create=True):
+            mon = StateMonitor(method="slack")
+        assert mon.recovery_low_gb == 25
+        assert mon.hs_stale_s == 900
+        assert mon.futile_scrub_alert_after == 3
+        assert mon._recovery_low_active is False
+        assert mon._hs_stale_active is False
+        assert mon._last_numeric_hs_time is None
+        assert mon._scrub_respawn_count == 0
+        assert mon._futile_scrub_alerted is False

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -79,6 +79,10 @@ def make_monitor(scrub_command="", low_space=100, space_previous=150,
     mon.scrub_log = scrub_log
     mon._last_scrub_time = last_scrub_time
     mon._low_space_active = low_space_active
+    # v2 futile-scrub-loop state (check_sensor_drive reads these)
+    mon.futile_scrub_alert_after = 3
+    mon._scrub_respawn_count = 0
+    mon._futile_scrub_alerted = False
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)
     return mon


### PR DESCRIPTION
**Stacked on #78** (base = `feature/scrub-trigger-fix`; retarget to `0.4.x` once #78 merges). Closes the residual risks #78's assurance report flagged (§5), scoped by **two rounds of adversarial review**. mjolnir-hamma only — no brokkr/sindri.

## What
Three additions to `plugins/state_monitor.py` (+ 3 config keys):

1. **`check_recovery_drives`** — alert when the **roomiest** `/media/pi/DATA??` drive is below `recovery_low_gb` (25). Closes the **WILL-RECUR** gap: the mj-side recovery targets had **no** free-space monitoring (`check_pi_space` watches `/` only; `check_drive` watches presence only), and DATA55 is already 100%. Local, telemetry-independent, **alert-only** (a full DATA drive isn't fixed by scrubbing). Per-drive-100% is normal rotation → only the roomiest triggers.

2. **`check_hs_staleness`** — alert when no numeric `bytes_remaining` (H&S) has arrived for `hs_stale_s` (900 s). Catches the **AGS-silent / reboot-loop** case where the value trigger goes blind. **Verified not redundant with `check_ping`**: ping hits the AGS *kernel* (up each ~60 s boot → `bad_ping` resets below `ping_max`), while H&S needs the AGS *app* (stays down). This is the gap that let a prior reboot loop run **~5.5 days unnoticed**. Zero network dependency.

3. **Futile-scrub-loop alert** (in `check_sensor_drive`) — escalate when the auto-scrub re-fires `futile_scrub_alert_after` times (3) without clearing low space. A **symptom** alert (no SSH/`df`/log-parsing) — sidesteps the policy question that made full futile-detection unshippable.

## Scope (two review rounds)
Round 1 cut a dark-shipped SSH `df` probe and a fragile full futile-detector. Round 2 verified the cuts are safe (the SSH probe would be **blind during the confirmed VL805-wedge failure** and couldn't remediate a wedged USB anyway) and added the lightweight futile *alert* above. **Deferred (tracked):** direct `df /ags/data` over SSH; full futile auto-detection; per-write-target DATA check. Full trail: `docs/residual-risk-design-v{1,2}.md`.

## Tests
**52/52** state_monitor tests pass (**18 new**, TDD — watched fail then pass), incl. all-paths-OSError→None (no `max([])` crash), lazy-init staleness clock, `None`-is-not-numeric guard, boundary re-arm, futile-loop escalation + reset. Full suite: 464 passed (3 pre-existing `test_hamma_noise` failures unrelated). Not deployed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)