### PR TITLE
Scrub resilience: make silent scrub failure impossible, visible, and self-healing

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -62,7 +62,7 @@ config_version = 1
         key_file = "/home/pi/.googlechat"
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
         scrub_hang_timeout_s = 900  # judge a scrub hung if the lock is held with no heartbeat progress this long (>SCAN_TIMEOUT=600s)
-        scrub_auto_recover = false  # kill a genuinely-hung scrub to free the lock (self-healing). DEFAULT OFF: validate on a bench unit (inject a hung scrub) before enabling fleet-wide; false = alert only
+        scrub_auto_recover = false  # kill a genuinely-hung scrub to free the lock (self-healing). DEFAULT OFF: validate on a bench unit (inject a hung scrub) before enabling fleet-wide; false = alert only. Enable tracked in hamma-dev/mjolnir-hamma#81
         scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub.log"  # durable capture of scrub stdout/stderr (rotated); mj05 ran blind on DEVNULL
 
     # Step to create HAMMA plot

--- a/config/main.toml
+++ b/config/main.toml
@@ -52,7 +52,9 @@ config_version = 1
     [steps.state_monitor]
         _preset = "state_monitor.outputs.plugin"
         power_delim = 15  # delimiter between normal power and low power
-        low_space = 100  # if # of GB is less than this, generate a notification
+        purge_space = 200  # GB free on the AGS drive below which to drain proactively (level-triggered, no alert)
+        alert_space = 75   # GB free below which to alert: falling despite the auto-scrub (purge losing)
+        scrub_cooldown_s = 300  # min seconds between level-triggered scrub launches while below purge_space (more responsive than the 15-min timer)
         ping_max = 3  # after this many pings, send chat message
         method = "gchat"  # the method how we're going to send notifications
         channel = "status"

--- a/config/main.toml
+++ b/config/main.toml
@@ -55,13 +55,14 @@ config_version = 1
         purge_space = 200  # GB free on the AGS drive below which to drain proactively (level-triggered, no alert)
         alert_space = 75   # GB free below which to alert: falling despite the auto-scrub (purge losing)
         scrub_cooldown_s = 300  # min seconds between level-triggered scrub launches while below purge_space (more responsive than the 15-min timer)
+        hs_stale_cycles = 15  # alert if bytes_remaining is NA this many consecutive cycles (~15 min) -- the AGS is dark and /ags/data can fill unseen
         ping_max = 3  # after this many pings, send chat message
         method = "gchat"  # the method how we're going to send notifications
         channel = "status"
         key_file = "/home/pi/.googlechat"
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
         scrub_hang_timeout_s = 900  # judge a scrub hung if the lock is held with no heartbeat progress this long (>SCAN_TIMEOUT=600s)
-        scrub_auto_recover = true   # kill a genuinely-hung scrub to free the lock (self-healing); false = alert only
+        scrub_auto_recover = false  # kill a genuinely-hung scrub to free the lock (self-healing). DEFAULT OFF: validate on a bench unit (inject a hung scrub) before enabling fleet-wide; false = alert only
         scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub.log"  # durable capture of scrub stdout/stderr (rotated); mj05 ran blind on DEVNULL
 
     # Step to create HAMMA plot

--- a/config/main.toml
+++ b/config/main.toml
@@ -58,6 +58,7 @@ config_version = 1
         channel = "status"
         key_file = "/home/pi/.googlechat"
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
+        stuck_scrub_cycles = 10  # alert if a prior scrub holds the lock this many consecutive monitor cycles (~10 min; likely hung)
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/config/main.toml
+++ b/config/main.toml
@@ -58,7 +58,9 @@ config_version = 1
         channel = "status"
         key_file = "/home/pi/.googlechat"
         scrub_command = "python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto"
-        stuck_scrub_cycles = 10  # alert if a prior scrub holds the lock this many consecutive monitor cycles (~10 min; likely hung)
+        scrub_hang_timeout_s = 900  # judge a scrub hung if the lock is held with no heartbeat progress this long (>SCAN_TIMEOUT=600s)
+        scrub_auto_recover = true   # kill a genuinely-hung scrub to free the lock (self-healing); false = alert only
+        scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub.log"  # durable capture of scrub stdout/stderr (rotated); mj05 ran blind on DEVNULL
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -411,6 +411,21 @@ When it does roll out, two things do **not** happen automatically and must be in
 
 ## Changelog
 
+- **v4 (mj05 hardware validation + cache hardening):** Ran the scrubber on mj05
+  against real `/ags/data` (AGS stopped): recovered to `DATA56`, purged 78 files,
+  freed ~72GB, retained the 1 corrupt + active file (recover-before-delete held).
+  Resilience features confirmed live: bounded 5.6s AGS scan, honest logging,
+  tmpfs heartbeat advancing. Incremental MJ-scan cache proven at scale —
+  **174× speedup** (1587s cold → 9.1s warm, 1191/1193 dirs cached on 1193 dirs);
+  an initial "cache never hits" report was chased to ground and shown to be
+  *not* a bug (RemoveIPC is off, no cleaner exists, aged cache still hits).
+  Two follow-ups landed: (1) `_refresh_cache_dirs()` refreshes the cache entries
+  for dirs that recovery wrote into (the cache is saved mid-scan, pre-recover, so
+  those dirs were re-read next run); (2) `write_scan_metrics()` appends a durable
+  per-run CSV (`~/brokkr/hamma/log/scrub_metrics.csv`: dirs_cached/total, cold
+  flag, scan_seconds, recovered, purged) so cache hit-rate is reviewable over
+  time and a real-world cold scan leaves a trail. `scrub_auto_recover` still off
+  (#81 unchanged).
 - **v3 (final capstone pass):** Closed the deploy/coverage gaps from the two integration/
   completeness reviews. Code: `low_space` now accepted-and-ignored (won't crash mj54's
   override, C1); `scrub_auto_recover` default flipped to **false** (bench-gate, M1); added a

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -382,7 +382,8 @@ Corrections applied after review (all three were CRITICAL false-kill or fail-ope
 
 **Deployment gate:** `scrub_auto_recover=true` is defensible now that the false-kill vectors
 are closed, but it kills processes — validate on a bench/idle unit (inject a real hung scrub)
-before enabling fleet-wide. The durable `scrub_log` on the SD still self-disables (→DEVNULL)
+before enabling fleet-wide. **Ships off; enabling is tracked in
+[hamma-dev/mjolnir-hamma#81](https://github.com/hamma-dev/mjolnir-hamma/issues/81).** The durable `scrub_log` on the SD still self-disables (→DEVNULL)
 under a full SD; accepted (degrades to old behavior; the tmpfs heartbeat is the load-bearing
 signal).
 

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -169,6 +169,31 @@ effort/7` so the periodic scan yields to brokkr's write pipeline without starvin
 roles:** the steady-state drain, and the reliable **re-spawn backstop** for §3.2 (after a
 hung scrub is killed, the next tick re-runs it — the low-space edge won't re-fire on its own).
 
+**Red-team corrections (3 reviewers) — no CRITICAL ship-blocker; honest scope:**
+- **I/O-priority stanza was on the wrong machine — removed.** The scrub runs on the mj-pi;
+  `/ags/data` + the write pipeline are on the *AGS Pi* (separate host, over SSH), so an mj-pi
+  `ionice` governs nothing on the contended drive (and `mq-deadline` ignores ionice anyway;
+  the AGS java writer already holds *realtime* I/O priority). Kept `Nice=10` (mj-pi CPU only).
+  **Because the scrub does no local block I/O on the AGS drive, the timer does NOT make the
+  fill worse** — it lengthens its own scan, not the writer. So §3.3 is safe to ship *before*
+  §3.5 (incremental scan), which remains the real scan-cost fix.
+- **`Wants=brokkr` → `After=` only:** a 15-min tick must not resurrect a deliberately-stopped
+  brokkr. **`StartLimitIntervalSec=0`:** so repeated §3.2 SIGKILLs (a killed scrub = a systemd
+  *failed* activation) can't trip the start-limit and silently disable the timer under
+  sustained AGS-sick conditions.
+- **Effective cadence is `>= 15 min`, not strict:** under storm load a scrub runs minutes and
+  a tick that lands mid-scrub is skipped by `flock -n`. Fine for a drain; don't advertise 15 min.
+- **`--since auto` kept (not narrowed):** a bounded `--since` would cut scan cost but
+  *under-purge* old confirmed files (they'd fall outside the MJ scan window) → less drain.
+  Completeness wins for a drain; §3.5 is the cost fix.
+- **A §3.2 kill leaves the oneshot in systemd `failed` for ≤15 min** (until the next tick
+  re-activates it) — a sitrep/health check must not misread that as a fault.
+- **M1 (inert recovery) closed for the healthy-disk case:** the kill releases the flock
+  synchronously, so §3.2's immediate `_spawn_scrub` succeeds; the ENOSPC case (where
+  `_spawn_scrub` refuses an `unknown` lock) falls back to the timer, a ≤15-min gap.
+- **Deploy coupling:** ship §3.3 only *with* §3.2 — a bare timer no-ops against a hung lock
+  until §3.1/§3.2 make a held lock visible/recoverable.
+
 A systemd timer (~15 min) that runs the scrub regardless of `bytes_remaining`.
 
 - **What it genuinely buys:** it keeps `/ags/data` drained in steady state so free space

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -215,8 +215,17 @@ A systemd timer (~15 min) that runs the scrub regardless of `bytes_remaining`.
 
 **Built:** `check_sensor_drive` in `state_monitor.py` is now level-triggered across
 `purge_space=200` / `alert_space=75` (replacing the single edge-triggered `low_space`);
-`_maybe_spawn_scrub` gates re-spawns to `scrub_cooldown_s=1800`; NA readings are skipped
-(fair-weather). Config keys in `main.toml`; tests in `test_state_monitor.py::TestTwoThresholdDrain`.
+`_maybe_spawn_scrub` gates re-launches to `scrub_cooldown_s=300` (5 min, so it's more
+responsive than the 15-min §3.3 timer), stamped **only on an actual launch** (a no-op while
+the lock is held doesn't burn the cooldown); NA readings are skipped (fair-weather). Config
+keys in `main.toml`; tests in `test_state_monitor.py::TestTwoThresholdDrain`.
+
+**Red-team corrections:** the alert re-arms on recovery into the drain band (≥ `alert_space`,
+hysteresis) not only above `purge_space`, so a unit oscillating around the floor pages each
+new dip rather than once ever; `__init__` warns if `alert_space >= purge_space`; the alert
+wording no longer claims "still falling" (it states the level + that the scrub is running).
+**Release note:** the 75–200 GB *purge band is now silent by design* — the old edge-trigger's
+"Remaining GB on drive" message is gone; the first operator page is at `alert_space=75`.
 
 Split `low_space` into a **purge** and a higher-urgency **alert** threshold, level-evaluated:
 

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -282,6 +282,37 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
 
 ---
 
+## §3.2 as-built + red-team corrections (honest scope)
+
+Built and reviewed (3 adversarial reviewers). **What §3.2 genuinely delivers:** it
+eliminates the *permanently-stuck lock* (the §1.1b silent-no-op mode) and the DEVNULL
+blindness, and auto-recovers **as soon as the AGS is reachable again**. **What it does NOT
+do (and no code can):** prevent the `/ags/data` fill while the AGS itself is wedged — killing
+a hung scrub frees the lock, not AGS bytes; only a *completed purge* drains the drive, and
+that needs a reachable AGS. Re-using the freed lock relies on the re-spawn below **plus the
+§3.3 timer** as the real backstop (the space trigger is edge-based and won't re-fire).
+
+Corrections applied after review (all three were CRITICAL false-kill or fail-open vectors):
+- **Heartbeat on tmpfs (`/dev/shm`), not the SD root.** The SD fills from logs during the
+  incident (HAM-112/113); a heartbeat that can't be written would make a healthy scrub look
+  hung. tmpfs stays writable when the SD is full.
+- **Detection by heartbeat *advancement* in the monitor's own `monotonic` clock**, never the
+  scrub's wall-clock `timestamp`. Immune to (a) sensor clock skew / NTP steps (a future
+  timestamp no longer disables detection; a backward step no longer false-kills) and (b) a
+  stale heartbeat left by a *previous* run (grace is counted from when the monitor first sees
+  the lock held, so a fresh scrub is never judged against an old file).
+- **Re-spawn after a successful kill** so the freed lock is used (§3.3 timer is the backstop).
+- Kill-path test hardening: assert the process **group** (not the pid) is `SIGKILL`ed, and
+  that the PID-reuse guard actually guards (both mutations now caught); `_pid_is_scrub`
+  matches `hamma_scrub.py`, not a loose substring; `write_status` atomicity asserted by
+  mechanism (temp + `os.replace`).
+
+**Deployment gate:** `scrub_auto_recover=true` is defensible now that the false-kill vectors
+are closed, but it kills processes — validate on a bench/idle unit (inject a real hung scrub)
+before enabling fleet-wide. The durable `scrub_log` on the SD still self-disables (→DEVNULL)
+under a full SD; accepted (degrades to old behavior; the tmpfs heartbeat is the load-bearing
+signal).
+
 ## Changelog
 
 - **v2 (post red-team):** Re-ranked §3 — silent-failure-mode elimination (§3.1) and

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -1,0 +1,223 @@
+# AGS scrub resilience — design
+
+**Scope:** `mjolnir-hamma` only (`plugins/state_monitor.py`, `scripts/hamma_scrub.py`,
+`config/main.toml`, a new systemd timer unit). No brokkr/sindri changes.
+
+**This spec is about one thing: keeping the AGS-pi drive (`/ags/data`) clean.** The scrub's
+job is to offload triggers from `/ags/data` to the mj-pi and purge what's confirmed.
+
+**Non-goals (explicitly out of scope):**
+- **mj-pi `/media/pi/DATA??` drive fullness.** A full MJ recovery drive is a *different*
+  problem with a *different* remedy (rotate/replace the drive), not something the scrub
+  fixes. It matters here only as a *precondition* (recover needs somewhere to land — §3.3);
+  monitoring/alerting on it belongs in a separate MJ-drive-management effort, not here.
+  (See the DATA55 observation in §1 — a real standing issue, filed separately.)
+- The AGS reboot loop / VL805 USB wedge (hardware; fixed by cold power-cycle).
+
+**Status:** design. Supersedes the direction of PR #78 (scrub-trigger-fix) and PR #80
+(disk-safety-monitors) — their useful pieces are folded in below; their framing (an
+edge-vs-level trigger fix) is not the root cause.
+
+---
+
+## 1. What actually happened (mj05, Jul 9–13 2026)
+
+Reconstructed from the telemetry CSVs and recovered-file forensics on mj05. `/ags/data`
+is the AGS USB drive (462 GB); `bytes_remaining` (H&S "Disk Remaining") is its free space.
+
+| Time (UTC) | Evidence | State |
+|---|---|---|
+| Jul 9 20:56 | telemetry 100.22 → 99.54 (clean, no NA) | free crosses `low_space`=100 GB |
+| Jul 9 20:56 → Jul 10 17:59 | **monotonic** 100 → 0, no upward tick | 21 h fill, **no purge freed a byte** |
+| entire fill window | **zero `*_recovered.bin` written** | scrub silent |
+| Jul 10 18:00 → Jul 11 03:34 | telemetry pinned at 0 | drive FULL ~10 h, data loss |
+| Jul 11 03:34 | first & only recovered-file cluster (5 files) | one scrub, ~31 h late |
+| Jul 11 ~04:20 → dark | free reads frozen 448.96 then NA; ping flaps | AGS drive drops → reboot loop |
+| Jul 13 ~11:48 | cold power-cycle | VL805 USB firmware reloads, recovers |
+
+Causal chain (settled): **`/ags/data` full → AGS reboot cycle → USB/FPGA (VL805) wedged →
+persistent reboots** until the operator stopped AGS (~Jul 11 12:00) and cold-cycled Jul 13.
+The reboot/USB half is understood and out of scope here.
+
+### What we proved about the scrubber
+
+1. **The trigger fired.** In the deployed code (`0.4.x @ 426ff2b`), `check_sensor_drive`
+   does `if (space_now < low_space) and (space_pre >= low_space): self._spawn_scrub()`.
+   At the crossing that is `(99.54 < 100) and (100.22 >= 100)` → **True**. The scrub
+   spawned. The failure is **downstream of the trigger** — this is why an edge-vs-level
+   trigger change (PR #78) does not address the root cause.
+2. **The spawned scrub freed nothing.** `bytes_remaining` fell 100 → 0 *monotonically*.
+   Any successful purge would show sawtooth; there is none. No purge freed space in 21 h.
+3. **It had somewhere to write.** DATA56 had 851 GB free throughout (the Jul 11 recovery
+   landed there). "No landing zone" is ruled out *for this incident*.
+4. **Why the pass failed is unrecoverable.** The scrub's output was `DEVNULL`'d, and the
+   journal plus all 10 rotated `brokkr_hamma_005.log.*` files were overwritten within
+   **7 minutes** by reboot-loop error spam (HAM-112). No trace survives.
+
+### What the current system tells us (measured Jul 13, healthy)
+
+- A full dry-run scrub (`--recover --purge -n --since auto`) completes in **21.5 s**, of
+  which **19.8 s is the MJ header scan** (40,565 files); it correctly finds 1 missing
+  trigger, 7 purgeable files. **The code path works** — the Jul 9–11 failure was
+  **condition-dependent** (sustained storm + a degrading AGS), not an always-broken scrub.
+- **Throughput is the constraint.** `recover` issues one `ssh "dd…"` **per trigger**;
+  `purge` issues one `ssh "rm…"` **per file** — sequential, plain SSH, no batching, no
+  persistent connection. Measured round-trip to the AGS: **0.29 s each plain vs 0.018 s
+  with `ControlMaster`** (16×). Purging ~444 files ≈ **2 min of SSH overhead on a healthy
+  AGS**, far worse on a degrading one. `select_target_drive` is also re-called *per
+  trigger*, each time `os.listdir`-ing all 904 DATA55 dirs.
+- **The recovery landing zone was fine.** DATA56 had 851 GB free throughout — "no landing
+  zone" is ruled out as a cause here. (Aside, out of scope: DATA55 has been 100 % full
+  since June 1, unmonitored — a real standing mj-pi issue to file separately, not something
+  this scrub spec addresses.)
+- **The trigger telemetry failed exactly when needed.** As the AGS degraded,
+  `bytes_remaining` went to 0/NA. Any purge decision that *reads* `bytes_remaining` is
+  blind in precisely this state.
+
+---
+
+## 2. Root cause
+
+Not a single bug. The safety net is **reactive, single-shot, blind, and throughput-
+limited**, and it depends on a telemetry signal that fails under the very condition it
+must handle:
+
+- **Reactive + single-shot:** it fires only on the downward `low_space` *crossing*. By the
+  time free space crosses the threshold you are already behind, and the trigger gives
+  exactly one attempt — no retry while space stays low.
+- **Blind:** the scrub runs with `DEVNULL`'d output; nobody can see whether it ran, hung on
+  the `flock`, crashed, or purged nothing. The one incident where we needed the record, the
+  logs were destroyed within minutes.
+- **Throughput-limited:** per-item sequential SSH means a heavy scrub can take minutes to
+  tens of minutes — potentially longer than the fill window it is racing.
+- **Telemetry-dependent:** the trigger reads `bytes_remaining`, which went NA as the AGS
+  degraded.
+
+At max trigger rate (≈500 triggers ≈ 100 GB in ~8 min ⇒ ~12.5 GB/min) a slow, single-shot,
+blind scrub cannot keep pace. At the *observed* incident rate (~5 GB/hr) it could have —
+had it simply **kept running**.
+
+---
+
+## 3. Design
+
+Four changes, layered. The first is the backbone; the rest harden it.
+
+### 3.1 Timer-driven periodic scrub (backbone)
+
+Run the scrub on a **systemd timer (~15 min)**, independent of `bytes_remaining`.
+
+- **Why a timer, not the low-space trigger:** it is **telemetry-independent** — it runs
+  whether or not `bytes_remaining` is reporting, which is the failure that broke this
+  incident. It keeps `/ags/data` drained in steady state so free space never *approaches*
+  the threshold under normal storms.
+- **Write-cost is not a concern** (evaluated): the scrub is read-dominated. The MJ scan is
+  pure reads (`relatime` vfat ⇒ no atime writes within a day); `recover` writes only
+  genuinely-missing triggers (~0–1/run in steady state); `purge` is KB-scale vfat metadata
+  deletes. Against the ~120 GB/day these drives already log 24/7, the timer adds **< 1 %**
+  write load — a rounding error on a 2 TB SSD's ~600–1200 TBW. Add `noatime` to be safe.
+- **The real timer cost is I/O contention**, not wear: a 20 s full scan every 15 min
+  competes with the write pipeline for USB bandwidth. Mitigated by the incremental scan
+  (§3.3).
+- Implementation: a `hamma-scrub.timer` + `hamma-scrub.service` (oneshot) running the
+  scrub as `pi`. Keep the existing `flock -n /tmp/hamma_scrub.lock` so timer and any
+  threshold-driven run can never overlap.
+
+### 3.2 Two-threshold escalation (on top of the timer, when telemetry is available)
+
+Split the single `low_space` into a **purge** threshold and a higher-urgency **alert**
+threshold, both level-evaluated on the 60 s monitor cycle:
+
+- **Purge at `xx = 200 GB` free** (higher): while free < `xx`, run the scrub every cooldown
+  (level-triggered, *not* a one-shot edge). This is proactive draining that starts well
+  before the situation is critical and is more responsive (every few minutes) than the
+  15-min timer. **No alert** — this is normal "working hard."
+- **Alert at `yy = 75 GB` free** (lower): fire a distinct notification only if free space
+  punches *through* `xx` down to `yy` **despite** the purging. That means **purge is
+  losing** — the safety net is failing and a human is needed. Debounced (alert once on
+  entry; re-arm when free climbs back above `yy`). If space stabilizes above `yy`, silence.
+
+The `xx → yy` band (200 → 75 GB = 125 GB ≈ 10 min of max-rate runway) is the window where
+purge gets to prove it can keep up before anyone is paged.
+
+**Parameter justification** (drive 462 GB; max fill 12.5 GB/min; fast scrub target 1–2 min):
+
+| Knob | Value | Rationale |
+|---|---|---|
+| timer interval | 15 min | steady-state drain; at observed ~5 GB/hr only ~1.25 GB accrues/interval |
+| `xx` purge start | 200 GB free | ~16 min max-rate runway to empty; comfortably above a fast scrub |
+| `yy` alert | 75 GB free | ~6 min max-rate runway left when paged — urgent but actionable; at observed rate ~15 h |
+
+At **max** rate the 15-min timer alone is too coarse (187 GB can accrue between ticks) —
+that is exactly the regime the level-triggered `xx` purge covers between timer ticks. At
+**observed** rate the timer alone suffices. The two mechanisms cover different regimes.
+
+### 3.3 Make the scrub fast (so it can survive surges)
+
+- **Persistent SSH** to the AGS via `ControlMaster`/`ControlPersist` (one connection reused
+  for all `dd`/`rm`): measured **16× per-op speedup** (0.29 s → 0.018 s). Add
+  `-o BatchMode=yes -o ConnectTimeout=10` so a sick AGS fails fast instead of hanging.
+- **Batch the deletes:** one `ssh "rm f1 f2 … fN"` (chunked) instead of N round-trips.
+- **Fix `select_target_drive`:** compute the target **once per run**, not per trigger
+  (drop the per-trigger `os.listdir` over 904 dirs).
+- **Incremental MJ scan:** cache the confirmed-header set keyed by hourly dir; on each run
+  scan only new/changed hours. Cuts the 20 s scan to near-zero in steady state, removing
+  the I/O-contention cost of a frequent timer.
+- **Tighten timeouts:** the 3600 s scan cap lets one futile pass hold the lock for an hour;
+  reduce to minutes now that SSH is fast and fails fast.
+
+### 3.4 Observability + failure detection (so the next incident is diagnosable)
+
+- **Persistent, rotation-safe scrub log** (`scrub_log`, already added in PR #78): capture
+  every run's scan/recover/purge **counts, per-phase timings, errors, and lock-acquisition
+  result**. Never `DEVNULL`.
+- **Futile-scrub alert:** if consecutive runs purge 0 files while free space keeps falling,
+  alert ("scrub running but not freeing space"). This is the symptom the 21-h silent ramp
+  never surfaced.
+- **Stuck-lock detection:** if `flock` fails to acquire for N consecutive runs, alert (a
+  prior scrub is hung).
+
+---
+
+## 4. What this supersedes
+
+| Prior work | Disposition |
+|---|---|
+| PR #78 edge→level trigger + cooldown | **Reframed.** Level-triggering survives as the `xx` purge behavior, but as *part of* the two-threshold + timer design, not as "the fix." The trigger was never the failure. |
+| PR #78 `scrub_log` | **Kept** — it is the one directly useful piece (§3.4). |
+| PR #80 Layer 1 `check_recovery_drives` | **Out of scope** — mj-pi `DATA??` fullness is a separate MJ-drive-management issue, not part of keeping `/ags/data` clean. Belongs in its own effort. |
+| PR #80 Layer 2 H&S staleness watchdog | **Folded in** — the timer's telemetry-independence is the structural answer; a staleness alert remains useful as a cheap signal. |
+| PR #80 Layer 3 futile-scrub alert | **Kept** (§3.4). |
+
+---
+
+## 5. Test plan
+
+- **Unit (pytest):** two-threshold state machine (purge below `xx`, alert crossing `yy`,
+  debounce/re-arm, no alert while `yy < free < xx`); `select_target_drive` called once;
+  batched-delete command construction; incremental-scan cache hit/miss; futile/stuck
+  detection latches.
+- **Scrub-script:** ControlMaster path (mock ssh), batched `rm` chunking, timeout/fail-fast
+  behavior, dry-run still deletes nothing.
+- **Integration (on a bench/idle unit):** timer fires and completes; a forced near-full
+  condition drives purge below `xx`, alert at `yy`, recovery re-arms; measure real scrub
+  wall-clock with ControlMaster+batch vs baseline.
+- **Load reproduction:** near-full `/ags/data` + synthetic sustained influx, instrumentation
+  on — confirm the scrub keeps pace or that the futile alert fires. This is the test the
+  original incident lacked.
+
+---
+
+## 6. Open questions / risks
+
+1. **Fast-scrub wall-clock under load** is still to be *measured*, not assumed — §5 load
+   test sets `xx`/timer definitively. Values in §3.2 are starting points.
+2. **Incremental-scan cache invalidation** (compression rewrites files, udisks suffixed
+   mounts `DATA071`) — must fall back to a full scan on cache miss/anomaly.
+3. **Timer + brokkr write contention** during a real storm — the incremental scan should
+   remove most of it; verify under load.
+4. **`bytes_remaining` = `/ags/data` free** is established empirically here (fills to 0,
+   scrub targets the same drive, 448.96 GB ceiling ≈ 462 GB drive). This **contradicts an
+   older internal note** claiming it is *not* the AGS drive — that note should be corrected.
+5. Per-unit variation (mj05 is `nochargecontroller`, no ttyUSB; PAMMA units differ) — keep
+   thresholds configurable per unit.

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -275,8 +275,17 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
   scan); it self-prunes (dirs not seen are dropped) and falls back to a full re-read on any
   cache anomaly (corrupt file, changed signature). `--mj-cache ""` forces a full scan. The
   full scanner (`_scan_mj_full`) is unchanged and used when no cache is configured. Tests:
-  `test_hamma_scrub.py::TestIncrementalScan` (10, incl. a patched `_read_dir_headers` proving
-  cache hits don't re-read, parity-vs-full-scan, corrupt-cache fallback, self-prune).
+  `test_hamma_scrub.py::TestIncrementalScan` (13, incl. a patched `_read_dir_headers` proving
+  older-dir cache hits don't re-read, parity-vs-full-scan, corrupt-cache fallback, self-prune).
+  **Red-team corrections (2 CRITICAL):** (1) cache is **JSON, not pickle** — `/dev/shm` is
+  world-writable (1777), so unpickling it was a local-RCE-as-`pi` vector; JSON stores headers
+  as hex and can't execute code on load. (2) brokkr **append-writes** `.bin` in place
+  (`mode="ab"`, no atomic rename) on **2 s-granularity vfat**, so an in-place completion can
+  leave `(mtime, count)` unchanged → stale header → wrong purge; fixed by **always
+  re-reading the newest hourly dir per drive** (the only one brokkr appends to — past dirs are
+  immutable once the hour rolls over). Tests pin both signature components on non-newest dirs
+  and the in-place-growth case. `duplicate_count` legitimately diverges from the full scanner
+  for cross-dir dups (log stat only, never a control input — commented).
 - **`select_target_drive` once per run**, not per trigger (drops a per-trigger `os.listdir`
   over 904 dirs). Minor for *this* incident (0 triggers recovered during the fill).
 - **`--since auto` for the timer path** needs pinning down — under a storm it pushes the MJ

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -213,6 +213,11 @@ A systemd timer (~15 min) that runs the scrub regardless of `bytes_remaining`.
 
 ### 3.4 Two-threshold escalation — fair-weather improvement (would NOT have prevented mj05)
 
+**Built:** `check_sensor_drive` in `state_monitor.py` is now level-triggered across
+`purge_space=200` / `alert_space=75` (replacing the single edge-triggered `low_space`);
+`_maybe_spawn_scrub` gates re-spawns to `scrub_cooldown_s=1800`; NA readings are skipped
+(fair-weather). Config keys in `main.toml`; tests in `test_state_monitor.py::TestTwoThresholdDrain`.
+
 Split `low_space` into a **purge** and a higher-urgency **alert** threshold, level-evaluated:
 
 - **Purge at `xx = 200 GB` free**: while free < `xx`, run the scrub every cooldown

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -111,30 +111,52 @@ happen silently** and **visible when it does**.
 Ordered by how directly each addresses the failure mode we cannot rule out (the hang), not
 by how appealing it sounds.
 
-### 3.1 Kill the silent-failure modes (THE fix for a hang) — highest priority
+### 3.1 Make silent failure impossible + visible (partially built) — highest priority
 
-- **Make `_spawn_scrub` honest about the lock.** Today it logs success whether or not
-  `flock` acquired. Have it detect and log/report lock contention explicitly (e.g. probe
-  `flock -n` acquisition, or have the scrub itself write a start/end record) so "a prior
-  scrub is still running" is *visible*, not silent.
-- **Bound the scan timeout.** Drop the scrub's `subprocess.run(timeout=3600)` scan cap to
-  minutes. This is the single value that bounds worst-case lock-hold time; until it drops,
-  `flock -n` + 3600 s = a scrub can wedge the safety net for an hour.
-- **Fail-fast SSH.** `-o BatchMode=yes -o ConnectTimeout=10` on every AGS call so a sick AGS
-  fails fast instead of hanging toward the cap. *(Built — see `perf(scrub)`; this is the
-  most incident-relevant part of that commit, more than the speedup.)*
-- **Stuck-lock detection + recovery.** If `flock` fails to acquire for N consecutive cycles,
-  alert (a prior scrub is hung) and consider killing/replacing the stale holder.
+**Built (commit `§3.1`), and honestly bounded by red-team review:**
+- **Fail-fast SSH** (`BatchMode` + `ConnectTimeout=10`) + **bounded scan timeout** (3600 →
+  `SCAN_TIMEOUT=600 s`). Real, unconditional wins: they shorten a hung scan's lock-hold from
+  up to an hour to ≤10 min. *(But 600 s bounds only the scan phase; recover/purge are
+  bounded per-item, not in aggregate — so total lock-hold is still not capped. §3.2.)*
+- **Honest `_spawn_scrub`** — probes the lock (real `flock(2)`, interoperates with the
+  spawned `flock -n`) and logs whether it actually spawned vs. skipped, instead of logging
+  "Spawned" unconditionally. **Limit:** only useful if the log survives — and mj05's logs
+  were destroyed in 7 min (HAM-112). So this is load-bearing only *with* §3.2's durable log.
+- **Stuck-lock detector** `check_scrub_health` — alerts once if the lock is held for
+  `stuck_scrub_cycles` (default 10 ≈ 10 min) consecutive cycles. **Three limits found in
+  review, all deferred to §3.2 because they need a *progress signal*:**
+  1. **Alert-only, no recovery.** It *narrates* a hang; it does not free the lock. The drive
+     still fills until a human acts (mj05: ~2 days unwatched).
+  2. **Lock-age ≠ progress → cry-wolf.** A legit large recovery (60 s/trigger, unbounded
+     aggregate) can hold the lock > 10 cycles → false "hung" alert. Can't distinguish
+     "grinding" from "hung" without a heartbeat.
+  3. **`/tmp`-full blind spot.** During a disk-full event the lockfile can be uncreatable
+     (`ENOSPC`) → the probe currently fails to "free" → the alert *cannot fire in the exact
+     incident it targets*, and `_spawn_scrub` resumes lying. Needs a tri-state
+     (held/free/**unknown**) where the detector escalates "unknown" but the spawner does not
+     suppress the scrub.
 
-### 3.2 Observability (so the next incident is diagnosable) — second
+**Conclusion:** §3.1's detection/visibility half is built; its **teeth (safe recovery) and
+robustness (no cry-wolf, no disk-full blind spot) all require a progress heartbeat** — which
+is §3.2. §3.1 and §3.2 are therefore implemented together (see §3.2).
 
-- **Persistent, rotation-safe scrub log** (`scrub_log`, from PR #78): every run's
-  scan/recover/purge **counts, per-phase timings, errors, and lock-acquisition result**.
-  Never `DEVNULL`. Without this, the next incident is as blind as this one.
+### 3.2 Progress heartbeat → durable log, real stuck-detection, self-healing — second (carries §3.1's teeth)
+
+The scrub writes a **heartbeat** (timestamp + phase + running counts) to a durable,
+rotation-safe file as it advances. Everything §3.1 couldn't do safely follows from it:
+- **Persistent, rotation-safe scrub log** (`scrub_log`, from PR #78): scan/recover/purge
+  counts, per-phase timings, errors, lock result. Survives the reboot-spam, so §3.1's honest
+  logging becomes durable.
+- **Progress-gated stuck detection:** redefine "stuck" as **lock held AND heartbeat stale**
+  (not just lock-age). This kills the cry-wolf false positive (a working recovery keeps the
+  heartbeat fresh) and is the only safe basis for auto-recovery.
+- **Self-healing recovery (§3.1's dropped teeth):** on a *genuine* hang (lock held +
+  heartbeat stale beyond threshold), **kill the stale scrub + free the lock** so the next
+  cycle re-spawns. Safe precisely because the heartbeat proves it's hung, not working.
+- **Tri-state lock probe** (held/free/unknown) so the `/tmp`-full case escalates in the
+  detector without suppressing the scrub in the spawner.
 - **Futile-scrub alert:** consecutive runs that purge 0 files while free space keeps falling
-  → alert ("running but not freeing space") — the symptom the 21-h ramp never surfaced.
-- **Honest spawn-side logging** (pairs with §3.1) so the state_monitor side can't lie about a
-  no-op'd spawn.
+  → "running but not freeing space" (the symptom the 21-h ramp never surfaced).
 
 ### 3.3 Timer-driven periodic scrub — steady-state drain, NOT the cure for a hang
 

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -8,28 +8,28 @@ job is to offload triggers from `/ags/data` to the mj-pi and purge what's confir
 
 **Non-goals (explicitly out of scope):**
 - **mj-pi `/media/pi/DATA??` drive fullness.** A full MJ recovery drive is a *different*
-  problem with a *different* remedy (rotate/replace the drive), not something the scrub
-  fixes. It matters here only as a *precondition* (recover needs somewhere to land — §3.3);
-  monitoring/alerting on it belongs in a separate MJ-drive-management effort, not here.
-  (See the DATA55 observation in §1 — a real standing issue, filed separately.)
+  problem with a *different* remedy (rotate/replace the drive). It matters here only as a
+  *precondition* (recover needs somewhere to land). Monitoring it belongs in a separate
+  MJ-drive-management effort. (DATA55 has been 100 % full since June 1 — file separately.)
 - The AGS reboot loop / VL805 USB wedge (hardware; fixed by cold power-cycle).
 
-**Status:** design. Supersedes the direction of PR #78 (scrub-trigger-fix) and PR #80
-(disk-safety-monitors) — their useful pieces are folded in below; their framing (an
-edge-vs-level trigger fix) is not the root cause.
+**Status:** design, **re-ranked after adversarial (red-team) review** — see the changelog at
+the end. Supersedes the direction of PR #78 (scrub-trigger-fix) and PR #80
+(disk-safety-monitors); their useful pieces are folded in. **Their framing (an edge-vs-level
+trigger fix) is not the root cause — and neither is a timer (see §2/§3).**
 
 ---
 
 ## 1. What actually happened (mj05, Jul 9–13 2026)
 
-Reconstructed from the telemetry CSVs and recovered-file forensics on mj05. `/ags/data`
-is the AGS USB drive (462 GB); `bytes_remaining` (H&S "Disk Remaining") is its free space.
+Reconstructed from telemetry CSVs and recovered-file forensics on mj05. `/ags/data` is the
+AGS USB drive (462 GB); `bytes_remaining` (H&S "Disk Remaining") is its free space.
 
 | Time (UTC) | Evidence | State |
 |---|---|---|
-| Jul 9 20:56 | telemetry 100.22 → 99.54 (clean, no NA) | free crosses `low_space`=100 GB |
-| Jul 9 20:56 → Jul 10 17:59 | **monotonic** 100 → 0, no upward tick | 21 h fill, **no purge freed a byte** |
-| entire fill window | **zero `*_recovered.bin` written** | scrub silent |
+| Jul 9 20:56 | telemetry 100.22 → 99.54 (clean, no NA in CSV) | free crosses `low_space`=100 GB |
+| Jul 9 20:56 → Jul 10 17:59 | **monotonic** 100 → 0, no upward tick | 21 h fill, no purge visibly freed space |
+| entire fill window | **zero `*_recovered.bin` written** | scrub did no recovery |
 | Jul 10 18:00 → Jul 11 03:34 | telemetry pinned at 0 | drive FULL ~10 h, data loss |
 | Jul 11 03:34 | first & only recovered-file cluster (5 files) | one scrub, ~31 h late |
 | Jul 11 ~04:20 → dark | free reads frozen 448.96 then NA; ping flaps | AGS drive drops → reboot loop |
@@ -37,164 +37,175 @@ is the AGS USB drive (462 GB); `bytes_remaining` (H&S "Disk Remaining") is its f
 
 Causal chain (settled): **`/ags/data` full → AGS reboot cycle → USB/FPGA (VL805) wedged →
 persistent reboots** until the operator stopped AGS (~Jul 11 12:00) and cold-cycled Jul 13.
-The reboot/USB half is understood and out of scope here.
+The reboot/USB half is understood and out of scope.
 
-### What we proved about the scrubber
+### What we can and cannot claim about the scrubber
 
-1. **The trigger fired.** In the deployed code (`0.4.x @ 426ff2b`), `check_sensor_drive`
-   does `if (space_now < low_space) and (space_pre >= low_space): self._spawn_scrub()`.
-   At the crossing that is `(99.54 < 100) and (100.22 >= 100)` → **True**. The scrub
-   spawned. The failure is **downstream of the trigger** — this is why an edge-vs-level
-   trigger change (PR #78) does not address the root cause.
-2. **The spawned scrub freed nothing.** `bytes_remaining` fell 100 → 0 *monotonically*.
-   Any successful purge would show sawtooth; there is none. No purge freed space in 21 h.
-3. **It had somewhere to write.** DATA56 had 851 GB free throughout (the Jul 11 recovery
-   landed there). "No landing zone" is ruled out *for this incident*.
-4. **Why the pass failed is unrecoverable.** The scrub's output was `DEVNULL`'d, and the
-   journal plus all 10 rotated `brokkr_hamma_005.log.*` files were overwritten within
-   **7 minutes** by reboot-loop error spam (HAM-112). No trace survives.
+1. **The trigger *should* have fired — but we cannot prove it *effectively* did.** In the
+   deployed code (`0.4.x @ 426ff2b`), `check_sensor_drive` does
+   `if (space_now < low_space) and (space_pre >= low_space): self._spawn_scrub()`. At the
+   crossing that is `(99.54 < 100) and (100.22 >= 100)` → **True**, so the *edge condition*
+   was met. But "condition met" ≠ "a scrub ran and did work." `_spawn_scrub` wraps the
+   command in **`flock -n`** (non-blocking) and logs `"Spawned scrub"` **unconditionally**
+   after `Popen` succeeds — *before* `flock` has acquired anything. So if a **prior scrub was
+   hung** holding the lock, the spawn is a **silent no-op** and even the log line would have
+   lied. **Two possibilities are indistinguishable from the destroyed evidence:** (a) a scrub
+   ran and freed nothing, or (b) the spawn silently no-op'd against a hung prior scrub. They
+   have *different fixes*. (Verified downstream: the deployed scrub had **no** fail-fast SSH
+   and a **3600 s** scan timeout — so a scan against the degrading AGS could hang up to an
+   hour, and with `flock -n` + the single-shot edge, one hang stalls the safety net for the
+   whole window. This makes (b) a live, code-supported hypothesis, not a footnote.)
+2. **No purge *visibly* freed space — strongly indicated, not proven.** `bytes_remaining`
+   fell 100 → 0 monotonically with no up-tick. At the observed ~5 GB/hr, a purge freeing even
+   a few GB *would* show (a 3 GB purge erases ~36 min of inflow in one 1-min sample), so this
+   inference is sound **at this rate**. It would NOT hold at the design's "max rate"
+   (12.5 GB/min), and it rests on the same `bytes_remaining` signal we elsewhere call
+   unreliable — so: *strongly indicated for the fill window, not proven.*
+3. **It had somewhere to write.** DATA56 had 851 GB free throughout. "No landing zone" is
+   ruled out for this incident.
+4. **Why it failed is unrecoverable.** Scrub output was `DEVNULL`'d; the journal + all 10
+   rotated `brokkr_hamma_005.log.*` were overwritten within **7 minutes** by reboot-loop
+   spam (HAM-112). No trace survives.
 
 ### What the current system tells us (measured Jul 13, healthy)
 
-- A full dry-run scrub (`--recover --purge -n --since auto`) completes in **21.5 s**, of
-  which **19.8 s is the MJ header scan** (40,565 files); it correctly finds 1 missing
-  trigger, 7 purgeable files. **The code path works** — the Jul 9–11 failure was
-  **condition-dependent** (sustained storm + a degrading AGS), not an always-broken scrub.
-- **Throughput is the constraint.** `recover` issues one `ssh "dd…"` **per trigger**;
-  `purge` issues one `ssh "rm…"` **per file** — sequential, plain SSH, no batching, no
-  persistent connection. Measured round-trip to the AGS: **0.29 s each plain vs 0.018 s
-  with `ControlMaster`** (16×). Purging ~444 files ≈ **2 min of SSH overhead on a healthy
-  AGS**, far worse on a degrading one. `select_target_drive` is also re-called *per
-  trigger*, each time `os.listdir`-ing all 904 DATA55 dirs.
-- **The recovery landing zone was fine.** DATA56 had 851 GB free throughout — "no landing
-  zone" is ruled out as a cause here. (Aside, out of scope: DATA55 has been 100 % full
-  since June 1, unmonitored — a real standing mj-pi issue to file separately, not something
-  this scrub spec addresses.)
-- **The trigger telemetry failed exactly when needed.** As the AGS degraded,
-  `bytes_remaining` went to 0/NA. Any purge decision that *reads* `bytes_remaining` is
-  blind in precisely this state.
+- A full dry-run scrub completes in ~21.5 s healthy, but under **active AGS recording** the
+  **AGS scan alone rose ~1 s → 99 s** and the MJ scan to minutes (see §3.5). The code path
+  works; the Jul 9–11 failure was **condition-dependent** (storm + degrading AGS).
+- **Throughput:** `recover` = one `ssh dd` per trigger, `purge` = one `ssh rm` per file —
+  sequential plain SSH. Round-trip 0.29 s plain / 0.018 s multiplexed.
+- **Telemetry failed when needed:** as the AGS degraded, `bytes_remaining` went NA. Any
+  decision that *reads* `bytes_remaining` is blind in exactly this state.
 
 ---
 
-## 2. Root cause
+## 2. Root cause (honest version)
 
-Not a single bug. The safety net is **reactive, single-shot, blind, and throughput-
-limited**, and it depends on a telemetry signal that fails under the very condition it
-must handle:
+**The specific mechanism is unrecoverable** (§1.4). What we *can* name is a set of
+structural defects, and — critically — **we must design for the failure mode we cannot rule
+out (a hung / silently-no-op'd scrub), not just the one that's easier to fix (a scrub that
+ran but was too slow).**
 
-- **Reactive + single-shot:** it fires only on the downward `low_space` *crossing*. By the
-  time free space crosses the threshold you are already behind, and the trigger gives
-  exactly one attempt — no retry while space stays low.
-- **Blind:** the scrub runs with `DEVNULL`'d output; nobody can see whether it ran, hung on
-  the `flock`, crashed, or purged nothing. The one incident where we needed the record, the
-  logs were destroyed within minutes.
-- **Throughput-limited:** per-item sequential SSH means a heavy scrub can take minutes to
-  tens of minutes — potentially longer than the fill window it is racing.
-- **Telemetry-dependent:** the trigger reads `bytes_remaining`, which went NA as the AGS
-  degraded.
+- **Silent single-point failure (the one the timer does NOT fix).** `flock -n` turns a
+  hung prior scrub into a silent no-op for every subsequent spawn; the spawn-side log lies;
+  the edge is single-shot so it never retries. A single hang → zero effective scrubs for the
+  whole window, invisibly.
+- **Blind.** `DEVNULL`'d output; the logs that might have caught it were destroyed in
+  minutes.
+- **No fail-fast.** Deployed SSH had no `ConnectTimeout`/`BatchMode`; the scan could hang up
+  to 3600 s against a sick AGS, holding the lock.
+- **Reactive + single-shot + telemetry-dependent.** Fires only on the downward crossing, one
+  attempt, off a signal (`bytes_remaining`) that went NA.
+- **Throughput-limited.** Per-item sequential SSH; a heavy scrub can outlast its fill window.
 
-At max trigger rate (≈500 triggers ≈ 100 GB in ~8 min ⇒ ~12.5 GB/min) a slow, single-shot,
-blind scrub cannot keep pace. At the *observed* incident rate (~5 GB/hr) it could have —
-had it simply **kept running**.
+**The trap to avoid:** PR #78 was tangential because it fixed trigger *arming* when the
+trigger provably armed. A **timer**, made the headline, is tangential *in the same way* if
+the real cause was a hang — more timer ticks just no-op against the held lock. So the timer
+is **not** the primary fix. The primary fixes are the ones that make a hang **impossible to
+happen silently** and **visible when it does**.
 
 ---
 
-## 3. Design
+## 3. Design — re-ranked
 
-Four changes, layered. The first is the backbone; the rest harden it.
+Ordered by how directly each addresses the failure mode we cannot rule out (the hang), not
+by how appealing it sounds.
 
-### 3.1 Timer-driven periodic scrub (backbone)
+### 3.1 Kill the silent-failure modes (THE fix for a hang) — highest priority
 
-Run the scrub on a **systemd timer (~15 min)**, independent of `bytes_remaining`.
+- **Make `_spawn_scrub` honest about the lock.** Today it logs success whether or not
+  `flock` acquired. Have it detect and log/report lock contention explicitly (e.g. probe
+  `flock -n` acquisition, or have the scrub itself write a start/end record) so "a prior
+  scrub is still running" is *visible*, not silent.
+- **Bound the scan timeout.** Drop the scrub's `subprocess.run(timeout=3600)` scan cap to
+  minutes. This is the single value that bounds worst-case lock-hold time; until it drops,
+  `flock -n` + 3600 s = a scrub can wedge the safety net for an hour.
+- **Fail-fast SSH.** `-o BatchMode=yes -o ConnectTimeout=10` on every AGS call so a sick AGS
+  fails fast instead of hanging toward the cap. *(Built — see `perf(scrub)`; this is the
+  most incident-relevant part of that commit, more than the speedup.)*
+- **Stuck-lock detection + recovery.** If `flock` fails to acquire for N consecutive cycles,
+  alert (a prior scrub is hung) and consider killing/replacing the stale holder.
 
-- **Why a timer, not the low-space trigger:** it is **telemetry-independent** — it runs
-  whether or not `bytes_remaining` is reporting, which is the failure that broke this
-  incident. It keeps `/ags/data` drained in steady state so free space never *approaches*
-  the threshold under normal storms.
-- **Write-cost is not a concern** (evaluated): the scrub is read-dominated. The MJ scan is
-  pure reads (`relatime` vfat ⇒ no atime writes within a day); `recover` writes only
-  genuinely-missing triggers (~0–1/run in steady state); `purge` is KB-scale vfat metadata
-  deletes. Against the ~120 GB/day these drives already log 24/7, the timer adds **< 1 %**
-  write load — a rounding error on a 2 TB SSD's ~600–1200 TBW. Add `noatime` to be safe.
-- **The real timer cost is I/O contention**, not wear: a 20 s full scan every 15 min
-  competes with the write pipeline for USB bandwidth. Mitigated by the incremental scan
-  (§3.3).
-- Implementation: a `hamma-scrub.timer` + `hamma-scrub.service` (oneshot) running the
-  scrub as `pi`. Keep the existing `flock -n /tmp/hamma_scrub.lock` so timer and any
-  threshold-driven run can never overlap.
+### 3.2 Observability (so the next incident is diagnosable) — second
 
-### 3.2 Two-threshold escalation (on top of the timer, when telemetry is available)
+- **Persistent, rotation-safe scrub log** (`scrub_log`, from PR #78): every run's
+  scan/recover/purge **counts, per-phase timings, errors, and lock-acquisition result**.
+  Never `DEVNULL`. Without this, the next incident is as blind as this one.
+- **Futile-scrub alert:** consecutive runs that purge 0 files while free space keeps falling
+  → alert ("running but not freeing space") — the symptom the 21-h ramp never surfaced.
+- **Honest spawn-side logging** (pairs with §3.1) so the state_monitor side can't lie about a
+  no-op'd spawn.
 
-Split the single `low_space` into a **purge** threshold and a higher-urgency **alert**
-threshold, both level-evaluated on the 60 s monitor cycle:
+### 3.3 Timer-driven periodic scrub — steady-state drain, NOT the cure for a hang
 
-- **Purge at `xx = 200 GB` free** (higher): while free < `xx`, run the scrub every cooldown
-  (level-triggered, *not* a one-shot edge). This is proactive draining that starts well
-  before the situation is critical and is more responsive (every few minutes) than the
-  15-min timer. **No alert** — this is normal "working hard."
-- **Alert at `yy = 75 GB` free** (lower): fire a distinct notification only if free space
-  punches *through* `xx` down to `yy` **despite** the purging. That means **purge is
-  losing** — the safety net is failing and a human is needed. Debounced (alert once on
-  entry; re-arm when free climbs back above `yy`). If space stabilizes above `yy`, silence.
+A systemd timer (~15 min) that runs the scrub regardless of `bytes_remaining`.
 
-The `xx → yy` band (200 → 75 GB = 125 GB ≈ 10 min of max-rate runway) is the window where
-purge gets to prove it can keep up before anyone is paged.
+- **What it genuinely buys:** it keeps `/ags/data` drained in steady state so free space
+  never *approaches* the threshold under normal storms, and it removes the **telemetry**
+  dependency (doesn't read `bytes_remaining`).
+- **What it does NOT buy (correction after review):** it is **not** "telemetry-independent
+  backbone" — it removes the telemetry dependency but **inherits the AGS-reachability
+  dependency, which is the thing that actually broke.** A timer firing into a rebooting AGS
+  still fails/hangs (now fast, *if* §3.1's fail-fast is deployed). And against a hung scrub
+  holding `flock -n`, **every timer tick no-ops** — the timer adds firing cadence, not
+  hang-recovery. It is only load-bearing once §3.1 is in place.
+- **Write-cost is not a concern** (evaluated): scrub is read-dominated (scan = reads, vfat
+  `relatime`; recover writes ~0–1/run steady-state; purge = KB vfat metadata). < 1 % of the
+  ~120 GB/day these drives already log. Add `noatime`.
+- Keep `flock -n` so timer and threshold runs can't overlap — **but only after §3.1 makes a
+  held lock visible**, else the timer just multiplies silent no-ops.
 
-**Parameter justification** (drive 462 GB; max fill 12.5 GB/min; fast scrub target 1–2 min):
+### 3.4 Two-threshold escalation — fair-weather improvement (would NOT have prevented mj05)
 
-| Knob | Value | Rationale |
+Split `low_space` into a **purge** and a higher-urgency **alert** threshold, level-evaluated:
+
+- **Purge at `xx = 200 GB` free**: while free < `xx`, run the scrub every cooldown
+  (level-triggered, not one-shot). Proactive draining before it's critical.
+- **Alert at `yy = 75 GB` free**: fire only if free punches *through* `xx` to `yy` **despite**
+  purging — i.e. **purge is losing**. Debounced; re-arm above `yy`.
+
+**Honest caveats (post-review):**
+- Both thresholds **read `bytes_remaining`**, which went NA in the failure mode — so this
+  layer is **blind exactly when it mattered**. It's a good-weather improvement.
+- **It would not have prevented this incident.** The scrub had ~21 h of runway after the
+  crossing and used none of it — *time was never the binding constraint*. Raising 100→200 GB
+  just moves the single edge-spawn earlier; if that spawn no-op'd (§1.1b), 200 vs 100 changes
+  nothing. 200/75 are reasonable belt-and-suspenders, **not** the fix.
+
+| Knob | Value | Rationale (arithmetic, not evidence) |
 |---|---|---|
-| timer interval | 15 min | steady-state drain; at observed ~5 GB/hr only ~1.25 GB accrues/interval |
-| `xx` purge start | 200 GB free | ~16 min max-rate runway to empty; comfortably above a fast scrub |
-| `yy` alert | 75 GB free | ~6 min max-rate runway left when paged — urgent but actionable; at observed rate ~15 h |
+| timer interval | 15 min | steady-state drain; observed ~5 GB/hr ⇒ ~1.25 GB/interval |
+| `xx` purge start | 200 GB free | ~16 min max-rate runway above a fast scrub |
+| `yy` alert | 75 GB free | ~6 min max-rate runway when paged; ~15 h at observed rate |
 
-At **max** rate the 15-min timer alone is too coarse (187 GB can accrue between ticks) —
-that is exactly the regime the level-triggered `xx` purge covers between timer ticks. At
-**observed** rate the timer alone suffices. The two mechanisms cover different regimes.
+### 3.5 Make the scrub fast + incremental scan — hardening (claims corrected)
 
-### 3.3 Make the scrub fast (so it can survive surges)
-
-**Measured (mj05 → AGS, Jul 13):** per-file purge baseline **~100 s / 500 files** (plain
-per-op SSH); **batched over one `ControlMaster` connection: 0.163 s / ~480 files** (4
-chunked `rm` calls) — a **~600×** speedup. Purge ceases to be a bottleneck; a full scrub's
-cost collapses onto the MJ scan (~20 s), which the incremental scan below then attacks. A
-fast scrub of ~20–30 s against the 200 GB purge start leaves ~16 min of max-rate runway.
-
-**Prototype validated on-sensor (mj05, Jul 13, Python 3.7.3, real files):** the implemented
-`open_control_master` + batched `purge_ags_files` deleted 230 throwaway AGS files in
-**0.117 s** vs a **~63 s** plain-per-file baseline (~500×), confirmed the drive empty after,
-and tore the master down cleanly. See `perf(scrub)` commit; 26 unit tests.
-
-**Scan-cost-under-load finding (important, drives the incremental scan):** the same day,
-under active AGS recording, a full scrub's **AGS scan alone rose from ~1 s to 99 s** (9 →
-35 files) and the MJ scan stretched to minutes — pure USB read/write contention with the
-live recording. Once purge is ~free, the scan is *the* bottleneck, and it inflates exactly
-when the system is busiest. The incremental scan (below) is therefore not optional polish —
-it is the load-bearing piece for keeping a periodic scrub cheap.
-
-
-- **Persistent SSH** to the AGS via `ControlMaster`/`ControlPersist` (one connection reused
-  for all `dd`/`rm`): measured **16× per-op speedup** (0.29 s → 0.018 s). Add
-  `-o BatchMode=yes -o ConnectTimeout=10` so a sick AGS fails fast instead of hanging.
-- **Batch the deletes:** one `ssh "rm f1 f2 … fN"` (chunked) instead of N round-trips.
-- **Fix `select_target_drive`:** compute the target **once per run**, not per trigger
-  (drop the per-trigger `os.listdir` over 904 dirs).
-- **Incremental MJ scan:** cache the confirmed-header set keyed by hourly dir; on each run
-  scan only new/changed hours. Cuts the 20 s scan to near-zero in steady state, removing
-  the I/O-contention cost of a frequent timer.
-- **Tighten timeouts:** the 3600 s scan cap lets one futile pass hold the lock for an hour;
-  reduce to minutes now that SSH is fast and fails fast.
-
-### 3.4 Observability + failure detection (so the next incident is diagnosable)
-
-- **Persistent, rotation-safe scrub log** (`scrub_log`, already added in PR #78): capture
-  every run's scan/recover/purge **counts, per-phase timings, errors, and lock-acquisition
-  result**. Never `DEVNULL`.
-- **Futile-scrub alert:** if consecutive runs purge 0 files while free space keeps falling,
-  alert ("scrub running but not freeing space"). This is the symptom the 21-h silent ramp
-  never surfaced.
-- **Stuck-lock detection:** if `flock` fails to acquire for N consecutive runs, alert (a
-  prior scrub is hung).
+- **Batch the deletes** (one `rm -f f1…fN` per 100 files) — **this is the robust win**, and
+  it works even on plain SSH (fewer round-trips). *Built.*
+- **Persistent SSH (`ControlMaster`)** — **credit corrected:** the headline "600×" is
+  *batching × multiplexing*; **batching alone gets ~100×** without ControlMaster's fragility.
+  And ControlMaster **self-disables in the failure mode** — on a sick AGS, `open_control_master`
+  fails → fallback to per-call SSH = the slow baseline. So the speedup is *fair-weather*; the
+  incident-relevant part of the same commit is the fail-fast flags (§3.1), not the speed.
+- **Measurement honesty (corrected):**
+  - Lab: batched+CM 0.163 s vs ~100 s / 500 files. On-sensor: 0.117 s vs ~63 s / 230 files.
+    Real, but **the on-sensor files were 0-byte throwaways** (the earlier "real AGS files"
+    wording was wrong — corrected in the commit trailer). Real 20 MB triggers cost *more* to
+    `rm` on vfat (cluster-chain freeing); the 0.117 s is a **floor**, not a representative
+    number for real payloads.
+  - **`recover` was never measured on-sensor.** The 16×/round-trip does **not** transfer to
+    `recover`'s `dd` of ~20 MB payloads (transfer-bound, not handshake-bound). Recover
+    throughput under storm rate is **unvalidated**.
+- **Incremental MJ scan** — cache the confirmed-header set per hourly dir; scan only new
+  hours. **This is the load-bearing scan fix**, because the scan — not purge — is the real
+  wall-clock driver: under active recording the AGS scan hit **99 s** (attribution to USB
+  I/O contention is a **hypothesis**, confounded by a 4× file-count rise; not isolated).
+  Note the shipped `perf(scrub)` commit does **not** speed the scan (it runs before the
+  ControlMaster opens, by design — a single call gets no multiplexing benefit).
+- **`select_target_drive` once per run**, not per trigger (drops a per-trigger `os.listdir`
+  over 904 dirs). Minor for *this* incident (0 triggers recovered during the fill).
+- **`--since auto` for the timer path** needs pinning down — under a storm it pushes the MJ
+  scan back over many dirs, undercutting the incremental-scan win.
 
 ---
 
@@ -202,41 +213,61 @@ it is the load-bearing piece for keeping a periodic scrub cheap.
 
 | Prior work | Disposition |
 |---|---|
-| PR #78 edge→level trigger + cooldown | **Reframed.** Level-triggering survives as the `xx` purge behavior, but as *part of* the two-threshold + timer design, not as "the fix." The trigger was never the failure. |
-| PR #78 `scrub_log` | **Kept** — it is the one directly useful piece (§3.4). |
-| PR #80 Layer 1 `check_recovery_drives` | **Out of scope** — mj-pi `DATA??` fullness is a separate MJ-drive-management issue, not part of keeping `/ags/data` clean. Belongs in its own effort. |
-| PR #80 Layer 2 H&S staleness watchdog | **Folded in** — the timer's telemetry-independence is the structural answer; a staleness alert remains useful as a cheap signal. |
-| PR #80 Layer 3 futile-scrub alert | **Kept** (§3.4). |
+| PR #78 edge→level trigger + cooldown | **Reframed** — level-triggering survives as the `xx` purge behavior (§3.4), not "the fix." |
+| PR #78 `scrub_log` | **Kept & promoted** — observability (§3.2) is now second-priority, not an afterthought. |
+| PR #80 Layer 1 `check_recovery_drives` | **Out of scope** — mj-pi `DATA??` fullness is a separate effort. |
+| PR #80 Layer 2 H&S staleness watchdog | **Folded in** — cheap signal; but note (§3.3) it shares the AGS-reachability dependency. |
+| PR #80 Layer 3 futile-scrub alert | **Kept** (§3.2). |
 
 ---
 
 ## 5. Test plan
 
-- **Unit (pytest):** two-threshold state machine (purge below `xx`, alert crossing `yy`,
-  debounce/re-arm, no alert while `yy < free < xx`); `select_target_drive` called once;
-  batched-delete command construction; incremental-scan cache hit/miss; futile/stuck
-  detection latches.
-- **Scrub-script:** ControlMaster path (mock ssh), batched `rm` chunking, timeout/fail-fast
-  behavior, dry-run still deletes nothing.
-- **Integration (on a bench/idle unit):** timer fires and completes; a forced near-full
-  condition drives purge below `xx`, alert at `yy`, recovery re-arms; measure real scrub
-  wall-clock with ControlMaster+batch vs baseline.
-- **Load reproduction:** near-full `/ags/data` + synthetic sustained influx, instrumentation
-  on — confirm the scrub keeps pace or that the futile alert fires. This is the test the
-  original incident lacked.
+- **Unit (pytest):** honest-lock logging + stuck-lock latch; bounded scan timeout; two-
+  threshold state machine (purge below `xx`, alert crossing `yy`, debounce/re-arm);
+  `select_target_drive` once; batched-delete chunking incl. **exact-multiple boundaries** and
+  **partial-chunk per-file attribution**; **`run()`-level ControlMaster wiring** (open →
+  thread to recover+purge → close); incremental-scan cache hit/miss; futile-scrub latch.
+  *(The batched-purge/ControlMaster/run-wiring tests exist; the rest are TODO.)*
+- **Integration (bench/idle unit):** timer fires; a forced near-full condition drives purge
+  below `xx`, alert at `yy`; **inject a hung scrub and verify §3.1 makes it visible + a timer
+  tick does NOT silently no-op.** Measure real scrub wall-clock incl. **recover** (unmeasured
+  so far).
+- **Load reproduction:** near-full `/ags/data` + sustained influx, instrumentation on —
+  confirm the scrub keeps pace *or* the futile/stuck alert fires. The test the incident
+  lacked.
 
 ---
 
 ## 6. Open questions / risks
 
-1. **Fast-scrub wall-clock under load** is still to be *measured*, not assumed — §5 load
-   test sets `xx`/timer definitively. Values in §3.2 are starting points.
-2. **Incremental-scan cache invalidation** (compression rewrites files, udisks suffixed
-   mounts `DATA071`) — must fall back to a full scan on cache miss/anomaly.
-3. **Timer + brokkr write contention** during a real storm — the incremental scan should
-   remove most of it; verify under load.
-4. **`bytes_remaining` = `/ags/data` free** is established empirically here (fills to 0,
-   scrub targets the same drive, 448.96 GB ceiling ≈ 462 GB drive). This **contradicts an
-   older internal note** claiming it is *not* the AGS drive — that note should be corrected.
-5. Per-unit variation (mj05 is `nochargecontroller`, no ttyUSB; PAMMA units differ) — keep
-   thresholds configurable per unit.
+1. **Which failure mode actually occurred is unrecoverable** (hang vs ran-but-freed-nothing).
+   The design now covers both, but §3 priorities assume the hang is at least as likely — if
+   later evidence points to "ran but slow," the timer (§3.3) rises in value.
+2. **Fast-scrub wall-clock under load** must be *measured* (recover especially); §3.4 values
+   are arithmetic starting points.
+3. **Incremental-scan cache invalidation** (compression rewrites, udisks suffixed mounts
+   `DATA071`) — fall back to full scan on cache miss/anomaly.
+4. **`bytes_remaining` = `/ags/data` free** is established empirically (fills to 0; scrub
+   targets the same drive; 448.96 ≈ 462 GB). This **contradicts an internal MEMORY note**
+   claiming it is sensor-internal storage, not the AGS drive — resolve/correct that note
+   before building the thresholds on it.
+5. **ControlMaster socket** is `/tmp/hamma_scrub_cm_<pid>.sock` — PID reuse after a hard
+   crash can collide with a stale socket (degrades to slow per-call SSH, silently). Consider
+   `%C`-hashed paths or stale-unlink. And `/tmp`-full during a disk-fill disables the
+   multiplexing exactly when needed — log the degradation.
+6. Per-unit variation (mj05 `nochargecontroller`; PAMMA differs) — thresholds configurable.
+
+---
+
+## Changelog
+
+- **v2 (post red-team):** Re-ranked §3 — silent-failure-mode elimination (§3.1) and
+  observability (§3.2) promoted above the timer (§3.3), which is demoted to steady-state
+  drain and no longer called the "backbone." Downgraded "the trigger fired" → "should have
+  fired / may have silently no-op'd" (§1.1) and "no purge, proved" → "strongly indicated,
+  rate-dependent" (§1.2). Corrected the fast-scrub claims (§3.5): batching-vs-multiplexing
+  credit, self-disables on sick AGS, 0-byte throwaway files, recover unmeasured, scan-
+  contention a hypothesis. Noted the two-threshold layer is blind in the failure mode and
+  would not have prevented mj05 (§3.4). Added the ControlMaster socket/`/tmp` risks (§6.5).
+- **v1:** timer-first design (superseded).

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -266,12 +266,17 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
   - **`recover` was never measured on-sensor.** The 16×/round-trip does **not** transfer to
     `recover`'s `dd` of ~20 MB payloads (transfer-bound, not handshake-bound). Recover
     throughput under storm rate is **unvalidated**.
-- **Incremental MJ scan** — cache the confirmed-header set per hourly dir; scan only new
-  hours. **This is the load-bearing scan fix**, because the scan — not purge — is the real
-  wall-clock driver: under active recording the AGS scan hit **99 s** (attribution to USB
-  I/O contention is a **hypothesis**, confounded by a 4× file-count rise; not isolated).
-  Note the shipped `perf(scrub)` commit does **not** speed the scan (it runs before the
-  ControlMaster opens, by design — a single call gets no multiplexing benefit).
+- **Incremental MJ scan (BUILT)** — `scan_mj_files(cache_file=...)` caches each hourly dir's
+  header set keyed by a cheap `(mtime, .bin-count)` signature; an unchanged dir is reused
+  without re-reading a single file, so only the current (being-written) hour and genuinely
+  new dirs pay the per-file cost. **This is the load-bearing scan fix** — the scan, not
+  purge, is the wall-clock driver (the MJ scan is the ~20 s / minutes-under-load cost). Cache
+  lives on **tmpfs** (`/dev/shm/hamma_scrub_mj_cache.pkl`, no SD wear; a reboot costs one full
+  scan); it self-prunes (dirs not seen are dropped) and falls back to a full re-read on any
+  cache anomaly (corrupt file, changed signature). `--mj-cache ""` forces a full scan. The
+  full scanner (`_scan_mj_full`) is unchanged and used when no cache is configured. Tests:
+  `test_hamma_scrub.py::TestIncrementalScan` (10, incl. a patched `_read_dir_headers` proving
+  cache hits don't re-read, parity-vs-full-scan, corrupt-cache fallback, self-prune).
 - **`select_target_drive` once per run**, not per trigger (drops a per-trigger `os.listdir`
   over 904 dirs). Minor for *this* incident (0 triggers recovered during the fill).
 - **`--since auto` for the timer path** needs pinning down — under a storm it pushes the MJ

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -332,10 +332,13 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
    are arithmetic starting points.
 3. **Incremental-scan cache invalidation** (compression rewrites, udisks suffixed mounts
    `DATA071`) — fall back to full scan on cache miss/anomaly.
-4. **`bytes_remaining` = `/ags/data` free** is established empirically (fills to 0; scrub
-   targets the same drive; 448.96 ≈ 462 GB). This **contradicts an internal MEMORY note**
-   claiming it is sensor-internal storage, not the AGS drive — resolve/correct that note
-   before building the thresholds on it.
+4. **`bytes_remaining` = free space at the `/ags/data` mount on the AGS Pi, in GB** —
+   **user-confirmed 2026-07-14**, consistent with the empirical read (fills to 0; scrub targets
+   the same mount; 448.96 ≈ 462 GB) and with the df cross-check on mj03/mj08. Do *not*
+   over-specify the medium: `/ags/data` is usually a USB drive but can be internal/SD on some
+   units (mj54 lacks the USB drive, HAM-110). Thresholds key off this signal; the residual
+   risk is only that it goes **NA** when the AGS is dark (§6/§3.4, mitigated by the
+   `hs_stale_cycles` watchdog), not that it points at the wrong drive.
 5. **ControlMaster socket** is `/tmp/hamma_scrub_cm_<pid>.sock` — PID reuse after a hard
    crash can collide with a stale socket (degrades to slow per-call SSH, silently). Consider
    `%C`-hashed paths or stale-unlink. And `/tmp`-full during a disk-fill disables the

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -406,11 +406,25 @@ When it does roll out, two things do **not** happen automatically and must be in
 3. **`scrub_auto_recover` ships `false`.** The SIGKILL self-heal stays off until it is validated
    on a bench/idle unit by injecting a genuinely hung scrub (§3.2 deployment gate). Flip to
    `true` per-unit only after that.
+4. **`scrub_metrics.csv` is self-capped, not logrotate-managed.** The per-run cache-metrics CSV
+   (`~/brokkr/hamma/log/scrub_metrics.csv`) has no external rotation, so `write_scan_metrics`
+   size-caps it in place (rolls to `.1` past `SCAN_METRICS_MAX_BYTES=1MB`, one generation). It
+   is on the SD but bounded — no HAM-112/113 fill vector. No install/config change needed;
+   both spawn paths run as `pi` so `~` resolves to `/home/pi`.
 
 ---
 
 ## Changelog
 
+- **v4.1 (red-team pass on the v4 follow-ups):** A 3-agent adversarial review caught that
+  `_refresh_cache_dirs` was fed `recover_triggers`' **relative** `target_path` while the cache
+  is keyed by **absolute** dirs — so the refresh silently no-op'd (feature did nothing), and the
+  original tests missed it by passing absolute paths. Fixed (rejoin `mj_path`) + added a run()-
+  level regression test driving the real relative output. Also: the metrics CSV claimed to be
+  "rotated by log tooling" but nothing rotates it — added an in-place size cap
+  (`SCAN_METRICS_MAX_BYTES`, roll to `.1`) and a test; added a test asserting `run()` actually
+  calls `write_scan_metrics` (the fixtures mocked it without asserting, hiding wiring regressions).
+  Root-vs-pi home-dir concern cleared (both spawn paths run as `pi`).
 - **v4 (mj05 hardware validation + cache hardening):** Ran the scrubber on mj05
   against real `/ags/data` (AGS stopped): recovered to `DATA56`, purged 78 files,
   freed ~72GB, retained the 1 corrupt + active file (recover-before-delete held).

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -301,7 +301,7 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
 | PR #78 `scrub_log` | **Kept & promoted** — observability (§3.2) is now second-priority, not an afterthought. |
 | PR #80 Layer 1 `check_recovery_drives` | **Out of scope** — mj-pi `DATA??` fullness is a separate effort. |
 | PR #80 Layer 2 H&S staleness watchdog | **Folded in** — cheap signal; but note (§3.3) it shares the AGS-reachability dependency. |
-| PR #80 Layer 3 futile-scrub alert | **Kept** (§3.2). |
+| PR #80 Layer 3 futile-scrub alert | **Partly reframed, not fully built.** §3.2 builds the *stuck/hung*-scrub alert (lock held, heartbeat not advancing) — NOT a per-run "scrub completed but freed ~0 bytes" delta check. The operator-facing half of "futile" (space keeps falling *despite* auto-scrubs) is covered instead by `alert_space=75` (§3.4). A true per-scrub freed-bytes assertion is unbuilt (would need a stable free-space read before/after, which is exactly the NA-prone signal). |
 
 ---
 
@@ -341,6 +341,14 @@ Split `low_space` into a **purge** and a higher-urgency **alert** threshold, lev
    `%C`-hashed paths or stale-unlink. And `/tmp`-full during a disk-fill disables the
    multiplexing exactly when needed — log the degradation.
 6. Per-unit variation (mj05 `nochargecontroller`; PAMMA differs) — thresholds configurable.
+7. **Observability rides the SD; durable observability is a *hard dependency* on HAM-112/113.**
+   The tmpfs heartbeat (`/dev/shm`) is the load-bearing *live* signal and survives an SD fill,
+   but the **post-mortem** — the durable `scrub_log` on the SD — self-disables (→DEVNULL) once
+   the SD floods with brokkr/rsyslog spam (the exact incident condition, HAM-112/113, both
+   still To Do). So a repeat could still leave *no on-disk trace of the scrub run* even with
+   this work deployed. The two are complementary, not substitutes: this effort makes the
+   *live* state visible and recoverable; HAM-112/113 is what makes the *forensic* record
+   survive. Ship both or accept the forensic gap.
 
 ---
 
@@ -375,8 +383,40 @@ before enabling fleet-wide. The durable `scrub_log` on the SD still self-disable
 under a full SD; accepted (degrades to old behavior; the tmpfs heartbeat is the load-bearing
 signal).
 
+## 7. Deployment notes (branch-only; nothing deployed)
+
+This whole effort lives on `feature/scrub-resilience` and is **not deployed anywhere**.
+When it does roll out, two things do **not** happen automatically and must be in the runbook:
+
+1. **The systemd timer only auto-installs on a fresh `unified_install` run.** The install step
+   (`unified_install/lib/brokkr.sh` "Config 5/5") copies the units and `enable --now
+   hamma-scrub.timer`. **Already-deployed units get nothing from a `git pull`** — the timer,
+   `.service`, and `.sh` wrapper must be copied and enabled by hand (same class of gap as the
+   DNS/40-eth0 redeploy). Until then those units still rely solely on the level-triggered
+   spawn from `check_sensor_drive`.
+2. **Clean the per-unit `low_space` override before pushing config.** mj54 carries a local
+   `low_space=10` (sensor-log#41). The new plugin **accepts + warns + ignores** `low_space`
+   (so it will not crash the pipeline, C1), but the override is now dead config — replace it
+   with per-unit `purge_space`/`alert_space` in `~/.config/brokkr/hamma/*.toml` so the unit
+   actually drains at the intended point instead of silently falling back to the fleet default.
+3. **`scrub_auto_recover` ships `false`.** The SIGKILL self-heal stays off until it is validated
+   on a bench/idle unit by injecting a genuinely hung scrub (§3.2 deployment gate). Flip to
+   `true` per-unit only after that.
+
+---
+
 ## Changelog
 
+- **v3 (final capstone pass):** Closed the deploy/coverage gaps from the two integration/
+  completeness reviews. Code: `low_space` now accepted-and-ignored (won't crash mj54's
+  override, C1); `scrub_auto_recover` default flipped to **false** (bench-gate, M1); added a
+  telemetry-staleness watchdog (`hs_stale_cycles`) so a *dark* AGS — `bytes_remaining` NA —
+  alerts instead of silently going unmonitored (GAP2); `purge_ags_files` now writes a
+  per-chunk heartbeat so a long purge can't be misread as hung (GAP1). Docs: corrected the
+  Layer-3 "futile-scrub alert" claim (stuck≠futile; operator half is `alert_space`, GAP3);
+  added the HAM-112/113 *hard dependency* for durable forensics (§6.7, GAP5); added this
+  Deployment-notes section (timer not auto-installed on existing units + mj54 cleanup, M2).
+  All 258 scrub-suite tests green.
 - **v2 (post red-team):** Re-ranked §3 — silent-failure-mode elimination (§3.1) and
   observability (§3.2) promoted above the timer (§3.3), which is demoted to steady-state
   drain and no longer called the "backbone." Downgraded "the trigger fired" → "should have

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -154,6 +154,13 @@ that is exactly the regime the level-triggered `xx` purge covers between timer t
 
 ### 3.3 Make the scrub fast (so it can survive surges)
 
+**Measured (mj05 → AGS, Jul 13):** per-file purge baseline **~100 s / 500 files** (plain
+per-op SSH); **batched over one `ControlMaster` connection: 0.163 s / ~480 files** (4
+chunked `rm` calls) — a **~600×** speedup. Purge ceases to be a bottleneck; a full scrub's
+cost collapses onto the MJ scan (~20 s), which §3.3's incremental scan then attacks. A fast
+scrub of ~20–30 s against the 200 GB purge start leaves ~16 min of max-rate runway.
+
+
 - **Persistent SSH** to the AGS via `ControlMaster`/`ControlPersist` (one connection reused
   for all `dd`/`rm`): measured **16× per-op speedup** (0.29 s → 0.018 s). Add
   `-o BatchMode=yes -o ConnectTimeout=10` so a sick AGS fails fast instead of hanging.

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -160,6 +160,15 @@ rotation-safe file as it advances. Everything §3.1 couldn't do safely follows f
 
 ### 3.3 Timer-driven periodic scrub — steady-state drain, NOT the cure for a hang
 
+**Built:** `files/hamma-scrub.{sh,service,timer}` + install wiring in
+`unified_install/lib/brokkr.sh`. Oneshot service runs the wrapper (`flock -n -E 0`
+over the same `/tmp/hamma_scrub.lock` + `--recover --purge --since auto`, kept in sync
+with `state_monitor`'s `scrub_command` and validated by `test_scrub_timer.py`); timer =
+`OnBootSec=10min` / `OnUnitActiveSec=15min`. Service is `Nice=10` + `IOSchedulingClass=best-
+effort/7` so the periodic scan yields to brokkr's write pipeline without starving. **Two
+roles:** the steady-state drain, and the reliable **re-spawn backstop** for §3.2 (after a
+hung scrub is killed, the next tick re-runs it — the low-space edge won't re-fire on its own).
+
 A systemd timer (~15 min) that runs the scrub regardless of `bytes_remaining`.
 
 - **What it genuinely buys:** it keeps `/ags/data` drained in steady state so free space

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -157,8 +157,20 @@ that is exactly the regime the level-triggered `xx` purge covers between timer t
 **Measured (mj05 → AGS, Jul 13):** per-file purge baseline **~100 s / 500 files** (plain
 per-op SSH); **batched over one `ControlMaster` connection: 0.163 s / ~480 files** (4
 chunked `rm` calls) — a **~600×** speedup. Purge ceases to be a bottleneck; a full scrub's
-cost collapses onto the MJ scan (~20 s), which §3.3's incremental scan then attacks. A fast
-scrub of ~20–30 s against the 200 GB purge start leaves ~16 min of max-rate runway.
+cost collapses onto the MJ scan (~20 s), which the incremental scan below then attacks. A
+fast scrub of ~20–30 s against the 200 GB purge start leaves ~16 min of max-rate runway.
+
+**Prototype validated on-sensor (mj05, Jul 13, Python 3.7.3, real files):** the implemented
+`open_control_master` + batched `purge_ags_files` deleted 230 throwaway AGS files in
+**0.117 s** vs a **~63 s** plain-per-file baseline (~500×), confirmed the drive empty after,
+and tore the master down cleanly. See `perf(scrub)` commit; 26 unit tests.
+
+**Scan-cost-under-load finding (important, drives the incremental scan):** the same day,
+under active AGS recording, a full scrub's **AGS scan alone rose from ~1 s to 99 s** (9 →
+35 files) and the MJ scan stretched to minutes — pure USB read/write contention with the
+live recording. Once purge is ~free, the scan is *the* bottleneck, and it inflates exactly
+when the system is busiest. The incremental scan (below) is therefore not optional polish —
+it is the load-bearing piece for keeping a periodic scrub cheap.
 
 
 - **Persistent SSH** to the AGS via `ControlMaster`/`ControlPersist` (one connection reused

--- a/docs/scrub-resilience-design.md
+++ b/docs/scrub-resilience-design.md
@@ -172,11 +172,20 @@ hung scrub is killed, the next tick re-runs it — the low-space edge won't re-f
 **Red-team corrections (3 reviewers) — no CRITICAL ship-blocker; honest scope:**
 - **I/O-priority stanza was on the wrong machine — removed.** The scrub runs on the mj-pi;
   `/ags/data` + the write pipeline are on the *AGS Pi* (separate host, over SSH), so an mj-pi
-  `ionice` governs nothing on the contended drive (and `mq-deadline` ignores ionice anyway;
-  the AGS java writer already holds *realtime* I/O priority). Kept `Nice=10` (mj-pi CPU only).
+  `ionice` governs nothing on the contended drive (and `mq-deadline` ignores ionice anyway).
+  Kept `Nice=10` (mj-pi CPU only).
   **Because the scrub does no local block I/O on the AGS drive, the timer does NOT make the
   fill worse** — it lengthens its own scan, not the writer. So §3.3 is safe to ship *before*
   §3.5 (incremental scan), which remains the real scan-cost fix.
+- **AGS-side commands are CPU-niced to the DAS floor (`AGS_NICE = "nice -n 19 "`).** Fleet
+  check (mj05 AGS) settled the priority question with data: active I/O scheduler is
+  `mq-deadline` (ignores ionice — the DAS's *realtime* ioprio is **set but inert**), and the
+  DAS java runs at CPU `nice 19` while an unniced remote command runs at `nice 0` — i.e. the
+  scrub would **outrank** the writer on CPU. Fix: wrap the heavy AGS-side commands (header
+  scan, recover `dd` reads, purge `rm` incl. the per-file retry) in `nice -n 19` so they sit
+  at the writer's floor instead of preempting it. `ionice` deliberately **not** used (theatre
+  under mq-deadline). The real CRC/fifo-overflow contention has a separate fix; this is just
+  the scrub being a good citizen so it can't steal CPU from the writer.
 - **`Wants=brokkr` → `After=` only:** a 15-min tick must not resurrect a deliberately-stopped
   brokkr. **`StartLimitIntervalSec=0`:** so repeated §3.2 SIGKILLs (a killed scrub = a systemd
   *failed* activation) can't trip the start-limit and silently disable the timer under
@@ -416,6 +425,15 @@ When it does roll out, two things do **not** happen automatically and must be in
 
 ## Changelog
 
+- **v4.2 (PR #82 review round + AGS-side priority):** Addressed jcburchfield's two review
+  gaps — (1) the post-kill auto-recover respawn now routes through the cooldown gate
+  (`_maybe_spawn_scrub`) so a re-hang can't drive an unbounded kill/respawn cycle; (2) added a
+  final purge heartbeat so the last chunk's deletions reach the durable status before `done`.
+  Then, per Phillip: made the scrub a **lower CPU priority than the DAS on the AGS itself**.
+  Fleet check (mj05 AGS) found `mq-deadline` (ionice inert) with the DAS at CPU `nice 19` and
+  unniced remote commands at `nice 0` — so the scrub was *outranking* the writer. Wrapped the
+  heavy AGS-side commands in `nice -n 19` (`AGS_NICE`); verified `nice -n 19` runs over the
+  scrub's SSH path on real hardware. ionice deliberately not used (no effect under mq-deadline).
 - **v4.1 (red-team pass on the v4 follow-ups):** A 3-agent adversarial review caught that
   `_refresh_cache_dirs` was fed `recover_triggers`' **relative** `target_path` while the cache
   is keyed by **absolute** dirs — so the refresh silently no-op'd (feature did nothing), and the

--- a/files/hamma-scrub.service
+++ b/files/hamma-scrub.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=HAMMA AGS scrub (periodic /ags/data drain, flock-wrapped)
+Documentation=https://github.com/hamma-dev/mjolnir-hamma
+# The scrub needs the deployed repo and a reachable AGS; run after brokkr is up.
+After=brokkr-hamma-default.service
+Wants=brokkr-hamma-default.service
+
+[Service]
+Type=oneshot
+User=pi
+Group=pi
+ExecStart=/usr/local/bin/hamma-scrub.sh
+# A periodic drain is not urgent: deprioritise CPU and I/O so the scan doesn't
+# contend with brokkr's write pipeline. best-effort/7 (lowest) yields to the
+# writer without starving, unlike the idle class. The incremental scan (design
+# §3.5) is the real contention fix; this is a cheap mitigation.
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/files/hamma-scrub.service
+++ b/files/hamma-scrub.service
@@ -1,19 +1,26 @@
 [Unit]
 Description=HAMMA AGS scrub (periodic /ags/data drain, flock-wrapped)
 Documentation=https://github.com/hamma-dev/mjolnir-hamma
-# The scrub needs the deployed repo and a reachable AGS; run after brokkr is up.
+# Order after brokkr (so the deployed repo is present) but do NOT pull it in --
+# a 15-min scrub tick must never resurrect a brokkr an operator deliberately
+# stopped for maintenance (so: After=, not Wants=).
 After=brokkr-hamma-default.service
-Wants=brokkr-hamma-default.service
+# state_monitor (§3.2) recovers a hung scrub by SIGKILLing it, which systemd
+# records as a failed activation. Those kills are ~15 min apart, but a
+# fleet-wide DefaultStartLimitIntervalSec change could let them accumulate and
+# trip the start-limit -- silently disabling this drain/backstop timer under
+# exactly the sustained-hang condition it exists for. Disable start-limiting.
+StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
 User=pi
 Group=pi
 ExecStart=/usr/local/bin/hamma-scrub.sh
-# A periodic drain is not urgent: deprioritise CPU and I/O so the scan doesn't
-# contend with brokkr's write pipeline. best-effort/7 (lowest) yields to the
-# writer without starving, unlike the idle class. The incremental scan (design
-# §3.5) is the real contention fix; this is a cheap mitigation.
+# Deprioritise CPU so the scrub's header parse/CRC yields to brokkr on the mj-pi.
+# NO I/O-priority knob: the contended device (/ags/data + the AGS write pipeline)
+# is on the SEPARATE AGS Pi, reached over SSH -- an mj-pi ionice class governs
+# nothing there (and mq-deadline ignores ionice anyway; the AGS writer already
+# holds realtime I/O priority). The real scan-cost fix is the incremental scan
+# (design §3.5).
 Nice=10
-IOSchedulingClass=best-effort
-IOSchedulingPriority=7

--- a/files/hamma-scrub.service
+++ b/files/hamma-scrub.service
@@ -18,9 +18,10 @@ User=pi
 Group=pi
 ExecStart=/usr/local/bin/hamma-scrub.sh
 # Deprioritise CPU so the scrub's header parse/CRC yields to brokkr on the mj-pi.
-# NO I/O-priority knob: the contended device (/ags/data + the AGS write pipeline)
-# is on the SEPARATE AGS Pi, reached over SSH -- an mj-pi ionice class governs
-# nothing there (and mq-deadline ignores ionice anyway; the AGS writer already
-# holds realtime I/O priority). The real scan-cost fix is the incremental scan
-# (design §3.5).
+# NO I/O-priority knob here: the contended device (/ags/data + the AGS write
+# pipeline) is on the SEPARATE AGS Pi, reached over SSH -- an mj-pi ionice class
+# governs nothing there, and mq-deadline ignores ionice anyway. The scrub's
+# AGS-side work is deprioritised on the AGS itself: the heavy remote commands
+# (header scan, recover reads, purge) are wrapped in `nice -n 19` so they run at
+# the DAS writer's CPU floor instead of outranking it (hamma_scrub.py AGS_NICE).
 Nice=10

--- a/files/hamma-scrub.sh
+++ b/files/hamma-scrub.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Periodic AGS scrub: drain /ags/data (recover missing triggers + purge those
+# confirmed on the mj-pi) under a non-blocking flock so a timer tick never
+# overlaps a state_monitor-spawned scrub or a prior tick.
+#
+# The scrub invocation MUST stay in sync with state_monitor's `scrub_command`
+# (config/main.toml): both share the /tmp lock and the /dev/shm heartbeat, so
+# check_scrub_health can supervise whichever one is running.
+#
+# Invoked by hamma-scrub.service on the schedule in hamma-scrub.timer.
+set -euo pipefail
+
+LOCK=/tmp/hamma_scrub.lock
+SCRUB=/home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py
+
+# -n   : skip (don't queue) if a scrub already holds the lock -- overlapping
+#        scrubs are pointless; the next tick retries.
+# -E 0 : treat "lock already held" as success so a normal skip doesn't mark the
+#        service failed; a real scrub error still propagates its exit code.
+exec flock -n -E 0 "$LOCK" python3 "$SCRUB" --recover --purge --since auto

--- a/files/hamma-scrub.timer
+++ b/files/hamma-scrub.timer
@@ -9,8 +9,10 @@ Documentation=https://github.com/hamma-dev/mjolnir-hamma
 OnBootSec=10min
 OnUnitActiveSec=15min
 AccuracySec=30s
-# Don't stampede queued runs after downtime; just resume the cadence.
-Persistent=false
+# NOTE: OnUnitActiveSec re-arms from the *last activation*, and a scrub under
+# storm load can run minutes; a tick during an in-progress scrub is skipped by
+# the wrapper's `flock -n`. So the effective drain cadence is ">= 15 min", not
+# a strict 15 min -- fine for a drain (~1.25 GB/tick at observed rates).
 
 [Install]
 WantedBy=timers.target

--- a/files/hamma-scrub.timer
+++ b/files/hamma-scrub.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Periodic HAMMA AGS scrub (steady-state drain of /ags/data)
+Documentation=https://github.com/hamma-dev/mjolnir-hamma
+
+[Timer]
+# Settle after boot, then run every 15 min. This is the steady-state drain AND
+# the reliable re-spawn path after check_scrub_health kills a hung scrub -- the
+# low-space edge trigger will not re-fire on its own once space is below it.
+OnBootSec=10min
+OnUnitActiveSec=15min
+AccuracySec=30s
+# Don't stampede queued runs after downtime; just resume the cadence.
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -724,7 +724,11 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             recovered = self._recover_stuck_scrub(status)
             if recovered:
                 self._scrub_first_held = None  # streak ends; re-measure next hold
-                self._spawn_scrub()  # use the freed lock (a timer is the backstop)
+                # Route the respawn through the cooldown gate so a scrub that
+                # re-hangs on the same root cause can't drive an unbounded
+                # kill/respawn cycle (bounded only by scrub_hang_timeout_s).
+                # The gate also arms _last_scrub_spawn; the timer is the backstop.
+                self._maybe_spawn_scrub()  # use the freed lock, cooldown-gated
         if self._stuck_scrub_alerted:
             return None
         self._stuck_scrub_alerted = True

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -3,6 +3,8 @@ Plugin to monitor state variables from the charge controller.
 """
 
 from math import nan
+import fcntl
+import os
 import shlex
 import shutil
 import subprocess
@@ -14,6 +16,10 @@ from notifiers import Notifier
 import brokkr.pipeline.base
 import brokkr.pipeline.decode
 import brokkr.utils.output
+
+# Lock file shared with the spawned `flock -n` scrub, so the monitor can probe
+# whether a prior scrub is still running (and detect a hung one).
+SCRUB_LOCK_FILE = "/tmp/hamma_scrub.lock"
 
 
 def sensor_prefix():
@@ -40,6 +46,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         low_pi_space=5,
         enable_drive_checks=True,
         scrub_command="",
+        stuck_scrub_cycles=10,
         **output_step_kwargs,
         ):
         """
@@ -73,6 +80,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_command : str, optional
             Shell command to run hamma_scrub.py when drive space is low.
             If empty (default), no scrub is spawned. Protected by flock.
+        stuck_scrub_cycles : int, optional
+            Alert if a prior scrub holds the lock for this many consecutive
+            monitor cycles (a hung scrub silently stalls the safety net).
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -92,6 +102,12 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.low_pi_space = low_pi_space*1000000000
         self.enable_drive_checks = enable_drive_checks
         self.scrub_command = scrub_command
+        # Stuck-scrub detection: alert if a prior scrub holds the lock for this
+        # many consecutive monitor cycles (a healthy scrub finishes in
+        # seconds-to-minutes; a hung one silently stalls the safety net).
+        self.stuck_scrub_cycles = stuck_scrub_cycles
+        self._scrub_lock_held_cycles = 0
+        self._stuck_scrub_alerted = False
 
         self.notifier = Notifier(
             method=method, key_file=key_file, channel=channel, logger=self.logger)
@@ -206,6 +222,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         if self.enable_drive_checks:
             checks.insert(0, self.check_drive)
             checks.append(self.check_sensor_drive)
+            checks.append(self.check_scrub_health)
 
         for check_fn in checks:
             try:
@@ -352,22 +369,94 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
 
+    def _scrub_lock_is_held(self):
+        """Return True if a scrub currently holds the flock (non-blocking).
+
+        Uses the same flock(2) advisory lock the spawned ``flock -n`` uses, so
+        the two interoperate. Fails safe to False (assume free) if the lock
+        file cannot be opened. Note the tiny benign TOCTOU window: the lock may
+        be grabbed between this probe and a subsequent spawn -- exclusion is
+        still guaranteed by the spawned ``flock -n`` itself; this probe only
+        makes "a prior scrub is running" *visible*.
+        """
+        try:
+            fd = os.open(SCRUB_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError:
+            return False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True  # someone else holds it
+        else:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+        finally:
+            os.close(fd)
+
     def _spawn_scrub(self):
-        """Spawn detached scrub process if scrub_command is configured."""
+        """Spawn a detached scrub, but only if no prior scrub is running.
+
+        The old code wrapped the command in ``flock -n`` and logged "Spawned
+        scrub" whether or not the lock was acquired -- so a hung prior scrub
+        made the spawn a silent no-op *and the log lied* (the mj05 failure).
+        Here we probe the lock first and log the truth. Exclusion is still
+        enforced by the spawned ``flock -n``; the probe is for honesty +
+        feeds the stuck-lock detector (`check_scrub_health`).
+        """
         if not self.scrub_command or not self.scrub_command.strip():
             return
-        lock_file = "/tmp/hamma_scrub.lock"
+        if self._scrub_lock_is_held():
+            self.logger.warning(
+                "Scrub NOT spawned: a prior scrub still holds %s "
+                "(possibly hung -- see check_scrub_health)", SCRUB_LOCK_FILE)
+            return
         try:
-            cmd = ["flock", "-n", lock_file] + shlex.split(self.scrub_command)
+            cmd = ["flock", "-n", SCRUB_LOCK_FILE] + shlex.split(
+                self.scrub_command)
             subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
-            self.logger.info("Spawned scrub: %s", " ".join(cmd))
+            self.logger.info("Scrub spawned (lock was free): %s",
+                             " ".join(cmd))
         except (OSError, ValueError) as e:
             self.logger.error("Failed to spawn scrub: %s", e)
+
+    def check_scrub_health(self, input_data):
+        """Detect a hung scrub: the lock held across many monitor cycles.
+
+        A healthy scrub finishes in seconds-to-minutes. If the lock stays held
+        for `stuck_scrub_cycles` consecutive cycles, a prior scrub is hung --
+        the failure mode a timer cannot fix (more spawns just no-op against the
+        held lock). Alert once; re-arm when the lock frees.
+
+        Parameters
+        ----------
+        input_data : Mapping[str, DataValue]
+            Same as argument of `execute` (unused; kept for check uniformity).
+
+        Returns
+        -------
+        str | None
+            Alert message when the stuck threshold is first crossed, else None.
+        """
+        if not self.scrub_command or not self.scrub_command.strip():
+            return None
+        if self._scrub_lock_is_held():
+            self._scrub_lock_held_cycles += 1
+            if (self._scrub_lock_held_cycles >= self.stuck_scrub_cycles
+                    and not self._stuck_scrub_alerted):
+                self._stuck_scrub_alerted = True
+                return ("Auto-scrub lock held for {} consecutive cycles -- a "
+                        "prior scrub is likely hung; manual intervention "
+                        "needed".format(self._scrub_lock_held_cycles))
+            return None
+        # Lock free -> reset the counter and re-arm the alert
+        self._scrub_lock_held_cycles = 0
+        self._stuck_scrub_alerted = False
+        return None
 
     def check_battery_voltage(self, input_data):
         """

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -4,10 +4,13 @@ Plugin to monitor state variables from the charge controller.
 
 from math import nan
 import fcntl
+import json
 import os
 import shlex
 import shutil
+import signal
 import subprocess
+import time
 
 # Third party imports
 from notifiers import Notifier
@@ -20,6 +23,14 @@ import brokkr.utils.output
 # Lock file shared with the spawned `flock -n` scrub, so the monitor can probe
 # whether a prior scrub is still running (and detect a hung one).
 SCRUB_LOCK_FILE = "/tmp/hamma_scrub.lock"
+# Heartbeat/status file the scrub writes as it advances (must match
+# hamma_scrub.DEFAULT_STATUS_FILE); read to tell a working scrub from a hung one.
+DEFAULT_SCRUB_STATUS_FILE = os.path.expanduser(
+    "~/brokkr/hamma/log/hamma_scrub_status.json")
+# Durable log capturing the scrub's own stdout/stderr (mj05 ran blind because
+# this was DEVNULL'd). Rotated at SCRUB_LOG_MAX_BYTES so it can't fill the disk.
+DEFAULT_SCRUB_LOG = os.path.expanduser("~/brokkr/hamma/log/hamma_scrub.log")
+SCRUB_LOG_MAX_BYTES = 5 * 1024 * 1024  # rotate the scrub log past this size
 
 
 def sensor_prefix():
@@ -46,7 +57,10 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         low_pi_space=5,
         enable_drive_checks=True,
         scrub_command="",
-        stuck_scrub_cycles=10,
+        scrub_hang_timeout_s=900,
+        scrub_status_file=DEFAULT_SCRUB_STATUS_FILE,
+        scrub_auto_recover=True,
+        scrub_log=DEFAULT_SCRUB_LOG,
         **output_step_kwargs,
         ):
         """
@@ -80,9 +94,18 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_command : str, optional
             Shell command to run hamma_scrub.py when drive space is low.
             If empty (default), no scrub is spawned. Protected by flock.
-        stuck_scrub_cycles : int, optional
-            Alert if a prior scrub holds the lock for this many consecutive
-            monitor cycles (a hung scrub silently stalls the safety net).
+        scrub_hang_timeout_s : numeric, optional
+            Seconds the scrub lock may be held with no heartbeat progress
+            before it is judged hung (default 900). Must exceed the scrub's own
+            longest single blocking phase (the AGS scan, SCAN_TIMEOUT=600s).
+        scrub_status_file : str, optional
+            Path to the scrub's heartbeat/status JSON (progress signal).
+        scrub_auto_recover : bool, optional
+            If True (default), kill a genuinely-hung scrub to free the lock
+            (self-healing); else only alert.
+        scrub_log : str, optional
+            Durable file capturing the scrub's stdout/stderr (rotated); empty
+            string disables (falls back to DEVNULL).
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -102,11 +125,14 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.low_pi_space = low_pi_space*1000000000
         self.enable_drive_checks = enable_drive_checks
         self.scrub_command = scrub_command
-        # Stuck-scrub detection: alert if a prior scrub holds the lock for this
-        # many consecutive monitor cycles (a healthy scrub finishes in
-        # seconds-to-minutes; a hung one silently stalls the safety net).
-        self.stuck_scrub_cycles = stuck_scrub_cycles
-        self._scrub_lock_held_cycles = 0
+        # Hung-scrub detection (progress-gated): a scrub is "hung" only if the
+        # lock is held AND its heartbeat has been stale this long -- so a long
+        # legit recovery (fresh heartbeat) is not mistaken for a hang.
+        self.scrub_hang_timeout_s = scrub_hang_timeout_s
+        self.scrub_status_file = scrub_status_file
+        self.scrub_auto_recover = scrub_auto_recover
+        self.scrub_log = scrub_log
+        self._scrub_first_held = None
         self._stuck_scrub_alerted = False
 
         self.notifier = Notifier(
@@ -369,29 +395,64 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return f"Remaining GB on drive is {space_now:.1f}"
         return None
 
-    def _scrub_lock_is_held(self):
-        """Return True if a scrub currently holds the flock (non-blocking).
+    def _scrub_lock_state(self):
+        """Return 'held', 'free', or 'unknown' for the scrub flock.
 
         Uses the same flock(2) advisory lock the spawned ``flock -n`` uses, so
-        the two interoperate. Fails safe to False (assume free) if the lock
-        file cannot be opened. Note the tiny benign TOCTOU window: the lock may
-        be grabbed between this probe and a subsequent spawn -- exclusion is
-        still guaranteed by the spawned ``flock -n`` itself; this probe only
-        makes "a prior scrub is running" *visible*.
+        the two interoperate. Returns 'unknown' (NOT 'free') when the lock file
+        can't be opened -- during a disk-full event (the exact incident) the
+        lockfile can be uncreatable (ENOSPC), and a stuck-detector must not go
+        blind then: the consumers treat 'unknown' as suspicious. The tiny
+        benign TOCTOU window is fine -- exclusion is enforced by the spawned
+        ``flock -n``; this probe only makes lock state *visible*.
         """
         try:
             fd = os.open(SCRUB_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o644)
-        except OSError:
-            return False
+        except OSError as e:
+            self.logger.warning("Scrub lock %s unreadable (%s); state unknown",
+                                SCRUB_LOCK_FILE, e)
+            return "unknown"
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except OSError:
-            return True  # someone else holds it
+            return "held"  # someone else holds it
         else:
             fcntl.flock(fd, fcntl.LOCK_UN)
-            return False
+            return "free"
         finally:
             os.close(fd)
+
+    def _read_scrub_status(self):
+        """Read the scrub heartbeat/status JSON, or None if absent/unreadable.
+
+        The running scrub updates this file (`hamma_scrub.write_status`) as it
+        advances; the ``timestamp`` field is the heartbeat used to tell a
+        working scrub from a hung one.
+        """
+        try:
+            with open(self.scrub_status_file) as f:
+                return json.load(f)
+        except (OSError, ValueError):
+            return None
+
+    def _open_scrub_log(self):
+        """Open the durable scrub log for append (rotating if oversized).
+
+        Returns an open file object, or None to fall back to DEVNULL. Rotating
+        past SCRUB_LOG_MAX_BYTES keeps the log from *becoming* a disk-fill.
+        """
+        if not self.scrub_log:
+            return None
+        try:
+            os.makedirs(os.path.dirname(self.scrub_log), exist_ok=True)
+            if (os.path.exists(self.scrub_log)
+                    and os.path.getsize(self.scrub_log) > SCRUB_LOG_MAX_BYTES):
+                os.replace(self.scrub_log, self.scrub_log + ".1")
+            return open(self.scrub_log, "ab")
+        except OSError as e:
+            self.logger.warning("Could not open scrub log %s (%s); using DEVNULL",
+                                self.scrub_log, e)
+            return None
 
     def _spawn_scrub(self):
         """Spawn a detached scrub, but only if no prior scrub is running.
@@ -399,38 +460,97 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         The old code wrapped the command in ``flock -n`` and logged "Spawned
         scrub" whether or not the lock was acquired -- so a hung prior scrub
         made the spawn a silent no-op *and the log lied* (the mj05 failure).
-        Here we probe the lock first and log the truth. Exclusion is still
-        enforced by the spawned ``flock -n``; the probe is for honesty +
-        feeds the stuck-lock detector (`check_scrub_health`).
+        Here we probe the lock first and log the truth, and capture the scrub's
+        output to a durable log (mj05 ran blind on DEVNULL'd output).
         """
         if not self.scrub_command or not self.scrub_command.strip():
             return
-        if self._scrub_lock_is_held():
+        state = self._scrub_lock_state()
+        if state == "held":
             self.logger.warning(
                 "Scrub NOT spawned: a prior scrub still holds %s "
                 "(possibly hung -- see check_scrub_health)", SCRUB_LOCK_FILE)
             return
+        if state == "unknown":
+            self.logger.warning(
+                "Scrub NOT spawned: lock %s unreadable (disk full?)",
+                SCRUB_LOCK_FILE)
+            return
+        log_fh = self._open_scrub_log()
+        if log_fh is not None:
+            out, err = log_fh, subprocess.STDOUT  # capture stderr into the log
+        else:
+            out, err = subprocess.DEVNULL, subprocess.DEVNULL
         try:
             cmd = ["flock", "-n", SCRUB_LOCK_FILE] + shlex.split(
                 self.scrub_command)
             subprocess.Popen(
                 cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=out,
+                stderr=err,
                 start_new_session=True,
             )
             self.logger.info("Scrub spawned (lock was free): %s",
                              " ".join(cmd))
         except (OSError, ValueError) as e:
             self.logger.error("Failed to spawn scrub: %s", e)
+        finally:
+            if log_fh is not None:
+                log_fh.close()  # Popen dup'd the fd; the parent can close
+
+    def _pid_is_scrub(self, pid):
+        """True if `pid` is (still) a running hamma_scrub process.
+
+        Guards against killing a recycled PID: we only ever kill a process
+        whose cmdline still names the scrub script.
+        """
+        try:
+            with open("/proc/{}/cmdline".format(pid), "rb") as f:
+                cmdline = f.read().replace(b"\x00", b" ").decode(
+                    "utf-8", "replace")
+        except OSError:
+            return False
+        return "hamma_scrub" in cmdline
+
+    def _recover_stuck_scrub(self, status):
+        """Kill a genuinely-hung scrub to free the lock. Returns True if killed.
+
+        Safe *because* the caller only invokes this once the heartbeat proves
+        no progress (not merely that the lock is old). Kills the whole process
+        group (scrub + its `flock` parent + any ssh children), after verifying
+        the PID still looks like a scrub (guards PID reuse).
+        """
+        pid = status.get("pid") if status else None
+        if not isinstance(pid, int):
+            self.logger.error(
+                "Stuck scrub detected but no usable PID in status; cannot "
+                "auto-recover -- manual kill needed")
+            return False
+        if not self._pid_is_scrub(pid):
+            self.logger.warning(
+                "Stuck-scrub PID %s no longer looks like a scrub (exited or "
+                "reused); not killing", pid)
+            return False
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except OSError as e:
+            self.logger.warning("Could not kill hung scrub PID %s: %s", pid, e)
+            return False
+        self.logger.error(
+            "Killed hung scrub PID %s (process group) to free the lock", pid)
+        return True
 
     def check_scrub_health(self, input_data):
-        """Detect a hung scrub: the lock held across many monitor cycles.
+        """Detect and (optionally) recover a *hung* scrub -- progress-gated.
 
-        A healthy scrub finishes in seconds-to-minutes. If the lock stays held
-        for `stuck_scrub_cycles` consecutive cycles, a prior scrub is hung --
-        the failure mode a timer cannot fix (more spawns just no-op against the
-        held lock). Alert once; re-arm when the lock frees.
+        "Hung" is defined as: the lock is held AND the scrub has made no
+        progress (stale heartbeat) for `scrub_hang_timeout_s`. This
+        distinguishes a hang from a legitimately long recovery (which keeps the
+        heartbeat fresh), avoiding cry-wolf. On a genuine hang, if
+        `scrub_auto_recover` is set, kill the stale scrub to free the lock
+        (self-healing -- a timer alone can't do this); alert once either way.
+        Re-arms when the lock frees. 'unknown' lock state (e.g. disk full) is
+        treated as suspicious, not free.
 
         Parameters
         ----------
@@ -440,23 +560,41 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         Returns
         -------
         str | None
-            Alert message when the stuck threshold is first crossed, else None.
+            Alert message when a hang is first detected, else None.
         """
         if not self.scrub_command or not self.scrub_command.strip():
             return None
-        if self._scrub_lock_is_held():
-            self._scrub_lock_held_cycles += 1
-            if (self._scrub_lock_held_cycles >= self.stuck_scrub_cycles
-                    and not self._stuck_scrub_alerted):
-                self._stuck_scrub_alerted = True
-                return ("Auto-scrub lock held for {} consecutive cycles -- a "
-                        "prior scrub is likely hung; manual intervention "
-                        "needed".format(self._scrub_lock_held_cycles))
+        state = self._scrub_lock_state()
+        if state == "free":
+            self._scrub_first_held = None
+            self._stuck_scrub_alerted = False
             return None
-        # Lock free -> reset the counter and re-arm the alert
-        self._scrub_lock_held_cycles = 0
-        self._stuck_scrub_alerted = False
-        return None
+
+        # held or unknown -> a scrub may be running/hung; measure progress
+        now = time.monotonic()
+        if self._scrub_first_held is None:
+            self._scrub_first_held = now
+        status = self._read_scrub_status()
+        hb = status.get("timestamp") if status else None
+        if isinstance(hb, (int, float)):
+            progress_age = time.time() - hb          # time since last heartbeat
+        else:
+            progress_age = now - self._scrub_first_held  # no heartbeat fallback
+
+        if progress_age <= self.scrub_hang_timeout_s:
+            return None  # fresh heartbeat (working) or not held long enough yet
+
+        # Genuine hang: lock held with no progress for scrub_hang_timeout_s
+        recovered = False
+        if self.scrub_auto_recover:
+            recovered = self._recover_stuck_scrub(status)
+        if self._stuck_scrub_alerted:
+            return None
+        self._stuck_scrub_alerted = True
+        action = ("killed the stale scrub to free the lock" if recovered
+                  else "manual intervention needed")
+        return ("Auto-scrub hung: lock held with no progress for {:.0f}s -- {}"
+                .format(progress_age, action))
 
     def check_battery_voltage(self, input_data):
         """

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -25,8 +25,8 @@ import brokkr.utils.output
 SCRUB_LOCK_FILE = "/tmp/hamma_scrub.lock"
 # Heartbeat/status file the scrub writes as it advances (must match
 # hamma_scrub.DEFAULT_STATUS_FILE); read to tell a working scrub from a hung one.
-DEFAULT_SCRUB_STATUS_FILE = os.path.expanduser(
-    "~/brokkr/hamma/log/hamma_scrub_status.json")
+# On tmpfs so it stays writable when the SD root fills (the incident condition).
+DEFAULT_SCRUB_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 # Durable log capturing the scrub's own stdout/stderr (mj05 ran blind because
 # this was DEVNULL'd). Rotated at SCRUB_LOG_MAX_BYTES so it can't fill the disk.
 DEFAULT_SCRUB_LOG = os.path.expanduser("~/brokkr/hamma/log/hamma_scrub.log")
@@ -132,7 +132,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.scrub_status_file = scrub_status_file
         self.scrub_auto_recover = scrub_auto_recover
         self.scrub_log = scrub_log
-        self._scrub_first_held = None
+        self._scrub_first_held = None      # monotonic; when lock streak began
+        self._scrub_last_progress = None   # monotonic; last heartbeat advance
+        self._scrub_progress_token = None  # last-seen heartbeat identity
         self._stuck_scrub_alerted = False
 
         self.notifier = Notifier(
@@ -510,7 +512,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
                     "utf-8", "replace")
         except OSError:
             return False
-        return "hamma_scrub" in cmdline
+        return "hamma_scrub.py" in cmdline
 
     def _recover_stuck_scrub(self, status):
         """Kill a genuinely-hung scrub to free the lock. Returns True if killed.
@@ -540,17 +542,33 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             "Killed hung scrub PID %s (process group) to free the lock", pid)
         return True
 
+    @staticmethod
+    def _progress_token(status):
+        """Identity of a heartbeat -- changes whenever the scrub advances.
+
+        We compare tokens for *change* across cycles; we never interpret the
+        scrub's ``timestamp`` as an absolute time, so a skewed/NTP-stepped
+        sensor clock can neither disable detection nor cause a false kill.
+        """
+        if not status:
+            return None
+        return (status.get("pid"), status.get("timestamp"),
+                status.get("phase"), status.get("recovered"),
+                status.get("purged"))
+
     def check_scrub_health(self, input_data):
         """Detect and (optionally) recover a *hung* scrub -- progress-gated.
 
-        "Hung" is defined as: the lock is held AND the scrub has made no
-        progress (stale heartbeat) for `scrub_hang_timeout_s`. This
-        distinguishes a hang from a legitimately long recovery (which keeps the
-        heartbeat fresh), avoiding cry-wolf. On a genuine hang, if
-        `scrub_auto_recover` is set, kill the stale scrub to free the lock
-        (self-healing -- a timer alone can't do this); alert once either way.
-        Re-arms when the lock frees. 'unknown' lock state (e.g. disk full) is
-        treated as suspicious, not free.
+        "Hung" = the lock is held AND the heartbeat has not *advanced* for
+        `scrub_hang_timeout_s`, measured in the monitor's own ``monotonic``
+        clock. Advancement (not absolute heartbeat age) distinguishes a hang
+        from a long legit recovery (fresh heartbeat) -> no cry-wolf; monotonic
+        + change-detection makes it immune to sensor clock skew and to a stale
+        heartbeat left by a *previous* run (grace is counted from the moment
+        THIS monitor first saw the lock held, not from the file's timestamp).
+        On a genuine hang, if `scrub_auto_recover`, kill the stale scrub AND
+        re-spawn a fresh one to use the freed lock; alert once either way.
+        'unknown' lock state (e.g. disk full) is treated as suspicious.
 
         Parameters
         ----------
@@ -567,34 +585,44 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         state = self._scrub_lock_state()
         if state == "free":
             self._scrub_first_held = None
+            self._scrub_last_progress = None
+            self._scrub_progress_token = None
             self._stuck_scrub_alerted = False
             return None
 
-        # held or unknown -> a scrub may be running/hung; measure progress
+        # held or unknown -> a scrub may be running/hung; track PROGRESS
         now = time.monotonic()
+        token = self._progress_token(self._read_scrub_status())
         if self._scrub_first_held is None:
+            # New held-streak: start the clock NOW and record (but do not judge)
+            # any pre-existing heartbeat -- it may belong to a previous run.
             self._scrub_first_held = now
-        status = self._read_scrub_status()
-        hb = status.get("timestamp") if status else None
-        if isinstance(hb, (int, float)):
-            progress_age = time.time() - hb          # time since last heartbeat
-        else:
-            progress_age = now - self._scrub_first_held  # no heartbeat fallback
+            self._scrub_last_progress = now
+            self._scrub_progress_token = token
+            return None
+        if token is not None and token != self._scrub_progress_token:
+            self._scrub_progress_token = token
+            self._scrub_last_progress = now  # heartbeat advanced -> progress
 
-        if progress_age <= self.scrub_hang_timeout_s:
-            return None  # fresh heartbeat (working) or not held long enough yet
+        idle = now - self._scrub_last_progress
+        if idle <= self.scrub_hang_timeout_s:
+            return None  # progressing, or not yet idle long enough
 
-        # Genuine hang: lock held with no progress for scrub_hang_timeout_s
+        # Genuine hang: lock held with no heartbeat advance for the timeout
         recovered = False
         if self.scrub_auto_recover:
+            status = self._read_scrub_status()
             recovered = self._recover_stuck_scrub(status)
+            if recovered:
+                self._scrub_first_held = None  # streak ends; re-measure next hold
+                self._spawn_scrub()  # use the freed lock (a timer is the backstop)
         if self._stuck_scrub_alerted:
             return None
         self._stuck_scrub_alerted = True
-        action = ("killed the stale scrub to free the lock" if recovered
+        action = ("killed the stale scrub and re-spawned" if recovered
                   else "manual intervention needed")
-        return ("Auto-scrub hung: lock held with no progress for {:.0f}s -- {}"
-                .format(progress_age, action))
+        return ("Auto-scrub hung: lock held, no progress for {:.0f}s -- {}"
+                .format(idle, action))
 
     def check_battery_voltage(self, input_data):
         """

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -53,6 +53,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         purge_space=200,
         alert_space=75,
         scrub_cooldown_s=300,
+        hs_stale_cycles=15,
         ping_max=3,
         channel=None,
         key_file=None,
@@ -61,8 +62,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_command="",
         scrub_hang_timeout_s=900,
         scrub_status_file=DEFAULT_SCRUB_STATUS_FILE,
-        scrub_auto_recover=True,
+        scrub_auto_recover=False,
         scrub_log=DEFAULT_SCRUB_LOG,
+        low_space=None,   # DEPRECATED: replaced by purge_space/alert_space
         **output_step_kwargs,
         ):
         """
@@ -88,6 +90,12 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             Minimum seconds between level-triggered scrub launches while free is
             below purge_space (retry cadence). Default 300 (5 min) -- more responsive
             than the 15-min §3.3 timer, which is the coarse backstop.
+        hs_stale_cycles : int, optional
+            Alert once if the sensor's `bytes_remaining` reads NA this many
+            consecutive monitor cycles (default 15, ~15 min). NA means the AGS is
+            dark, so every space-based decision is blind and `/ags/data` can fill
+            unseen -- this watchdog is the only thing that speaks up in that state.
+            Reset (and re-armed) by any numeric reading.
         ping_max : int, optional
             The maximum number of consecutive ping errors before we send an error message
             via `method`. Any ping errors are still logged locally.
@@ -111,11 +119,17 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_status_file : str, optional
             Path to the scrub's heartbeat/status JSON (progress signal).
         scrub_auto_recover : bool, optional
-            If True (default), kill a genuinely-hung scrub to free the lock
-            (self-healing); else only alert.
+            If True, kill a genuinely-hung scrub to free the lock (self-healing);
+            else only alert. Default **False** -- this SIGKILLs a process group,
+            so it stays off until validated on a bench unit (§3.2 deploy gate).
         scrub_log : str, optional
             Durable file capturing the scrub's stdout/stderr (rotated); empty
             string disables (falls back to DEVNULL).
+        low_space : numeric, optional
+            **Deprecated.** The old single edge-triggered threshold, replaced by
+            purge_space/alert_space (§3.4). Accepted only so a stale per-unit
+            override (e.g. mj54's `low_space=10`) does not crash pipeline build --
+            it is warned about and otherwise ignored.
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -136,6 +150,20 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.scrub_cooldown_s = scrub_cooldown_s
         self._last_scrub_spawn = None   # monotonic; level-trigger retry gate
         self._low_space_alerted = False
+        # Telemetry-staleness watchdog: bytes_remaining goes NA when the AGS is
+        # dark, so the two-threshold path is blind exactly then -- alert instead
+        # of silently missing a fill (the mj05 condition).
+        self.hs_stale_cycles = hs_stale_cycles
+        self._hs_stale_count = 0
+        self._hs_stale_alerted = False
+        # Legacy config compatibility: a deployed per-unit override may still set
+        # `low_space` (removed in favour of purge_space/alert_space). Accept and
+        # ignore it -- brokkr's Executable.__init__ has no **kwargs, so an
+        # unconsumed key would crash the whole telemetry pipeline at build time.
+        if low_space is not None:
+            self.logger.warning(
+                "state_monitor: `low_space=%s` is deprecated and ignored; use "
+                "purge_space/alert_space", low_space)
         if alert_space >= purge_space:
             self.logger.warning(
                 "state_monitor: alert_space (%s) >= purge_space (%s) -- the "
@@ -415,7 +443,20 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         """
         space_now, _space_pre = self.now_then(input_data, 'bytes_remaining')
         if not isinstance(space_now, (int, float)) or space_now != space_now:
-            return None  # NA / non-numeric -> can't evaluate
+            # NA / non-numeric: can't evaluate space. Persistent NA means the
+            # AGS is dark (not sending H&S) -- the drive can fill unseen, so
+            # alert once rather than fail silent (the mj05 blind spot).
+            self._hs_stale_count += 1
+            if (self._hs_stale_count >= self.hs_stale_cycles
+                    and not self._hs_stale_alerted):
+                self._hs_stale_alerted = True
+                return ("AGS telemetry (bytes_remaining) NA for {} cycles -- "
+                        "the AGS may be dark/unreachable; /ags/data can fill "
+                        "unseen".format(self._hs_stale_count))
+            return None
+        # Numeric reading: AGS is reporting -> clear the staleness watchdog.
+        self._hs_stale_count = 0
+        self._hs_stale_alerted = False
         if space_now >= self.purge_space:
             # Healthy: re-arm the alert and the immediate-spawn on next descent.
             self._low_space_alerted = False

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -136,6 +136,11 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.scrub_cooldown_s = scrub_cooldown_s
         self._last_scrub_spawn = None   # monotonic; level-trigger retry gate
         self._low_space_alerted = False
+        if alert_space >= purge_space:
+            self.logger.warning(
+                "state_monitor: alert_space (%s) >= purge_space (%s) -- the "
+                "'purge is losing' alert will fire on every routine drain; "
+                "expected alert_space < purge_space", alert_space, purge_space)
         self.ping_max = ping_max
         self.bad_ping = 0  # Track the number of bad pings
         self.low_pi_space = low_pi_space*1000000000
@@ -418,28 +423,38 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return None
         # Below the purge threshold: drain proactively (level-triggered + cooldown).
         self._maybe_spawn_scrub()
-        # Below the alert threshold too: purge is losing -> alert once.
-        if space_now < self.alert_space and not self._low_space_alerted:
+        if space_now >= self.alert_space:
+            # Drain band [alert_space, purge_space): draining, no alert. Re-arm
+            # the alert here (hysteresis) so a fresh drop below alert_space in a
+            # later oscillation pages again -- not just once per full recovery.
+            self._low_space_alerted = False
+            return None
+        # Below the alert threshold: purge is losing -> alert once.
+        if not self._low_space_alerted:
             self._low_space_alerted = True
-            return ("Sensor drive low: {:.1f} GB free (below {:g} GB) and still "
-                    "falling despite auto-scrub -- intervention may be needed"
-                    .format(space_now, self.alert_space))
+            return ("Sensor drive critically low: {:.1f} GB free (below the "
+                    "{:g} GB alert floor); auto-scrub is running -- "
+                    "intervention may be needed".format(
+                        space_now, self.alert_space))
         return None
 
     def _maybe_spawn_scrub(self):
         """Spawn a scrub at most once per `scrub_cooldown_s` (level-trigger retry).
 
-        The cooldown stops check_sensor_drive from re-attempting every 60 s
-        monitor cycle while free stays below `purge_space`. `_spawn_scrub`
-        itself no-ops (via the flock probe) if a scrub is already running.
+        The cooldown stops check_sensor_drive from re-launching every 60 s
+        monitor cycle. It is armed only when a scrub *actually launches* -- a
+        no-op attempt (lock held by a running scrub, or a spawn error) does NOT
+        consume the cooldown, so we re-probe the (cheap) flock every cycle and
+        launch the instant the lock frees.
         """
         now = time.monotonic()
         if (self._last_scrub_spawn is not None
                 and now - self._last_scrub_spawn < self.scrub_cooldown_s):
             return False
-        self._last_scrub_spawn = now
-        self._spawn_scrub()
-        return True
+        if self._spawn_scrub():
+            self._last_scrub_spawn = now
+            return True
+        return False
 
     def _scrub_lock_state(self):
         """Return 'held', 'free', or 'unknown' for the scrub flock.
@@ -508,25 +523,32 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         made the spawn a silent no-op *and the log lied* (the mj05 failure).
         Here we probe the lock first and log the truth, and capture the scrub's
         output to a durable log (mj05 ran blind on DEVNULL'd output).
+
+        Returns
+        -------
+        bool
+            True iff a scrub was actually launched (so the level-trigger's
+            cooldown is armed only on a real launch, not a no-op).
         """
         if not self.scrub_command or not self.scrub_command.strip():
-            return
+            return False
         state = self._scrub_lock_state()
         if state == "held":
             self.logger.warning(
                 "Scrub NOT spawned: a prior scrub still holds %s "
                 "(possibly hung -- see check_scrub_health)", SCRUB_LOCK_FILE)
-            return
+            return False
         if state == "unknown":
             self.logger.warning(
                 "Scrub NOT spawned: lock %s unreadable (disk full?)",
                 SCRUB_LOCK_FILE)
-            return
+            return False
         log_fh = self._open_scrub_log()
         if log_fh is not None:
             out, err = log_fh, subprocess.STDOUT  # capture stderr into the log
         else:
             out, err = subprocess.DEVNULL, subprocess.DEVNULL
+        launched = False
         try:
             cmd = ["flock", "-n", SCRUB_LOCK_FILE] + shlex.split(
                 self.scrub_command)
@@ -538,11 +560,13 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             )
             self.logger.info("Scrub spawned (lock was free): %s",
                              " ".join(cmd))
+            launched = True
         except (OSError, ValueError) as e:
             self.logger.error("Failed to spawn scrub: %s", e)
         finally:
             if log_fh is not None:
                 log_fh.close()  # Popen dup'd the fd; the parent can close
+        return launched
 
     def _pid_is_scrub(self, pid):
         """True if `pid` is (still) a running hamma_scrub process.

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -50,7 +50,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self,
         method=None,
         power_delim=1,
-        low_space=100,
+        purge_space=200,
+        alert_space=75,
+        scrub_cooldown_s=300,
         ping_max=3,
         channel=None,
         key_file=None,
@@ -75,9 +77,17 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             The delimiter between normal power and low power.
             If power falls below this value, it is considered low
             and a notification will be generated.
-        low_space : numeric, optional
-            If the number of gigabytes remaining falls below this threshold, generate
-            a notification.
+        purge_space : numeric, optional
+            GB free on the AGS drive below which to run the scrub proactively
+            (level-triggered, every scrub_cooldown_s). No alert -- this is the
+            "drain harder" band. Default 200.
+        alert_space : numeric, optional
+            GB free below which to alert: free fell this far *despite* the
+            purging, so purge is losing. Default 75 (< purge_space).
+        scrub_cooldown_s : numeric, optional
+            Minimum seconds between level-triggered scrub launches while free is
+            below purge_space (retry cadence). Default 300 (5 min) -- more responsive
+            than the 15-min §3.3 timer, which is the coarse backstop.
         ping_max : int, optional
             The maximum number of consecutive ping errors before we send an error message
             via `method`. Any ping errors are still logged locally.
@@ -119,7 +129,13 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         # Setup simpleeval parser and class initial state
         self._previous_data = None
         self.power_delim = power_delim
-        self.low_space = low_space
+        # Two-threshold drain/escalation on the AGS drive (§3.4). purge_space =
+        # proactive-drain band; alert_space = "purge is losing" alarm.
+        self.purge_space = purge_space
+        self.alert_space = alert_space
+        self.scrub_cooldown_s = scrub_cooldown_s
+        self._last_scrub_spawn = None   # monotonic; level-trigger retry gate
+        self._low_space_alerted = False
         self.ping_max = ping_max
         self.bad_ping = 0  # Track the number of bad pings
         self.low_pi_space = low_pi_space*1000000000
@@ -369,12 +385,18 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         return None
 
     def check_sensor_drive(self, input_data):
-        """
-        Check the remaining space on sensor.
+        """Two-threshold drain + escalation on the AGS drive (§3.4).
 
-        This will check to see how much space is remaining on a sensor USB drive.
-        If it falls below the value given by the class attribute `low_space`,
-        send a message and optionally spawn a scrub process.
+        LEVEL-triggered, not edge (the old edge fired once at the crossing and
+        never retried -- the mj05 failure mode). While free < `purge_space`, run
+        the scrub every `scrub_cooldown_s` (proactive drain, more responsive
+        than the §3.3 timer). If free falls below `alert_space` *despite* the
+        purging -- purge is losing -- alert once (re-arm when free recovers
+        above `purge_space`).
+
+        Fair-weather layer: `bytes_remaining` goes NA when the AGS is dark, so a
+        non-numeric reading is skipped; the §3.3 timer + §3.2 stuck-detector
+        cover the AGS-dark case.
 
         Parameters
         ----------
@@ -384,18 +406,40 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         Returns
         -------
         str | None
-            Message to send depending on the check, or None if no message.
-
+            Alert message when free first drops below `alert_space`, else None.
         """
-        space_now, space_pre = self.now_then(input_data, 'bytes_remaining')
-        # Use >= for `pre` so a previous sample sitting exactly on the
-        # threshold still counts as above it. Strict `>` silently misses
-        # the edge when pre lands on low_space (a real case on mj07:
-        # 100.0 -> 99.96 with low_space=100 never fired).
-        if (space_now < self.low_space) and (space_pre >= self.low_space):
-            self._spawn_scrub()
-            return f"Remaining GB on drive is {space_now:.1f}"
+        space_now, _space_pre = self.now_then(input_data, 'bytes_remaining')
+        if not isinstance(space_now, (int, float)) or space_now != space_now:
+            return None  # NA / non-numeric -> can't evaluate
+        if space_now >= self.purge_space:
+            # Healthy: re-arm the alert and the immediate-spawn on next descent.
+            self._low_space_alerted = False
+            self._last_scrub_spawn = None
+            return None
+        # Below the purge threshold: drain proactively (level-triggered + cooldown).
+        self._maybe_spawn_scrub()
+        # Below the alert threshold too: purge is losing -> alert once.
+        if space_now < self.alert_space and not self._low_space_alerted:
+            self._low_space_alerted = True
+            return ("Sensor drive low: {:.1f} GB free (below {:g} GB) and still "
+                    "falling despite auto-scrub -- intervention may be needed"
+                    .format(space_now, self.alert_space))
         return None
+
+    def _maybe_spawn_scrub(self):
+        """Spawn a scrub at most once per `scrub_cooldown_s` (level-trigger retry).
+
+        The cooldown stops check_sensor_drive from re-attempting every 60 s
+        monitor cycle while free stays below `purge_space`. `_spawn_scrub`
+        itself no-ops (via the flock probe) if a scrub is already running.
+        """
+        now = time.monotonic()
+        if (self._last_scrub_spawn is not None
+                and now - self._last_scrub_spawn < self.scrub_cooldown_s):
+            return False
+        self._last_scrub_spawn = now
+        self._spawn_scrub()
+        return True
 
     def _scrub_lock_state(self):
         """Return 'held', 'free', or 'unknown' for the scrub flock.

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -58,6 +58,11 @@ SSH_CONNECT_TIMEOUT = 10  # seconds to establish an SSH connection (fail fast)
 CONTROL_PERSIST = 60      # seconds the shared ControlMaster lingers after last use
 PURGE_CHUNK_SIZE = 100    # AGS files deleted per batched `rm` (one SSH round-trip)
 PURGE_TIMEOUT = 30        # seconds per batched delete chunk
+# Bounds worst-case lock-hold time: an auto-scrub runs under `flock -n`, so a
+# hung scan blocks every subsequent spawn for its whole timeout. The old 3600s
+# cap let one hung scan stall the safety net for an hour; minutes is enough for
+# a legitimately large scan under load (observed worst case ~99s).
+SCAN_TIMEOUT = 600        # seconds for the remote AGS strider scan
 
 # Exit codes
 EXIT_OK = 0
@@ -572,7 +577,7 @@ def scan_ags_files(ags_host, ags_path, control_path=None):
         run_cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        timeout=3600,
+        timeout=SCAN_TIMEOUT,
     )
 
     if result.returncode != 0:

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -79,6 +79,12 @@ DEFAULT_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 # adds no SD wear; a reboot just costs one full scan.
 DEFAULT_MJ_CACHE = "/dev/shm/hamma_scrub_mj_cache.json"
 
+# Durable per-run CSV of MJ-scan cache performance (hit-rate over time). Unlike
+# the /dev/shm status/cache, this lives on disk so a cold scan (cache lost
+# between runs) leaves a reviewable trail. Rotated by the same log tooling.
+DEFAULT_METRICS_FILE = os.path.expanduser(
+    "~/brokkr/hamma/log/scrub_metrics.csv")
+
 # Exit codes
 EXIT_OK = 0
 EXIT_MISSING = 1
@@ -444,6 +450,46 @@ def _refresh_cache_dirs(cache_file, dirs):
         _save_scan_cache(cache_file, cache)
 
 
+SCAN_METRICS_HEADER = (
+    "utc,dirs_cached,dirs_total,cold,scan_seconds,recovered,purged")
+
+
+def write_scan_metrics(path, mj, recovered, purged):
+    """Append one CSV row summarizing this run's MJ-scan cache performance.
+
+    Durable (unlike the /dev/shm status file), so cache hit-rate can be reviewed
+    over time. A ``cold`` row (0 dirs cached over a large total) flags that the
+    cache was lost between runs -- the signal to catch a real-world cache miss.
+    When the cache is disabled (full scanner, no ``cache_hits``) the cache
+    columns are left blank rather than reporting a bogus cold flag. ``path`` of
+    None disables it; best-effort, never raises.
+    """
+    if not path:
+        return
+    try:
+        hits = mj.get("cache_hits")
+        total = mj.get("dirs_total")
+        if hits is None or total is None:
+            hits_s = total_s = cold_s = ""      # full scanner: no cache stats
+        else:
+            hits_s, total_s = str(hits), str(total)
+            cold_s = "1" if (total > 0 and hits == 0) else "0"
+        utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        row = "{},{},{},{},{},{},{}\n".format(
+            utc, hits_s, total_s, cold_s,
+            round(mj.get("elapsed", 0), 1), recovered, purged)
+        new_file = not os.path.exists(path)
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(path, "a") as f:
+            if new_file:
+                f.write(SCAN_METRICS_HEADER + "\n")
+            f.write(row)
+    except OSError as e:
+        logger.debug("Could not write scan metrics %s: %s", path, e)
+
+
 def scan_mj_files(base_path, since=None, cache_file=None):
     """Scan local mjolnir .bin files and collect headers.
 
@@ -537,6 +583,7 @@ def _scan_mj_incremental(base_path, since, cache_file):
         "dirs_skipped": dirs_skipped,
         "elapsed": elapsed,
         "cache_hits": cache_hits,
+        "dirs_total": len(new_cache),
     }
 
 
@@ -1897,13 +1944,18 @@ def _build_parser():
              "headers instead of re-reading every file (default: %(default)s; "
              "empty string forces a full scan every run)",
     )
+    parser.add_argument(
+        "--metrics-file", default=DEFAULT_METRICS_FILE,
+        help="Durable CSV appended one row per run with MJ-scan cache "
+             "hit-rate/timing (default: %(default)s; empty string disables)",
+    )
     return parser
 
 
 def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         limit=DEFAULT_LIMIT, since=None, recover=False, dry_run=False,
         purge=False, status_file=DEFAULT_STATUS_FILE,
-        mj_cache=DEFAULT_MJ_CACHE):
+        mj_cache=DEFAULT_MJ_CACHE, metrics_file=DEFAULT_METRICS_FILE):
     """Run the scrubber and return exit code.
 
     Parameters
@@ -1983,11 +2035,13 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
     if not ags["entries"]:
         logger.info("No AGS data found — nothing to compare")
         write_status(status_file, "done", recovered=0, purged=0)
+        write_scan_metrics(metrics_file, mj, 0, 0)
         return EXIT_OK
 
     if mj["file_count"] == 0 and mj["skipped"] == 0:
         logger.error("No DATA drives or .bin files found at %s", mj_path)
         write_status(status_file, "error", error="no MJ drives/files")
+        write_scan_metrics(metrics_file, mj, 0, 0)
         return EXIT_NO_DATA
 
     comparison = compare_headers(ags["entries"], mj["headers"])
@@ -2093,11 +2147,11 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                 "dry_run": dry_run,
             }
 
-    write_status(
-        status_file, "done",
-        recovered=len([r for r in (recovery_results or [])
-                       if r["status"] == "recovered"]),
-        purged=len((purge_results or {}).get("deleted", [])))
+    recovered_n = len([r for r in (recovery_results or [])
+                       if r["status"] == "recovered"])
+    purged_n = len((purge_results or {}).get("deleted", []))
+    write_status(status_file, "done", recovered=recovered_n, purged=purged_n)
+    write_scan_metrics(metrics_file, mj, recovered_n, purged_n)
 
     if json_output:
         print(format_json_report(results, ags_host,
@@ -2145,6 +2199,7 @@ def main():
         purge=args.purge,
         status_file=args.status_file or None,
         mj_cache=args.mj_cache or None,
+        metrics_file=args.metrics_file or None,
     )
     sys.exit(rc)
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -1300,7 +1300,7 @@ def identify_purgeable_files(ags_entries, mj_headers, recovery_results=None):
 
 
 def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
-                    control_path=None):
+                    control_path=None, status_file=None):
     """Delete AGS files via SSH, batched over one connection.
 
     Files are deleted in chunks of ``PURGE_CHUNK_SIZE`` — a single
@@ -1321,6 +1321,10 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
         If True, log what would be deleted but take no action.
     control_path : str or None
         ControlMaster socket to reuse for the SSH calls.
+    status_file : str or None
+        If given, write a ``purge``-phase heartbeat (``purged``/``total``) to
+        this status file after each chunk, so a long purge advances the progress
+        token and the monitor's hung-scrub detector does not misjudge it as stuck.
 
     Returns
     -------
@@ -1336,6 +1340,13 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
 
     for start in range(0, len(filenames), PURGE_CHUNK_SIZE):
         chunk = filenames[start:start + PURGE_CHUNK_SIZE]
+        # Per-chunk heartbeat: purge over a wedging SSH pipe can take a while;
+        # advancing the heartbeat here lets the monitor's hung-scrub detector
+        # tell a working purge from a stalled one (else a long purge could look
+        # hung and be killed).
+        write_status(status_file, "purge",
+                     purged=sum(1 for r in results if r["status"] == "deleted"),
+                     total=len(filenames))
 
         if dry_run:
             for fname in chunk:
@@ -2018,6 +2029,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                 purge_deletions = purge_ags_files(
                     ags_host, ags_path, eligibility["purgeable"],
                     dry_run=dry_run, control_path=control_path,
+                    status_file=status_file,
                 )
             else:
                 purge_deletions = []

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -1148,9 +1148,35 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
             continue
 
         if result.returncode != 0:
+            # `rm -f f1..fN` exits non-zero if ANY file errored, but it still
+            # deleted the others. Marking the whole chunk "failed" would lie
+            # (the report would under-count deletions during a disk-fill).
+            # Retry per-file to attribute status correctly -- only failing
+            # chunks pay the per-file cost; healthy chunks stay batched-fast.
             stderr = result.stderr.decode('utf-8', errors='replace').strip()
-            logger.warning("Failed to delete chunk on %s: %s", ags_host, stderr)
-            _record(chunk, "failed", stderr)
+            logger.warning("Batched delete on %s returned non-zero (%s); "
+                           "retrying per-file to attribute status",
+                           ags_host, stderr)
+            for fname, quoted in zip(chunk, remote_paths):
+                one_cmd = ssh_cmd(ags_host, "rm -f " + quoted,
+                                  control_path=control_path)
+                try:
+                    one = subprocess.run(
+                        one_cmd, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE, timeout=PURGE_TIMEOUT)
+                except subprocess.TimeoutExpired:
+                    results.append({"filename": fname, "status": "failed",
+                                    "error": "SSH timeout ({}s)".format(
+                                        PURGE_TIMEOUT)})
+                    continue
+                if one.returncode == 0:
+                    results.append({"filename": fname, "status": "deleted",
+                                    "error": None})
+                else:
+                    results.append({
+                        "filename": fname, "status": "failed",
+                        "error": one.stderr.decode(
+                            'utf-8', errors='replace').strip()})
         else:
             _record(chunk, "deleted", None)
 
@@ -1698,81 +1724,78 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
     }
 
     # Recovery + purge reuse one SSH connection (per-op cost ~16x lower).
-    # It self-closes via ControlPersist; close_control_master() below is the
-    # happy-path teardown, with ControlPersist as the exception backstop.
-    control_path = open_control_master(ags_host)
-
-    # Recovery flow
+    # The context manager guarantees teardown even if recover/purge raise
+    # (the bare open/close pair leaked the socket on exceptions).
     recovery_results = None
-    if recover and comparison["missing_on_mj"]:
-        cleanup_orphaned_temps(mj_path)
-        candidates = filter_recovery_candidates(
-            comparison["missing_on_mj"], ags["entries"],
-            since_cutoff=since_cutoff,
-        )
-        recovery_results = recover_triggers(
-            candidates, ags_host, ags_path, mj_path, dry_run=dry_run,
-            control_path=control_path,
-        )
-        recovered_count = len([r for r in recovery_results
-                               if r["status"] == "recovered"])
-        failed_count = len([r for r in recovery_results
-                            if r["status"] == "failed"])
-        if recovered_count:
-            logger.info("Recovery: %d succeeded", recovered_count)
-        if failed_count:
-            logger.warning("Recovery: %d failed", failed_count)
-
-    # Update mj_headers and missing list with recovered triggers
-    if recovery_results:
-        recovered_headers = set()
-        for r in recovery_results:
-            if r["status"] == "recovered":
-                mj["headers"].add(r["header"])
-                recovered_headers.add(r["header"])
-        if recovered_headers:
-            comparison["missing_on_mj"] = [
-                e for e in comparison["missing_on_mj"]
-                if e["header"] not in recovered_headers
-            ]
-            results["missing_on_mj"] = comparison["missing_on_mj"]
-            results["matched"] += len(recovered_headers)
-
-    # Purge flow
     purge_results = None
-    if purge:
-        eligibility = identify_purgeable_files(
-            ags["entries"], mj["headers"], recovery_results,
-        )
-        if eligibility["purgeable"]:
-            purge_deletions = purge_ags_files(
-                ags_host, ags_path, eligibility["purgeable"],
-                dry_run=dry_run, control_path=control_path,
+    with ssh_control_master(ags_host) as control_path:
+        # Recovery flow
+        if recover and comparison["missing_on_mj"]:
+            cleanup_orphaned_temps(mj_path)
+            candidates = filter_recovery_candidates(
+                comparison["missing_on_mj"], ags["entries"],
+                since_cutoff=since_cutoff,
             )
-        else:
-            purge_deletions = []
+            recovery_results = recover_triggers(
+                candidates, ags_host, ags_path, mj_path, dry_run=dry_run,
+                control_path=control_path,
+            )
+            recovered_count = len([r for r in recovery_results
+                                   if r["status"] == "recovered"])
+            failed_count = len([r for r in recovery_results
+                                if r["status"] == "failed"])
+            if recovered_count:
+                logger.info("Recovery: %d succeeded", recovered_count)
+            if failed_count:
+                logger.warning("Recovery: %d failed", failed_count)
 
-        deleted_names = [d["filename"] for d in purge_deletions
-                         if d["status"] == "deleted"]
-        failed_purge = [d for d in purge_deletions
-                        if d["status"] == "failed"]
+        # Update mj_headers and missing list with recovered triggers
+        if recovery_results:
+            recovered_headers = set()
+            for r in recovery_results:
+                if r["status"] == "recovered":
+                    mj["headers"].add(r["header"])
+                    recovered_headers.add(r["header"])
+            if recovered_headers:
+                comparison["missing_on_mj"] = [
+                    e for e in comparison["missing_on_mj"]
+                    if e["header"] not in recovered_headers
+                ]
+                results["missing_on_mj"] = comparison["missing_on_mj"]
+                results["matched"] += len(recovered_headers)
 
-        if deleted_names:
-            logger.info("Purge: deleted %d AGS files", len(deleted_names))
-        if failed_purge:
-            logger.warning("Purge: %d deletions failed", len(failed_purge))
+        # Purge flow
+        if purge:
+            eligibility = identify_purgeable_files(
+                ags["entries"], mj["headers"], recovery_results,
+            )
+            if eligibility["purgeable"]:
+                purge_deletions = purge_ags_files(
+                    ags_host, ags_path, eligibility["purgeable"],
+                    dry_run=dry_run, control_path=control_path,
+                )
+            else:
+                purge_deletions = []
 
-        # Normalize to flat filename lists for reports (matching spec JSON shape)
-        purge_results = {
-            "deleted": [d["filename"] for d in purge_deletions
-                        if d["status"] in ("deleted", "dry_run")],
-            "failed": [{"filename": d["filename"], "error": d["error"]}
-                       for d in purge_deletions if d["status"] == "failed"],
-            "retained": eligibility["retained"],
-            "dry_run": dry_run,
-        }
+            deleted_names = [d["filename"] for d in purge_deletions
+                             if d["status"] == "deleted"]
+            failed_purge = [d for d in purge_deletions
+                            if d["status"] == "failed"]
 
-    close_control_master(ags_host, control_path)
+            if deleted_names:
+                logger.info("Purge: deleted %d AGS files", len(deleted_names))
+            if failed_purge:
+                logger.warning("Purge: %d deletions failed", len(failed_purge))
+
+            # Flatten to filename lists for reports (matching spec JSON shape)
+            purge_results = {
+                "deleted": [d["filename"] for d in purge_deletions
+                            if d["status"] in ("deleted", "dry_run")],
+                "failed": [{"filename": d["filename"], "error": d["error"]}
+                           for d in purge_deletions if d["status"] == "failed"],
+                "retained": eligibility["retained"],
+                "dry_run": dry_run,
+            }
 
     if json_output:
         print(format_json_report(results, ags_host,

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -58,6 +58,16 @@ SSH_CONNECT_TIMEOUT = 10  # seconds to establish an SSH connection (fail fast)
 CONTROL_PERSIST = 60      # seconds the shared ControlMaster lingers after last use
 PURGE_CHUNK_SIZE = 100    # AGS files deleted per batched `rm` (one SSH round-trip)
 PURGE_TIMEOUT = 30        # seconds per batched delete chunk
+# CPU-nice the scrub's heavy AGS-side commands (header scan, recover reads,
+# purge) so they cannot preempt the DAS writer on the AGS Pi. Verified on the
+# fleet: the DAS runs at CPU nice 19 (the floor) while an unniced remote command
+# runs at nice 0 -- i.e. the scrub would OUTRANK the writer on CPU. `nice -n 19`
+# demotes it to the writer's floor. No ionice: the AGS's active I/O scheduler is
+# mq-deadline, which ignores ionice classes entirely (the DAS's "realtime" I/O
+# prio is set but inert), so ionice here would be theatre. `nice` is coreutils,
+# always present. The mj-pi side is deprioritised separately via the service
+# unit's Nice= (files/hamma-scrub.service).
+AGS_NICE = "nice -n 19 "
 # Bounds the SCAN phase's contribution to lock-hold time -- NOT the whole scrub:
 # recover is per-trigger (RECOVER_TIMEOUT) and purge per-chunk (PURGE_TIMEOUT),
 # so the aggregate scan+recover+purge lock-hold is NOT bounded by this alone.
@@ -868,7 +878,7 @@ def scan_ags_files(ags_host, ags_path, control_path=None):
 
     run_cmd = ssh_cmd(
         ags_host,
-        "python3 {script} {path}; rm -f {script}".format(
+        AGS_NICE + "python3 {script} {path}; rm -f {script}".format(
             script=remote_script, path=ags_path),
         control_path=control_path)
     logger.debug("Running: %s", " ".join(run_cmd))
@@ -1179,7 +1189,7 @@ def extract_trigger(ags_host, ags_path, filename, offset, size,
         Extracted data, or None on failure.
     """
     filepath = "{}/{}".format(ags_path, filename)
-    dd_cmd = (
+    dd_cmd = AGS_NICE + (
         "dd if={} iflag=skip_bytes,count_bytes bs=4096"
         " skip={} count={} status=none"
     ).format(filepath, offset, size)
@@ -1447,7 +1457,7 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
         remote_paths = [
             shlex.quote("{}/{}".format(ags_path, fname)) for fname in chunk
         ]
-        rm_command = "rm -f " + " ".join(remote_paths)
+        rm_command = AGS_NICE + "rm -f " + " ".join(remote_paths)
         cmd = ssh_cmd(ags_host, rm_command, control_path=control_path)
         logger.info("Deleting %d AGS file(s) on %s", len(chunk), ags_host)
         try:
@@ -1474,7 +1484,7 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
                            "retrying per-file to attribute status",
                            ags_host, stderr)
             for fname, quoted in zip(chunk, remote_paths):
-                one_cmd = ssh_cmd(ags_host, "rm -f " + quoted,
+                one_cmd = ssh_cmd(ags_host, AGS_NICE + "rm -f " + quoted,
                                   control_path=control_path)
                 try:
                     one = subprocess.run(

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -17,7 +17,6 @@ import contextlib
 import glob
 import json
 import logging
-import pickle
 import math
 import os
 import re
@@ -78,7 +77,7 @@ DEFAULT_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 # (mtime, .bin-count) signature, so unchanged dirs are reused instead of
 # re-reading every file's header (the ~99s-under-load MJ scan). On tmpfs so it
 # adds no SD wear; a reboot just costs one full scan.
-DEFAULT_MJ_CACHE = "/dev/shm/hamma_scrub_mj_cache.pkl"
+DEFAULT_MJ_CACHE = "/dev/shm/hamma_scrub_mj_cache.json"
 
 # Exit codes
 EXIT_OK = 0
@@ -347,33 +346,51 @@ def _parse_since(since_str):
 
 
 def _load_scan_cache(path):
-    """Load the incremental MJ-scan cache; {} on any problem (safe fallback)."""
+    """Load the incremental MJ-scan cache; {} on any problem (safe fallback).
+
+    JSON, NOT pickle: the cache lives on world-writable tmpfs (`/dev/shm` is
+    mode 1777), so unpickling it would be a local code-execution vector as the
+    scrub's user. JSON stores headers as hex and can never execute code on load.
+    """
     try:
-        with open(path, "rb") as f:
-            data = pickle.load(f)
-        return data if isinstance(data, dict) else {}
-    except (OSError, EOFError, ValueError, pickle.UnpicklingError,
-            AttributeError):
+        with open(path) as f:
+            raw = json.load(f)
+        if not isinstance(raw, dict):
+            return {}
+        return {
+            k: {"sig": tuple(v["sig"]),
+                "headers": {bytes.fromhex(h) for h in v["headers"]},
+                "file_count": v["file_count"],
+                "skipped": v["skipped"]}
+            for k, v in raw.items()
+        }
+    except (OSError, ValueError, KeyError, TypeError):
         return {}
 
 
 def _save_scan_cache(path, cache):
-    """Atomically persist the MJ-scan cache (best-effort; never raises)."""
+    """Atomically persist the MJ-scan cache as JSON (best-effort; never raises)."""
     try:
+        raw = {k: {"sig": list(v["sig"]),
+                   "headers": sorted(h.hex() for h in v["headers"]),
+                   "file_count": v["file_count"],
+                   "skipped": v["skipped"]}
+               for k, v in cache.items()}
         os.makedirs(os.path.dirname(path), exist_ok=True)
         tmp = path + ".tmp"
-        with open(tmp, "wb") as f:
-            pickle.dump(cache, f, protocol=pickle.HIGHEST_PROTOCOL)
+        with open(tmp, "w") as f:
+            json.dump(raw, f)
         os.replace(tmp, path)
-    except (OSError, pickle.PicklingError) as e:
+    except (OSError, TypeError, ValueError) as e:
         logger.debug("Could not write MJ-scan cache %s: %s", path, e)
 
 
 def _read_dir_headers(subdir, bin_names):
     """Read the 128-byte header of each .bin in one hourly dir.
 
-    Returns (headers set, file_count, skipped). Isolated so both the full and
-    incremental scanners share identical per-file semantics.
+    Returns (headers set, file_count, skipped). Used by the incremental scanner
+    for the dirs it must (re)read; the full scanner has its own inline read with
+    identical per-file semantics (the parity test keeps them in lockstep).
     """
     headers = set()
     skipped = 0
@@ -410,12 +427,16 @@ def scan_mj_files(base_path, since=None, cache_file=None):
 def _scan_mj_incremental(base_path, since, cache_file):
     """MJ scan that re-reads only new/changed hourly dirs; reuses the rest.
 
-    A written HAMMA .bin file never changes, so a directory whose
-    ``(mtime, .bin-count)`` signature matches the cache has the same headers --
-    reuse them without touching the files. Only the current (being-written)
-    hour and any genuinely new dirs pay the per-file read cost. The cache lives
-    on tmpfs (no SD wear) and self-prunes (dirs not seen this run are dropped);
-    any anomaly falls back to a full re-read of that dir.
+    A directory whose ``(mtime, .bin-count)`` signature matches the cache is
+    reused without touching its files. TWO safety rules make this sound despite
+    brokkr append-writing .bin in place on 2 s-granularity vfat (so an in-place
+    completion may leave the signature unchanged):
+      1. the newest hourly dir per drive -- the one brokkr is actively
+         appending to -- is ALWAYS re-read (never cache-hit);
+      2. once an hour rolls over, brokkr writes the next hour's dir, so past
+         dirs are immutable and safe to cache.
+    The cache lives on tmpfs (no SD wear), self-prunes (dirs not seen are
+    dropped), and falls back to a full re-read on any anomaly.
     """
     t0 = time.time()
     old_cache = _load_scan_cache(cache_file)
@@ -432,6 +453,8 @@ def _scan_mj_incremental(base_path, since, cache_file):
         except OSError as e:
             logger.warning("Error scanning %s: %s, skipping", drive, e)
             continue
+        # First pass: the qualifying hourly dirs (cheap; per-dir, not per-file).
+        subdirs = []
         for name in names:
             subdir = os.path.join(drive, name)
             if name == "compressed" or not os.path.isdir(subdir):
@@ -439,6 +462,9 @@ def _scan_mj_incremental(base_path, since, cache_file):
             if since and name < since:
                 dirs_skipped += 1
                 continue
+            subdirs.append((name, subdir))
+        newest = subdirs[-1][0] if subdirs else None  # names are sorted
+        for name, subdir in subdirs:
             try:
                 bin_names = sorted(
                     e for e in os.listdir(subdir) if e.endswith(".bin"))
@@ -446,7 +472,9 @@ def _scan_mj_incremental(base_path, since, cache_file):
             except OSError:
                 continue
             cached = old_cache.get(subdir)
-            if cached is not None and cached.get("sig") == sig:
+            # Force-read the actively-written newest dir (rule 1).
+            if (name != newest and cached is not None
+                    and cached.get("sig") == sig):
                 dir_headers = cached["headers"]
                 dir_files = cached["file_count"]
                 dir_skipped = cached["skipped"]
@@ -462,6 +490,9 @@ def _scan_mj_incremental(base_path, since, cache_file):
 
     _save_scan_cache(cache_file, new_cache)
     elapsed = time.time() - t0
+    # NOTE: this differs from _scan_mj_full's per-file dup count for headers
+    # duplicated ACROSS hourly dirs; it is a log stat only, never a control input
+    # (compare_headers/identify_purgeable_files use the `headers` set alone).
     duplicate_count = max(0, file_count - skipped - len(headers))
     logger.info("MJ scan (incremental): %d unique from %d files, "
                 "%d/%d dirs cached (%.1fs)", len(headers), file_count,

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -65,6 +65,12 @@ PURGE_TIMEOUT = 30        # seconds per batched delete chunk
 # stall the safety net for an hour. 600s is ~6x the observed worst case (~99s).
 SCAN_TIMEOUT = 600        # seconds for the remote AGS strider scan
 
+# Heartbeat/status file the scrub updates as it advances, so the monitor
+# (state_monitor.check_scrub_health) can tell a working scrub from a hung one
+# (progress, not just lock age) and safely recover only genuine hangs.
+DEFAULT_STATUS_FILE = os.path.expanduser(
+    "~/brokkr/hamma/log/hamma_scrub_status.json")
+
 # Exit codes
 EXIT_OK = 0
 EXIT_MISSING = 1
@@ -178,6 +184,38 @@ def ssh_control_master(host):
         yield control_path
     finally:
         close_control_master(host, control_path)
+
+
+def write_status(path, phase, **counts):
+    """Atomically write the scrub heartbeat/status file (best-effort).
+
+    Records ``pid``, ``phase``, a wall-clock ``timestamp`` (the heartbeat), and
+    any running ``counts`` (e.g. recovered=, purged=). Written via temp-file +
+    ``os.replace`` so a reader never sees a partial file. Failures are logged at
+    debug and swallowed -- a heartbeat that can't be written must never crash
+    or block the scrub. ``path`` of None is a no-op.
+
+    Parameters
+    ----------
+    path : str or None
+        Destination status file, or None to disable.
+    phase : str
+        Current phase: 'start', 'scan', 'recover', 'purge', 'done', 'error'.
+    **counts
+        Extra fields to record (e.g. recovered, purged, missing).
+    """
+    if not path:
+        return
+    payload = {"pid": os.getpid(), "phase": phase, "timestamp": time.time()}
+    payload.update(counts)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(payload, f)
+        os.replace(tmp, path)
+    except OSError as e:
+        logger.debug("Could not write status file %s: %s", path, e)
 
 
 def extract_headers(fileobj, file_size, filename):
@@ -1220,7 +1258,7 @@ def cleanup_orphaned_temps(mj_path, max_age=ORPHAN_MAX_AGE):
 
 
 def recover_triggers(candidates, ags_host, ags_path, mj_path, dry_run=False,
-                     control_path=None):
+                     control_path=None, status_file=None):
     """Recover missing triggers from AGS to MJ DATA drives.
 
     Parameters
@@ -1247,6 +1285,11 @@ def recover_triggers(candidates, ags_host, ags_path, mj_path, dry_run=False,
     results = []
 
     for candidate in candidates:
+        # Heartbeat per trigger: recover is the long phase, so this is the
+        # granularity the monitor needs to tell "grinding" from "hung".
+        write_status(status_file, "recover", recovered=len(
+            [r for r in results if r["status"] == "recovered"]),
+            total=len(candidates))
         src_file = candidate["filename"]
         src_offset = candidate["offset"]
         trig_idx = candidate["index"]
@@ -1629,12 +1672,17 @@ def _build_parser():
         "--purge", action="store_true",
         help="After recovery, delete AGS files fully confirmed on MJ (requires --recover)",
     )
+    parser.add_argument(
+        "--status-file", default=DEFAULT_STATUS_FILE,
+        help="Heartbeat/status JSON the scrub updates as it advances "
+             "(default: %(default)s; empty string disables)",
+    )
     return parser
 
 
 def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         limit=DEFAULT_LIMIT, since=None, recover=False, dry_run=False,
-        purge=False):
+        purge=False, status_file=DEFAULT_STATUS_FILE):
     """Run the scrubber and return exit code.
 
     Parameters
@@ -1656,12 +1704,15 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         If True, show what would be recovered without transferring.
     purge : bool
         If True, delete AGS files fully confirmed on MJ after recovery.
+    status_file : str or None
+        Heartbeat/status file to update as the scrub advances (None disables).
 
     Returns
     -------
     int
         Exit code.
     """
+    write_status(status_file, "start")
     if dry_run and not recover:
         logger.warning("--dry-run has no effect without --recover")
 
@@ -1686,10 +1737,12 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
             logger.info("Filtering MJ directories to >= %s", since_cutoff)
 
     # AGS scan runs first (needed for auto-detect and comparison)
+    write_status(status_file, "scan")
     try:
         ags = scan_ags_files(ags_host, ags_path)
     except RuntimeError as e:
         logger.error("AGS scan failed: %s", e)
+        write_status(status_file, "error", error="ags scan failed")
         return EXIT_SSH_ERROR
 
     # Auto-detect: derive cutoff from the scanned AGS entries
@@ -1701,14 +1754,17 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
             logger.info(
                 "Auto-detect found no valid GPS data; scanning all MJ dirs")
 
+    write_status(status_file, "scan_mj")
     mj = scan_mj_files(mj_path, since=since_cutoff)
 
     if not ags["entries"]:
         logger.info("No AGS data found — nothing to compare")
+        write_status(status_file, "done", recovered=0, purged=0)
         return EXIT_OK
 
     if mj["file_count"] == 0 and mj["skipped"] == 0:
         logger.error("No DATA drives or .bin files found at %s", mj_path)
+        write_status(status_file, "error", error="no MJ drives/files")
         return EXIT_NO_DATA
 
     comparison = compare_headers(ags["entries"], mj["headers"])
@@ -1737,6 +1793,8 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
     with ssh_control_master(ags_host) as control_path:
         # Recovery flow
         if recover and comparison["missing_on_mj"]:
+            write_status(status_file, "recover", recovered=0,
+                         missing=len(comparison["missing_on_mj"]))
             cleanup_orphaned_temps(mj_path)
             candidates = filter_recovery_candidates(
                 comparison["missing_on_mj"], ags["entries"],
@@ -1744,7 +1802,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
             )
             recovery_results = recover_triggers(
                 candidates, ags_host, ags_path, mj_path, dry_run=dry_run,
-                control_path=control_path,
+                control_path=control_path, status_file=status_file,
             )
             recovered_count = len([r for r in recovery_results
                                    if r["status"] == "recovered"])
@@ -1772,6 +1830,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
 
         # Purge flow
         if purge:
+            write_status(status_file, "purge")
             eligibility = identify_purgeable_files(
                 ags["entries"], mj["headers"], recovery_results,
             )
@@ -1802,6 +1861,12 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                 "retained": eligibility["retained"],
                 "dry_run": dry_run,
             }
+
+    write_status(
+        status_file, "done",
+        recovered=len([r for r in (recovery_results or [])
+                       if r["status"] == "recovered"]),
+        purged=len((purge_results or {}).get("deleted", [])))
 
     if json_output:
         print(format_json_report(results, ags_host,
@@ -1847,6 +1912,7 @@ def main():
         recover=args.recover,
         dry_run=args.dry_run,
         purge=args.purge,
+        status_file=args.status_file or None,
     )
     sys.exit(rc)
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -58,10 +58,11 @@ SSH_CONNECT_TIMEOUT = 10  # seconds to establish an SSH connection (fail fast)
 CONTROL_PERSIST = 60      # seconds the shared ControlMaster lingers after last use
 PURGE_CHUNK_SIZE = 100    # AGS files deleted per batched `rm` (one SSH round-trip)
 PURGE_TIMEOUT = 30        # seconds per batched delete chunk
-# Bounds worst-case lock-hold time: an auto-scrub runs under `flock -n`, so a
-# hung scan blocks every subsequent spawn for its whole timeout. The old 3600s
-# cap let one hung scan stall the safety net for an hour; minutes is enough for
-# a legitimately large scan under load (observed worst case ~99s).
+# Bounds the SCAN phase's contribution to lock-hold time -- NOT the whole scrub:
+# recover is per-trigger (RECOVER_TIMEOUT) and purge per-chunk (PURGE_TIMEOUT),
+# so the aggregate scan+recover+purge lock-hold is NOT bounded by this alone.
+# An auto-scrub runs under `flock -n`; the old 3600s scan cap let one hung scan
+# stall the safety net for an hour. 600s is ~6x the observed worst case (~99s).
 SCAN_TIMEOUT = 600        # seconds for the remote AGS strider scan
 
 # Exit codes

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -17,6 +17,7 @@ import contextlib
 import glob
 import json
 import logging
+import pickle
 import math
 import os
 import re
@@ -72,6 +73,12 @@ SCAN_TIMEOUT = 600        # seconds for the remote AGS strider scan
 # incident (HAM-112/113), and a heartbeat that can't be written would make a
 # healthy scrub look hung. tmpfs stays writable when the SD is full.
 DEFAULT_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
+
+# Incremental-scan cache: per-hourly-dir MJ header sets keyed by a cheap
+# (mtime, .bin-count) signature, so unchanged dirs are reused instead of
+# re-reading every file's header (the ~99s-under-load MJ scan). On tmpfs so it
+# adds no SD wear; a reboot just costs one full scan.
+DEFAULT_MJ_CACHE = "/dev/shm/hamma_scrub_mj_cache.pkl"
 
 # Exit codes
 EXIT_OK = 0
@@ -339,7 +346,138 @@ def _parse_since(since_str):
     )
 
 
-def scan_mj_files(base_path, since=None):
+def _load_scan_cache(path):
+    """Load the incremental MJ-scan cache; {} on any problem (safe fallback)."""
+    try:
+        with open(path, "rb") as f:
+            data = pickle.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, EOFError, ValueError, pickle.UnpicklingError,
+            AttributeError):
+        return {}
+
+
+def _save_scan_cache(path, cache):
+    """Atomically persist the MJ-scan cache (best-effort; never raises)."""
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "wb") as f:
+            pickle.dump(cache, f, protocol=pickle.HIGHEST_PROTOCOL)
+        os.replace(tmp, path)
+    except (OSError, pickle.PicklingError) as e:
+        logger.debug("Could not write MJ-scan cache %s: %s", path, e)
+
+
+def _read_dir_headers(subdir, bin_names):
+    """Read the 128-byte header of each .bin in one hourly dir.
+
+    Returns (headers set, file_count, skipped). Isolated so both the full and
+    incremental scanners share identical per-file semantics.
+    """
+    headers = set()
+    skipped = 0
+    for name in bin_names:
+        fp = os.path.join(subdir, name)
+        try:
+            if os.path.getsize(fp) < HEADER_SIZE:
+                skipped += 1
+                continue
+            with open(fp, "rb") as f:
+                header = f.read(HEADER_SIZE)
+            if len(header) < HEADER_SIZE:
+                skipped += 1
+            else:
+                headers.add(header)
+        except OSError as e:
+            logger.warning("Error reading %s: %s", fp, e)
+            skipped += 1
+    return headers, len(bin_names), skipped
+
+
+def scan_mj_files(base_path, since=None, cache_file=None):
+    """Scan local mjolnir .bin files and collect headers.
+
+    Dispatches to the incremental scanner when ``cache_file`` is given (reuses
+    per-hourly-dir header sets whose ``(mtime, .bin-count)`` signature is
+    unchanged -- the fix for the O(all-files) MJ scan), else the full scanner.
+    """
+    if cache_file:
+        return _scan_mj_incremental(base_path, since, cache_file)
+    return _scan_mj_full(base_path, since)
+
+
+def _scan_mj_incremental(base_path, since, cache_file):
+    """MJ scan that re-reads only new/changed hourly dirs; reuses the rest.
+
+    A written HAMMA .bin file never changes, so a directory whose
+    ``(mtime, .bin-count)`` signature matches the cache has the same headers --
+    reuse them without touching the files. Only the current (being-written)
+    hour and any genuinely new dirs pay the per-file read cost. The cache lives
+    on tmpfs (no SD wear) and self-prunes (dirs not seen this run are dropped);
+    any anomaly falls back to a full re-read of that dir.
+    """
+    t0 = time.time()
+    old_cache = _load_scan_cache(cache_file)
+    new_cache = {}
+    headers = set()
+    file_count = skipped = dirs_skipped = cache_hits = 0
+
+    drives = sorted(glob.glob(os.path.join(base_path, DRIVE_PATTERN)))
+    if not drives:
+        logger.info("No DATA drives found at %s", base_path)
+    for drive in drives:
+        try:
+            names = sorted(os.listdir(drive))
+        except OSError as e:
+            logger.warning("Error scanning %s: %s, skipping", drive, e)
+            continue
+        for name in names:
+            subdir = os.path.join(drive, name)
+            if name == "compressed" or not os.path.isdir(subdir):
+                continue
+            if since and name < since:
+                dirs_skipped += 1
+                continue
+            try:
+                bin_names = sorted(
+                    e for e in os.listdir(subdir) if e.endswith(".bin"))
+                sig = (os.stat(subdir).st_mtime, len(bin_names))
+            except OSError:
+                continue
+            cached = old_cache.get(subdir)
+            if cached is not None and cached.get("sig") == sig:
+                dir_headers = cached["headers"]
+                dir_files = cached["file_count"]
+                dir_skipped = cached["skipped"]
+                cache_hits += 1
+            else:
+                dir_headers, dir_files, dir_skipped = _read_dir_headers(
+                    subdir, bin_names)
+            new_cache[subdir] = {"sig": sig, "headers": dir_headers,
+                                 "file_count": dir_files, "skipped": dir_skipped}
+            headers |= dir_headers
+            file_count += dir_files
+            skipped += dir_skipped
+
+    _save_scan_cache(cache_file, new_cache)
+    elapsed = time.time() - t0
+    duplicate_count = max(0, file_count - skipped - len(headers))
+    logger.info("MJ scan (incremental): %d unique from %d files, "
+                "%d/%d dirs cached (%.1fs)", len(headers), file_count,
+                cache_hits, len(new_cache), elapsed)
+    return {
+        "headers": headers,
+        "file_count": file_count,
+        "duplicate_count": duplicate_count,
+        "skipped": skipped,
+        "dirs_skipped": dirs_skipped,
+        "elapsed": elapsed,
+        "cache_hits": cache_hits,
+    }
+
+
+def _scan_mj_full(base_path, since=None):
     """Scan local mjolnir .bin files and collect headers.
 
     Parameters
@@ -1679,12 +1817,19 @@ def _build_parser():
         help="Heartbeat/status JSON the scrub updates as it advances "
              "(default: %(default)s; empty string disables)",
     )
+    parser.add_argument(
+        "--mj-cache", default=DEFAULT_MJ_CACHE,
+        help="Incremental MJ-scan cache file: reuse unchanged hourly dirs' "
+             "headers instead of re-reading every file (default: %(default)s; "
+             "empty string forces a full scan every run)",
+    )
     return parser
 
 
 def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         limit=DEFAULT_LIMIT, since=None, recover=False, dry_run=False,
-        purge=False, status_file=DEFAULT_STATUS_FILE):
+        purge=False, status_file=DEFAULT_STATUS_FILE,
+        mj_cache=DEFAULT_MJ_CACHE):
     """Run the scrubber and return exit code.
 
     Parameters
@@ -1708,6 +1853,8 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         If True, delete AGS files fully confirmed on MJ after recovery.
     status_file : str or None
         Heartbeat/status file to update as the scrub advances (None disables).
+    mj_cache : str or None
+        Incremental MJ-scan cache file (None forces a full scan every run).
 
     Returns
     -------
@@ -1757,7 +1904,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                 "Auto-detect found no valid GPS data; scanning all MJ dirs")
 
     write_status(status_file, "scan_mj")
-    mj = scan_mj_files(mj_path, since=since_cutoff)
+    mj = scan_mj_files(mj_path, since=since_cutoff, cache_file=mj_cache)
 
     if not ags["entries"]:
         logger.info("No AGS data found — nothing to compare")
@@ -1915,6 +2062,7 @@ def main():
         dry_run=args.dry_run,
         purge=args.purge,
         status_file=args.status_file or None,
+        mj_cache=args.mj_cache or None,
     )
     sys.exit(rc)
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -1496,6 +1496,13 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
         else:
             _record(chunk, "deleted", None)
 
+    # Final heartbeat: the per-chunk beat fires BEFORE its chunk's rm, so the
+    # last chunk's deletions aren't reflected until here. Write the completed
+    # count so the durable status is accurate before the 'done' phase.
+    write_status(status_file, "purge",
+                 purged=sum(1 for r in results if r["status"] == "deleted"),
+                 total=len(filenames))
+
     return results
 
 

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -13,6 +13,7 @@ Usage:
 
 # Standard library imports
 import argparse
+import contextlib
 import glob
 import json
 import logging
@@ -52,6 +53,12 @@ MIN_FREE_SPACE = 104857600  # 100MB minimum free space on target drive
 RECOVER_TIMEOUT = 60  # seconds per dd extraction
 ORPHAN_MAX_AGE = 3600  # seconds (1 hour) before orphaned temps are deleted
 
+# SSH / throughput constants
+SSH_CONNECT_TIMEOUT = 10  # seconds to establish an SSH connection (fail fast)
+CONTROL_PERSIST = 60      # seconds the shared ControlMaster lingers after last use
+PURGE_CHUNK_SIZE = 100    # AGS files deleted per batched `rm` (one SSH round-trip)
+PURGE_TIMEOUT = 30        # seconds per batched delete chunk
+
 # Exit codes
 EXIT_OK = 0
 EXIT_MISSING = 1
@@ -65,6 +72,106 @@ GPS_UTC_OFFSET_OFFSET = 86  # float32
 GPS_SUBSECOND_OFFSET = 94   # uint32
 GPS_ECC_OFFSET = 98         # uint32
 GPS_EPOCH = 315964800        # UTC epoch for GPS week 0
+
+
+def ssh_cmd(host, remote_command, control_path=None):
+    """Build an ssh command list for a remote command on the AGS.
+
+    Adds ``BatchMode`` (never prompt) and ``ConnectTimeout`` (fail fast on a
+    sick/unreachable AGS). When ``control_path`` is given, routes over an
+    existing ControlMaster socket so many calls reuse one connection.
+
+    Parameters
+    ----------
+    host : str
+        SSH host (e.g. ``hamma``).
+    remote_command : str
+        The command to run on the remote host.
+    control_path : str or None
+        Path to a ControlMaster socket to reuse, or None for a fresh connection.
+
+    Returns
+    -------
+    list of str
+        The argv for ``subprocess.run``/``Popen``.
+    """
+    cmd = ["ssh", "-o", "BatchMode=yes",
+           "-o", "ConnectTimeout={}".format(SSH_CONNECT_TIMEOUT)]
+    if control_path:
+        cmd += ["-o", "ControlPath={}".format(control_path)]
+    cmd += [host, remote_command]
+    return cmd
+
+
+def open_control_master(host):
+    """Start a shared SSH ControlMaster to ``host``; return its socket path.
+
+    Reusing the socket lets many ``ssh_cmd`` calls skip the per-connection
+    handshake (~16x faster per round-trip, measured). The master lingers
+    ``CONTROL_PERSIST`` seconds after the last use, so it self-closes even
+    without an explicit teardown.
+
+    Parameters
+    ----------
+    host : str
+        SSH host (e.g. ``hamma``).
+
+    Returns
+    -------
+    str or None
+        ControlMaster socket path, or None if setup failed (callers then fall
+        back to per-call connections transparently).
+    """
+    control_path = "/tmp/hamma_scrub_cm_{}.sock".format(os.getpid())
+    try:
+        result = subprocess.run(
+            ["ssh", "-o", "BatchMode=yes",
+             "-o", "ConnectTimeout={}".format(SSH_CONNECT_TIMEOUT),
+             "-o", "ControlMaster=yes",
+             "-o", "ControlPersist={}".format(CONTROL_PERSIST),
+             "-o", "ControlPath={}".format(control_path),
+             host, "true"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=SSH_CONNECT_TIMEOUT + 5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.warning("ControlMaster setup error (%s); using per-call SSH", e)
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "ControlMaster setup failed (%s); using per-call SSH",
+            result.stderr.decode('utf-8', errors='replace').strip())
+        return None
+    return control_path
+
+
+def close_control_master(host, control_path):
+    """Tear down a ControlMaster socket opened by ``open_control_master``."""
+    if not control_path:
+        return
+    try:
+        subprocess.run(
+            ["ssh", "-o", "ControlPath={}".format(control_path),
+             "-O", "exit", host],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
+@contextlib.contextmanager
+def ssh_control_master(host):
+    """Context-manager form of :func:`open_control_master` with teardown.
+
+    Yields the socket path (or None if setup failed) and always closes the
+    master on exit.
+    """
+    control_path = open_control_master(host)
+    try:
+        yield control_path
+    finally:
+        close_control_master(host, control_path)
 
 
 def extract_headers(fileobj, file_size, filename):
@@ -399,7 +506,7 @@ def decode_strider_output(data):
     return entries
 
 
-def scan_ags_files(ags_host, ags_path):
+def scan_ags_files(ags_host, ags_path, control_path=None):
     """Run remote strider on AGS sensor and collect headers.
 
     Parameters
@@ -454,9 +561,11 @@ def scan_ags_files(ags_host, ags_path):
         if local_tmp is not None and os.path.exists(local_tmp):
             os.unlink(local_tmp)
 
-    run_cmd = ["ssh", ags_host,
-               "python3 {script} {path}; rm -f {script}".format(
-                   script=remote_script, path=ags_path)]
+    run_cmd = ssh_cmd(
+        ags_host,
+        "python3 {script} {path}; rm -f {script}".format(
+            script=remote_script, path=ags_path),
+        control_path=control_path)
     logger.debug("Running: %s", " ".join(run_cmd))
 
     result = subprocess.run(
@@ -740,7 +849,8 @@ def select_target_drive(mj_path, min_free=MIN_FREE_SPACE):
     return None
 
 
-def extract_trigger(ags_host, ags_path, filename, offset, size):
+def extract_trigger(ags_host, ags_path, filename, offset, size,
+                    control_path=None):
     """Extract a single trigger from AGS via SSH dd.
 
     Parameters
@@ -755,6 +865,8 @@ def extract_trigger(ags_host, ags_path, filename, offset, size):
         Byte offset in file.
     size : int
         Total bytes to extract (header + payload + padding).
+    control_path : str or None
+        ControlMaster socket to reuse for the SSH call.
 
     Returns
     -------
@@ -766,7 +878,7 @@ def extract_trigger(ags_host, ags_path, filename, offset, size):
         "dd if={} iflag=skip_bytes,count_bytes bs=4096"
         " skip={} count={} status=none"
     ).format(filepath, offset, size)
-    cmd = ["ssh", ags_host, dd_cmd]
+    cmd = ssh_cmd(ags_host, dd_cmd, control_path=control_path)
     logger.debug("Extracting: %s", " ".join(cmd))
     try:
         result = subprocess.run(
@@ -972,8 +1084,15 @@ def identify_purgeable_files(ags_entries, mj_headers, recovery_results=None):
     return {"purgeable": purgeable, "retained": retained}
 
 
-def purge_ags_files(ags_host, ags_path, filenames, dry_run=False):
-    """Delete AGS files via SSH.
+def purge_ags_files(ags_host, ags_path, filenames, dry_run=False,
+                    control_path=None):
+    """Delete AGS files via SSH, batched over one connection.
+
+    Files are deleted in chunks of ``PURGE_CHUNK_SIZE`` — a single
+    ``rm -f f1 f2 ...`` per chunk (one SSH round-trip) rather than one SSH per
+    file. Reusing a ControlMaster socket (``control_path``) collapses the
+    per-file cost by ~16x; batching collapses the round-trip count. Chunk
+    status maps to every file in the chunk (delete succeeds/fails as a unit).
 
     Parameters
     ----------
@@ -985,6 +1104,8 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False):
         Filenames to delete.
     dry_run : bool
         If True, log what would be deleted but take no action.
+    control_path : str or None
+        ControlMaster socket to reuse for the SSH calls.
 
     Returns
     -------
@@ -993,50 +1114,45 @@ def purge_ags_files(ags_host, ags_path, filenames, dry_run=False):
         and optional error.
     """
     results = []
-    for fname in filenames:
-        remote_path = "{}/{}".format(ags_path, fname)
+
+    def _record(chunk, status, error):
+        for fname in chunk:
+            results.append({"filename": fname, "status": status, "error": error})
+
+    for start in range(0, len(filenames), PURGE_CHUNK_SIZE):
+        chunk = filenames[start:start + PURGE_CHUNK_SIZE]
 
         if dry_run:
-            logger.info("Would delete: %s:%s", ags_host, remote_path)
-            results.append({
-                "filename": fname,
-                "status": "dry_run",
-                "error": None,
-            })
+            for fname in chunk:
+                logger.info("Would delete: %s:%s/%s", ags_host, ags_path, fname)
+            _record(chunk, "dry_run", None)
             continue
 
-        cmd = ["ssh", ags_host, "rm " + shlex.quote(remote_path)]
-        logger.info("Deleting: %s:%s", ags_host, remote_path)
+        remote_paths = [
+            shlex.quote("{}/{}".format(ags_path, fname)) for fname in chunk
+        ]
+        rm_command = "rm -f " + " ".join(remote_paths)
+        cmd = ssh_cmd(ags_host, rm_command, control_path=control_path)
+        logger.info("Deleting %d AGS file(s) on %s", len(chunk), ags_host)
         try:
             result = subprocess.run(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                timeout=15,
+                timeout=PURGE_TIMEOUT,
             )
         except subprocess.TimeoutExpired:
-            logger.warning("Timeout deleting %s on %s", fname, ags_host)
-            results.append({
-                "filename": fname,
-                "status": "failed",
-                "error": "SSH timeout (15s)",
-            })
+            logger.warning("Timeout deleting %d file(s) on %s",
+                           len(chunk), ags_host)
+            _record(chunk, "failed", "SSH timeout ({}s)".format(PURGE_TIMEOUT))
             continue
 
         if result.returncode != 0:
             stderr = result.stderr.decode('utf-8', errors='replace').strip()
-            logger.warning("Failed to delete %s: %s", fname, stderr)
-            results.append({
-                "filename": fname,
-                "status": "failed",
-                "error": stderr,
-            })
+            logger.warning("Failed to delete chunk on %s: %s", ags_host, stderr)
+            _record(chunk, "failed", stderr)
         else:
-            results.append({
-                "filename": fname,
-                "status": "deleted",
-                "error": None,
-            })
+            _record(chunk, "deleted", None)
 
     return results
 
@@ -1071,7 +1187,8 @@ def cleanup_orphaned_temps(mj_path, max_age=ORPHAN_MAX_AGE):
     return count
 
 
-def recover_triggers(candidates, ags_host, ags_path, mj_path, dry_run=False):
+def recover_triggers(candidates, ags_host, ags_path, mj_path, dry_run=False,
+                     control_path=None):
     """Recover missing triggers from AGS to MJ DATA drives.
 
     Parameters
@@ -1174,7 +1291,8 @@ def recover_triggers(candidates, ags_host, ags_path, mj_path, dry_run=False):
             continue
 
         # Extract trigger via SSH dd
-        data = extract_trigger(ags_host, ags_path, src_file, src_offset, size)
+        data = extract_trigger(ags_host, ags_path, src_file, src_offset, size,
+                               control_path=control_path)
         if data is None:
             results.append({
                 "source_file": src_file,
@@ -1579,6 +1697,11 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         "warnings": [],
     }
 
+    # Recovery + purge reuse one SSH connection (per-op cost ~16x lower).
+    # It self-closes via ControlPersist; close_control_master() below is the
+    # happy-path teardown, with ControlPersist as the exception backstop.
+    control_path = open_control_master(ags_host)
+
     # Recovery flow
     recovery_results = None
     if recover and comparison["missing_on_mj"]:
@@ -1589,6 +1712,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         )
         recovery_results = recover_triggers(
             candidates, ags_host, ags_path, mj_path, dry_run=dry_run,
+            control_path=control_path,
         )
         recovered_count = len([r for r in recovery_results
                                if r["status"] == "recovered"])
@@ -1623,7 +1747,7 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         if eligibility["purgeable"]:
             purge_deletions = purge_ags_files(
                 ags_host, ags_path, eligibility["purgeable"],
-                dry_run=dry_run,
+                dry_run=dry_run, control_path=control_path,
             )
         else:
             purge_deletions = []
@@ -1647,6 +1771,8 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
             "retained": eligibility["retained"],
             "dry_run": dry_run,
         }
+
+    close_control_master(ags_host, control_path)
 
     if json_output:
         print(format_json_report(results, ags_host,

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -412,6 +412,38 @@ def _read_dir_headers(subdir, bin_names):
     return headers, len(bin_names), skipped
 
 
+def _refresh_cache_dirs(cache_file, dirs):
+    """Re-read the given hourly dirs and update their entries in the scan cache.
+
+    The incremental cache is saved *during* the MJ scan, before the recover
+    phase writes recovered .bin files. Those dirs are therefore stale in the
+    cache (old sig + missing the new headers), so the next scan would re-read
+    them. Refreshing them here -- after recovery -- lets the next scan cache-hit
+    them instead. Best-effort: a missing cache, empty ``dirs``, or an unreadable
+    dir is a silent no-op (the only cost of skipping is a re-read next run).
+    """
+    if not cache_file or not dirs:
+        return
+    cache = _load_scan_cache(cache_file)
+    if not cache:
+        return
+    updated = False
+    for subdir in dirs:
+        try:
+            bin_names = sorted(
+                e for e in os.listdir(subdir) if e.endswith(".bin"))
+            sig = (os.stat(subdir).st_mtime, len(bin_names))
+        except OSError:
+            continue
+        dir_headers, dir_files, dir_skipped = _read_dir_headers(
+            subdir, bin_names)
+        cache[subdir] = {"sig": sig, "headers": dir_headers,
+                         "file_count": dir_files, "skipped": dir_skipped}
+        updated = True
+    if updated:
+        _save_scan_cache(cache_file, cache)
+
+
 def scan_mj_files(base_path, since=None, cache_file=None):
     """Scan local mjolnir .bin files and collect headers.
 
@@ -2007,10 +2039,17 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
         # Update mj_headers and missing list with recovered triggers
         if recovery_results:
             recovered_headers = set()
+            recovered_dirs = set()
             for r in recovery_results:
                 if r["status"] == "recovered":
                     mj["headers"].add(r["header"])
                     recovered_headers.add(r["header"])
+                    if r.get("target_path"):
+                        recovered_dirs.add(os.path.dirname(r["target_path"]))
+            # Recovery wrote new .bin into these dirs AFTER the scan saved the
+            # cache (pre-recovery), leaving them stale. Refresh so the next
+            # scan cache-hits them instead of re-reading.
+            _refresh_cache_dirs(mj_cache, recovered_dirs)
             if recovered_headers:
                 comparison["missing_on_mj"] = [
                     e for e in comparison["missing_on_mj"]

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -80,10 +80,14 @@ DEFAULT_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 DEFAULT_MJ_CACHE = "/dev/shm/hamma_scrub_mj_cache.json"
 
 # Durable per-run CSV of MJ-scan cache performance (hit-rate over time). Unlike
-# the /dev/shm status/cache, this lives on disk so a cold scan (cache lost
-# between runs) leaves a reviewable trail. Rotated by the same log tooling.
+# the /dev/shm status/cache, this lives on the SD so a cold scan (cache lost
+# between runs) leaves a reviewable trail. Size-capped in-place (one .1
+# generation) rather than relying on external logrotate -- keeps it bounded on
+# the SD in line with the HAM-112/113 SD-fill stance, since nothing else rotates
+# it (the sibling scrub_log is hand-rotated by state_monitor, not this file).
 DEFAULT_METRICS_FILE = os.path.expanduser(
     "~/brokkr/hamma/log/scrub_metrics.csv")
+SCAN_METRICS_MAX_BYTES = 1_000_000  # ~20k rows; rotate to .1 past this
 
 # Exit codes
 EXIT_OK = 0
@@ -478,10 +482,17 @@ def write_scan_metrics(path, mj, recovered, purged):
         row = "{},{},{},{},{},{},{}\n".format(
             utc, hits_s, total_s, cold_s,
             round(mj.get("elapsed", 0), 1), recovered, purged)
-        new_file = not os.path.exists(path)
         parent = os.path.dirname(path)
         if parent:
             os.makedirs(parent, exist_ok=True)
+        # Bound the file: nothing external rotates it. Past the cap, move it to
+        # .1 (one generation) and start fresh -- so the SD can't fill from it.
+        try:
+            if os.path.getsize(path) >= SCAN_METRICS_MAX_BYTES:
+                os.replace(path, path + ".1")
+        except OSError:
+            pass
+        new_file = not os.path.exists(path)
         with open(path, "a") as f:
             if new_file:
                 f.write(SCAN_METRICS_HEADER + "\n")
@@ -2099,7 +2110,11 @@ def run(ags_host, ags_path, mj_path, json_output=False, output_file=None,
                     mj["headers"].add(r["header"])
                     recovered_headers.add(r["header"])
                     if r.get("target_path"):
-                        recovered_dirs.add(os.path.dirname(r["target_path"]))
+                        # target_path is RELATIVE to mj_path (recover_triggers
+                        # stores os.path.relpath); the scan cache is keyed by
+                        # ABSOLUTE dirs, so rejoin mj_path before refreshing.
+                        recovered_dirs.add(os.path.dirname(
+                            os.path.join(mj_path, r["target_path"])))
             # Recovery wrote new .bin into these dirs AFTER the scan saved the
             # cache (pre-recovery), leaving them stale. Refresh so the next
             # scan cache-hits them instead of re-reading.

--- a/scripts/hamma_scrub.py
+++ b/scripts/hamma_scrub.py
@@ -68,8 +68,10 @@ SCAN_TIMEOUT = 600        # seconds for the remote AGS strider scan
 # Heartbeat/status file the scrub updates as it advances, so the monitor
 # (state_monitor.check_scrub_health) can tell a working scrub from a hung one
 # (progress, not just lock age) and safely recover only genuine hangs.
-DEFAULT_STATUS_FILE = os.path.expanduser(
-    "~/brokkr/hamma/log/hamma_scrub_status.json")
+# On tmpfs (/dev/shm), NOT the SD root: the SD fills from logs during the exact
+# incident (HAM-112/113), and a heartbeat that can't be written would make a
+# healthy scrub look hung. tmpfs stays writable when the SD is full.
+DEFAULT_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 
 # Exit codes
 EXIT_OK = 0

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2504,3 +2504,14 @@ class TestWriteStatus:
         hamma_scrub.write_status(p, "done", purged=5)
         data = json.loads(pathlib.Path(p).read_text())
         assert data["phase"] == "done" and data["purged"] == 5
+
+    def test_writes_via_temp_then_os_replace(self, hamma_scrub, tmp_path):
+        # Atomicity MECHANISM: writes go to a temp path then os.replace onto the
+        # target (a reader never sees a torn file). A non-atomic direct write
+        # would fail this.
+        p = str(tmp_path / "status.json")
+        with patch("os.replace", wraps=os.replace) as mock_replace:
+            hamma_scrub.write_status(p, "scan", purged=0)
+        assert mock_replace.call_count == 1
+        src, dst = mock_replace.call_args[0]
+        assert src == p + ".tmp" and dst == p

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -84,6 +84,12 @@ class TestConstants:
     def test_max_datasize(self, hamma_scrub):
         assert hamma_scrub.MAX_DATASIZE == 20000000
 
+    def test_ags_nice_prefix(self, hamma_scrub):
+        """AGS-side commands are CPU-niced to 19 (the DAS writer's floor) so the
+        scrub cannot preempt the writer. No ionice: the AGS runs mq-deadline,
+        which ignores I/O priority classes."""
+        assert hamma_scrub.AGS_NICE == "nice -n 19 "
+
 
 class TestExtractHeaders:
     """Test extract_headers_from_file with synthetic data."""
@@ -422,8 +428,9 @@ class TestScanAgsFiles:
         assert run_argv[0] == "ssh"
         assert "BatchMode=yes" in run_argv
         assert run_argv[-2] == "10.10.10.1"
+        # CPU-niced to the DAS writer's floor so the scan can't preempt it.
         assert run_argv[-1] == (
-            "python3 /tmp/hamma_strider.py /ags/data; "
+            "nice -n 19 python3 /tmp/hamma_strider.py /ags/data; "
             "rm -f /tmp/hamma_strider.py")
 
         # Local temp file written and cleaned up
@@ -825,7 +832,7 @@ class TestExtractTrigger:
 
         assert data == mock_result.stdout
         cmd = mock_run.call_args[0][0]
-        assert "dd" in cmd[-1]
+        assert cmd[-1].startswith("nice -n 19 dd ")  # niced below the DAS writer
         assert "skip=1000" in cmd[-1]
         assert "count=104" in cmd[-1]
         assert "iflag=skip_bytes,count_bytes" in cmd[-1]
@@ -1493,7 +1500,7 @@ class TestPurgeAgsFiles:
         assert "hamma" in cmd
         # remote rm command is the last argv element; path is shlex-quoted
         assert "'/ags/data/ags file.bin'" in cmd[-1]
-        assert cmd[-1].startswith("rm -f ")
+        assert cmd[-1].startswith("nice -n 19 rm -f ")  # niced below the DAS writer
 
 
 class TestRecoveryReport:
@@ -2357,8 +2364,22 @@ class TestPurgeBatching:
             hamma_scrub.purge_ags_files(
                 "hamma", "/ags/data", ["a.bin", "b.bin"], dry_run=False)
         remote = mock_run.call_args[0][0][-1]
+        assert remote.startswith("nice -n 19 rm -f ")  # niced below the DAS writer
         assert "/ags/data/a.bin" in remote
         assert "/ags/data/b.bin" in remote
+
+    def test_per_file_retry_rm_is_niced(self, hamma_scrub):
+        """The per-file retry after a partial-chunk failure is niced too."""
+        batch_fail = MagicMock()
+        batch_fail.returncode = 1
+        batch_fail.stderr = b'rm: cannot remove one'
+        with patch("subprocess.run",
+                   side_effect=[batch_fail, self._ok(), self._ok()]) as mock_run:
+            hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", ["a.bin", "b.bin"], dry_run=False)
+        # calls[1] and [2] are the per-file retries
+        retry = mock_run.call_args_list[1][0][0][-1]
+        assert retry.startswith("nice -n 19 rm -f ")
 
     def test_chunk_failure_marks_all_in_chunk_failed(self, hamma_scrub):
         m = MagicMock()

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2333,8 +2333,24 @@ class TestPurgeBatching:
                 status_file="/tmp/s.json")
         purge_beats = [c for c in mock_ws.call_args_list
                        if len(c.args) >= 2 and c.args[1] == "purge"]
-        assert len(purge_beats) == 3
+        # 3 pre-chunk beats + 1 final beat (reflects the last chunk's deletions)
+        assert len(purge_beats) == 4
         assert all(c.args[0] == "/tmp/s.json" for c in purge_beats)
+
+    def test_final_heartbeat_reflects_last_chunk(self, hamma_scrub):
+        """A final heartbeat after the loop must report the FULL deleted count.
+        The per-chunk beat fires BEFORE its chunk's rm, so without a trailing
+        write the last chunk's deletions never reach the heartbeat before the
+        'done' phase. Jeff review #2."""
+        files = ["ags{:03d}.bin".format(i) for i in range(250)]  # 3 chunks
+        with patch.object(hamma_scrub, "write_status") as mock_ws, \
+             patch("subprocess.run", return_value=self._ok()):
+            hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", files, dry_run=False,
+                status_file="/tmp/s.json")
+        purge_beats = [c for c in mock_ws.call_args_list
+                       if len(c.args) >= 2 and c.args[1] == "purge"]
+        assert purge_beats[-1].kwargs.get("purged") == 250  # all, not 200
 
     def test_chunk_command_deletes_multiple_files(self, hamma_scrub):
         with patch("subprocess.run", return_value=self._ok()) as mock_run:

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -1854,10 +1854,12 @@ class TestMain:
 
     @pytest.fixture(autouse=True)
     def _stub_control_master(self, hamma_scrub):
-        """run() opens a real SSH ControlMaster; stub it out in unit tests."""
+        """run() opens a real SSH ControlMaster + writes a status file to the
+        real home; stub both out in unit tests."""
         with patch.object(hamma_scrub, "open_control_master",
                           return_value=None), \
-             patch.object(hamma_scrub, "close_control_master"):
+             patch.object(hamma_scrub, "close_control_master"), \
+             patch.object(hamma_scrub, "write_status"):
             yield
 
     def test_exit_code_0_all_match(self, hamma_scrub):
@@ -2190,10 +2192,12 @@ class TestRunSinceAuto:
 
     @pytest.fixture(autouse=True)
     def _stub_control_master(self, hamma_scrub):
-        """run() opens a real SSH ControlMaster; stub it out in unit tests."""
+        """run() opens a real SSH ControlMaster + writes a status file to the
+        real home; stub both out in unit tests."""
         with patch.object(hamma_scrub, "open_control_master",
                           return_value=None), \
-             patch.object(hamma_scrub, "close_control_master"):
+             patch.object(hamma_scrub, "close_control_master"), \
+             patch.object(hamma_scrub, "write_status"):
             yield
 
     def test_since_auto_derives_cutoff_from_ags(self, hamma_scrub):
@@ -2452,6 +2456,7 @@ class TestRunControlMasterWiring:
         sentinel = "/tmp/sentinel_cm.sock"
         with patch.object(hamma_scrub, "scan_ags_files", return_value=ags), \
              patch.object(hamma_scrub, "scan_mj_files", return_value=mj), \
+             patch.object(hamma_scrub, "write_status"), \
              patch.object(hamma_scrub, "open_control_master",
                           return_value=sentinel) as mock_open, \
              patch.object(hamma_scrub, "close_control_master") as mock_close, \
@@ -2469,3 +2474,33 @@ class TestRunControlMasterWiring:
         assert mock_recover.call_args.kwargs.get("control_path") == sentinel
         assert mock_purge.call_args.kwargs.get("control_path") == sentinel
         mock_close.assert_called_once_with("hamma", sentinel)
+
+
+class TestWriteStatus:
+    """Scrub writes an atomic heartbeat/status file for the monitor to read."""
+
+    def test_writes_json_with_timestamp_phase_pid_counts(self, hamma_scrub,
+                                                         tmp_path):
+        p = str(tmp_path / "sub" / "status.json")  # dir does not exist yet
+        hamma_scrub.write_status(p, "purge", recovered=2, purged=10)
+        data = json.loads(pathlib.Path(p).read_text())
+        assert data["phase"] == "purge"
+        assert data["recovered"] == 2 and data["purged"] == 10
+        assert data["pid"] == os.getpid()
+        assert isinstance(data["timestamp"], (int, float))
+
+    def test_none_path_is_noop(self, hamma_scrub):
+        hamma_scrub.write_status(None, "scan")  # must not raise
+
+    def test_write_failure_is_swallowed(self, hamma_scrub):
+        # Unwritable location -> logged at debug, never raised (status is
+        # best-effort; a failed heartbeat must not crash the scrub).
+        hamma_scrub.write_status("/proc/cannot/write/status.json", "scan")
+
+    def test_atomic_replace_used(self, hamma_scrub, tmp_path):
+        # Overwriting an existing status file must not leave a partial file.
+        p = str(tmp_path / "status.json")
+        hamma_scrub.write_status(p, "scan", purged=0)
+        hamma_scrub.write_status(p, "done", purged=5)
+        data = json.loads(pathlib.Path(p).read_text())
+        assert data["phase"] == "done" and data["purged"] == 5

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2320,6 +2320,20 @@ class TestPurgeBatching:
         assert len(results) == 250
         assert all(r["status"] == "deleted" for r in results)
 
+    def test_writes_per_chunk_heartbeat(self, hamma_scrub):
+        """A long purge advances the heartbeat per chunk so the monitor can't
+        mistake a working purge for a hung one (GAP: purge was heartbeat-blind)."""
+        files = ["ags{:03d}.bin".format(i) for i in range(250)]  # 3 chunks
+        with patch.object(hamma_scrub, "write_status") as mock_ws, \
+             patch("subprocess.run", return_value=self._ok()):
+            hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", files, dry_run=False,
+                status_file="/tmp/s.json")
+        purge_beats = [c for c in mock_ws.call_args_list
+                       if len(c.args) >= 2 and c.args[1] == "purge"]
+        assert len(purge_beats) == 3
+        assert all(c.args[0] == "/tmp/s.json" for c in purge_beats)
+
     def test_chunk_command_deletes_multiple_files(self, hamma_scrub):
         with patch("subprocess.run", return_value=self._ok()) as mock_run:
             hamma_scrub.purge_ags_files(

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -397,12 +397,16 @@ class TestScanAgsFiles:
             "10.10.10.1:/tmp/hamma_strider.py",
         ]
 
-        # SSH runs the deployed script (no stdin piping)
-        assert run_call[0][0] == [
-            "ssh", "10.10.10.1",
+        # SSH runs the deployed script (no stdin piping). Command is built via
+        # ssh_cmd(), so it carries BatchMode/ConnectTimeout opts; host and the
+        # remote command are the last two argv elements.
+        run_argv = run_call[0][0]
+        assert run_argv[0] == "ssh"
+        assert "BatchMode=yes" in run_argv
+        assert run_argv[-2] == "10.10.10.1"
+        assert run_argv[-1] == (
             "python3 /tmp/hamma_strider.py /ags/data; "
-            "rm -f /tmp/hamma_strider.py",
-        ]
+            "rm -f /tmp/hamma_strider.py")
 
         # Local temp file written and cleaned up
         mock_write.assert_called_once_with(
@@ -1468,9 +1472,10 @@ class TestPurgeAgsFiles:
 
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "ssh"
-        assert cmd[1] == "hamma"
-        # shlex.quote wraps paths with spaces in single quotes
-        assert "'/ags/data/ags file.bin'" in cmd[2]
+        assert "hamma" in cmd
+        # remote rm command is the last argv element; path is shlex-quoted
+        assert "'/ags/data/ags file.bin'" in cmd[-1]
+        assert cmd[-1].startswith("rm -f ")
 
 
 class TestRecoveryReport:
@@ -1829,6 +1834,14 @@ class TestCLI:
 class TestMain:
     """Test main() integration."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_control_master(self, hamma_scrub):
+        """run() opens a real SSH ControlMaster; stub it out in unit tests."""
+        with patch.object(hamma_scrub, "open_control_master",
+                          return_value=None), \
+             patch.object(hamma_scrub, "close_control_master"):
+            yield
+
     def test_exit_code_0_all_match(self, hamma_scrub):
         """All matched -> exit code 0."""
         hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
@@ -2157,6 +2170,14 @@ class TestMain:
 class TestRunSinceAuto:
     """Test --since auto integration in run()."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_control_master(self, hamma_scrub):
+        """run() opens a real SSH ControlMaster; stub it out in unit tests."""
+        with patch.object(hamma_scrub, "open_control_master",
+                          return_value=None), \
+             patch.object(hamma_scrub, "close_control_master"):
+            yield
+
     def test_since_auto_derives_cutoff_from_ags(self, hamma_scrub):
         """run() with since='auto' derives cutoff from AGS entries."""
         hdr = _make_gps_header()
@@ -2229,3 +2250,127 @@ class TestRunSinceAuto:
                 mj_path="/media/pi", since="auto",
             )
             assert rc == hamma_scrub.EXIT_SSH_ERROR
+
+
+class TestSshCmd:
+    """Test the ssh command builder (BatchMode/ConnectTimeout + optional ControlMaster)."""
+
+    def test_basic_command_has_host_and_remote(self, hamma_scrub):
+        cmd = hamma_scrub.ssh_cmd("hamma", "rm -f /x")
+        assert cmd[0] == "ssh"
+        assert "hamma" in cmd
+        assert cmd[-1] == "rm -f /x"
+
+    def test_includes_batchmode_and_connecttimeout(self, hamma_scrub):
+        joined = " ".join(hamma_scrub.ssh_cmd("hamma", "true"))
+        assert "BatchMode=yes" in joined
+        assert "ConnectTimeout=" in joined
+
+    def test_no_control_path_by_default(self, hamma_scrub):
+        joined = " ".join(hamma_scrub.ssh_cmd("hamma", "true"))
+        assert "ControlPath" not in joined
+
+    def test_control_path_added_when_given(self, hamma_scrub):
+        joined = " ".join(
+            hamma_scrub.ssh_cmd("hamma", "true", control_path="/tmp/cm.sock"))
+        assert "ControlPath=/tmp/cm.sock" in joined
+
+
+class TestPurgeBatching:
+    """Purge deletes in chunks over one connection, not one SSH per file."""
+
+    def _ok(self):
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = b''
+        return m
+
+    def test_one_ssh_call_per_chunk_not_per_file(self, hamma_scrub):
+        files = ["ags{:03d}.bin".format(i) for i in range(250)]
+        with patch("subprocess.run", return_value=self._ok()) as mock_run:
+            results = hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", files, dry_run=False)
+        # 250 files, chunk size 100 -> 3 calls, not 250
+        assert mock_run.call_count == 3
+        assert len(results) == 250
+        assert all(r["status"] == "deleted" for r in results)
+
+    def test_chunk_command_deletes_multiple_files(self, hamma_scrub):
+        with patch("subprocess.run", return_value=self._ok()) as mock_run:
+            hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", ["a.bin", "b.bin"], dry_run=False)
+        remote = mock_run.call_args[0][0][-1]
+        assert "/ags/data/a.bin" in remote
+        assert "/ags/data/b.bin" in remote
+
+    def test_chunk_failure_marks_all_in_chunk_failed(self, hamma_scrub):
+        m = MagicMock()
+        m.returncode = 255
+        m.stderr = b'Connection closed by remote host'
+        with patch("subprocess.run", return_value=m):
+            results = hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", ["a.bin", "b.bin"], dry_run=False)
+        assert all(r["status"] == "failed" for r in results)
+        assert "Connection closed" in results[0]["error"]
+
+    def test_passes_control_path_through(self, hamma_scrub):
+        with patch("subprocess.run", return_value=self._ok()) as mock_run:
+            hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", ["a.bin"], dry_run=False,
+                control_path="/tmp/cm.sock")
+        joined = " ".join(mock_run.call_args[0][0])
+        assert "ControlPath=/tmp/cm.sock" in joined
+
+
+class TestSshControlMaster:
+    """Test the shared-connection context manager."""
+
+    def _ok(self):
+        m = MagicMock()
+        m.returncode = 0
+        m.stderr = b''
+        return m
+
+    def test_yields_socket_path_on_success(self, hamma_scrub):
+        with patch("subprocess.run", return_value=self._ok()):
+            with hamma_scrub.ssh_control_master("hamma") as cp:
+                assert cp is not None
+                assert isinstance(cp, str)
+
+    def test_yields_none_when_master_fails(self, hamma_scrub):
+        bad = MagicMock()
+        bad.returncode = 255
+        bad.stderr = b'connect failed'
+        with patch("subprocess.run", return_value=bad):
+            with hamma_scrub.ssh_control_master("hamma") as cp:
+                assert cp is None
+
+    def test_yields_none_on_setup_timeout(self, hamma_scrub):
+        with patch("subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(cmd="ssh", timeout=15)):
+            with hamma_scrub.ssh_control_master("hamma") as cp:
+                assert cp is None
+
+    def test_tears_down_master_on_exit(self, hamma_scrub):
+        with patch("subprocess.run", return_value=self._ok()) as mock_run:
+            with hamma_scrub.ssh_control_master("hamma"):
+                pass
+        last_cmd = mock_run.call_args_list[-1][0][0]
+        assert "-O" in last_cmd
+        assert "exit" in last_cmd
+
+
+class TestExtractTriggerControlPath:
+    """extract_trigger routes through ssh_cmd and honors control_path."""
+
+    def test_control_path_in_ssh_command(self, hamma_scrub):
+        header, body = _make_trigger()
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = header + body
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            hamma_scrub.extract_trigger(
+                "hamma", "/ags/data", "ags001.bin", 1000, len(header + body),
+                control_path="/tmp/cm.sock")
+        joined = " ".join(mock_run.call_args[0][0])
+        assert "ControlPath=/tmp/cm.sock" in joined

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2229,7 +2229,9 @@ class TestRunSinceAuto:
                 mj_path="/media/pi", since="auto",
             )
             # scan_mj_files called with cutoff derived from AGS data
-            mock_mj.assert_called_once_with("/media/pi", since=expected_cutoff)
+            mock_mj.assert_called_once()
+            assert mock_mj.call_args.args[0] == "/media/pi"
+            assert mock_mj.call_args.kwargs["since"] == expected_cutoff
             assert rc == 0
 
     def test_since_auto_no_valid_gps_scans_all(self, hamma_scrub):
@@ -2261,7 +2263,8 @@ class TestRunSinceAuto:
                 mj_path="/media/pi", since="auto",
             )
             # scan_mj_files called without since filter
-            mock_mj.assert_called_once_with("/media/pi", since=None)
+            mock_mj.assert_called_once()
+            assert mock_mj.call_args.kwargs["since"] is None
 
     def test_since_auto_ags_scan_fails(self, hamma_scrub):
         """If AGS scan fails, return EXIT_SSH_ERROR."""
@@ -2515,3 +2518,110 @@ class TestWriteStatus:
         assert mock_replace.call_count == 1
         src, dst = mock_replace.call_args[0]
         assert src == p + ".tmp" and dst == p
+
+
+class TestIncrementalScan:
+    """§3.5: scan_mj_files(cache_file=...) reuses unchanged hourly dirs."""
+
+    def _dir(self, tmp_path, drive="DATA37", hour="2026-04-10T14"):
+        d = tmp_path / drive / hour
+        d.mkdir(parents=True)
+        return d
+
+    def test_second_run_hits_cache_without_rereading(self, hamma_scrub,
+                                                     tmp_path):
+        d = self._dir(tmp_path)
+        hdr, rest = _make_trigger()
+        (d / "a.bin").write_bytes(hdr + rest)
+        cache = str(tmp_path / "cache.pkl")
+        r1 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert r1["cache_hits"] == 0 and hdr in r1["headers"]
+        # Unchanged dir on the 2nd run -> cache hit, files NOT re-read.
+        with patch.object(hamma_scrub, "_read_dir_headers") as mock_read:
+            r2 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        mock_read.assert_not_called()
+        assert r2["cache_hits"] == 1
+        assert r2["headers"] == r1["headers"]
+
+    def test_new_file_invalidates_dir_cache(self, hamma_scrub, tmp_path):
+        d = self._dir(tmp_path)
+        h1, rest = _make_trigger()
+        (d / "a.bin").write_bytes(h1 + rest)
+        cache = str(tmp_path / "c.pkl")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)  # build
+        h2 = bytearray(h1)
+        h2[50] = 9
+        h2 = bytes(h2)
+        (d / "b.bin").write_bytes(h2 + rest)  # count 1->2 => sig changes
+        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert h1 in res["headers"] and h2 in res["headers"]
+        assert res["cache_hits"] == 0  # re-read
+
+    def test_corrupt_cache_falls_back(self, hamma_scrub, tmp_path):
+        d = self._dir(tmp_path)
+        hdr, rest = _make_trigger()
+        (d / "a.bin").write_bytes(hdr + rest)
+        cache = tmp_path / "c.pkl"
+        cache.write_bytes(b"not a pickle")
+        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=str(cache))
+        assert hdr in res["headers"] and res["cache_hits"] == 0
+
+    def test_incremental_matches_full_scan(self, hamma_scrub, tmp_path):
+        for i, hour in enumerate(["2026-04-10T14", "2026-04-10T15"]):
+            d = tmp_path / "DATA37" / hour
+            d.mkdir(parents=True)
+            hdr, rest = _make_trigger()
+            hdr = bytearray(hdr)
+            hdr[50] = i
+            (d / "a.bin").write_bytes(bytes(hdr) + rest)
+        (tmp_path / "DATA37" / "2026-04-10T16").mkdir(parents=True)
+        (tmp_path / "DATA37" / "2026-04-10T16" / "trunc.bin").write_bytes(
+            b"\x00" * 8)  # truncated -> skipped in both
+        full = hamma_scrub.scan_mj_files(str(tmp_path))
+        incr = hamma_scrub.scan_mj_files(
+            str(tmp_path), cache_file=str(tmp_path / "c.pkl"))
+        assert incr["headers"] == full["headers"]
+        assert incr["file_count"] == full["file_count"]
+        assert incr["skipped"] == full["skipped"]
+
+    def test_cache_self_prunes_removed_dir(self, hamma_scrub, tmp_path):
+        import pickle
+        da = tmp_path / "DATA37" / "2026-04-10T14"
+        da.mkdir(parents=True)
+        hdr, rest = _make_trigger()
+        (da / "a.bin").write_bytes(hdr + rest)
+        cache = str(tmp_path / "c.pkl")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        import shutil as _sh
+        _sh.rmtree(str(tmp_path / "DATA37" / "2026-04-10T14"))
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        with open(cache, "rb") as f:
+            saved = pickle.load(f)
+        assert all("2026-04-10T14" not in k for k in saved)  # pruned
+
+    def test_compressed_dir_skipped(self, hamma_scrub, tmp_path):
+        comp = tmp_path / "DATA37" / "compressed"
+        comp.mkdir(parents=True)
+        (comp / "x.bin").write_bytes(b"\x00" * 200)  # must be ignored
+        res = hamma_scrub.scan_mj_files(
+            str(tmp_path), cache_file=str(tmp_path / "c.pkl"))
+        assert res["file_count"] == 0
+
+    def test_since_filters_dirs(self, hamma_scrub, tmp_path):
+        for hour in ["2026-04-10T14", "2026-04-11T09"]:
+            d = tmp_path / "DATA37" / hour
+            d.mkdir(parents=True)
+            hdr, rest = _make_trigger()
+            hdr = bytearray(hdr)
+            hdr[50] = ord(hour[9])
+            (d / "a.bin").write_bytes(bytes(hdr) + rest)
+        res = hamma_scrub.scan_mj_files(
+            str(tmp_path), since="2026-04-11", cache_file=str(tmp_path / "c.pkl"))
+        assert res["file_count"] == 1 and res["dirs_skipped"] == 1
+
+    def test_empty_cache_file_uses_full_scanner(self, hamma_scrub, tmp_path):
+        d = self._dir(tmp_path)
+        hdr, rest = _make_trigger()
+        (d / "a.bin").write_bytes(hdr + rest)
+        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file="")
+        assert "cache_hits" not in res  # dispatched to the full scanner

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -370,6 +370,24 @@ class TestStriderProtocol:
 class TestScanAgsFiles:
     """Test SSH-based AGS scanning."""
 
+    def test_scan_uses_bounded_timeout(self, hamma_scrub):
+        """AGS scan timeout is bounded to minutes (SCAN_TIMEOUT), not the old
+        3600s cap: a hung scan holds the scrub lock for its whole timeout, so
+        an hour-long cap lets one hung scan stall the safety net for an hour."""
+        assert hamma_scrub.SCAN_TIMEOUT <= 900
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = b''
+        mock_result.stderr = b''
+        with patch("subprocess.run", return_value=mock_result) as mock_run, \
+             patch("tempfile.mkstemp",
+                   return_value=(99, "/tmp/local_strider.py")), \
+             patch("os.write"), patch("os.close"), \
+             patch("os.path.exists", return_value=True), patch("os.unlink"):
+            hamma_scrub.scan_ags_files("10.10.10.1", "/ags/data")
+        run_call = mock_run.call_args_list[1]
+        assert run_call.kwargs["timeout"] == hamma_scrub.SCAN_TIMEOUT
+
     def test_deploys_strider_via_scp_then_runs(self, hamma_scrub):
         """scan_ags_files deploys strider via SCP, then runs via SSH."""
         mock_result = MagicMock()

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -374,7 +374,7 @@ class TestScanAgsFiles:
         """AGS scan timeout is bounded to minutes (SCAN_TIMEOUT), not the old
         3600s cap: a hung scan holds the scrub lock for its whole timeout, so
         an hour-long cap lets one hung scan stall the safety net for an hour."""
-        assert hamma_scrub.SCAN_TIMEOUT <= 900
+        assert hamma_scrub.SCAN_TIMEOUT == 600
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_result.stdout = b''

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2691,3 +2691,32 @@ class TestIncrementalScan:
         (d / "a.bin").write_bytes(hdr + rest)
         res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file="")
         assert "cache_hits" not in res  # dispatched to the full scanner
+
+    def test_refresh_cache_dirs_lets_next_scan_hit_recovered_dir(
+            self, hamma_scrub, tmp_path):
+        """The cache is saved DURING the scan, before recovery writes new .bin
+        files. Refreshing a recovered dir's cache entry lets the NEXT scan
+        cache-hit it (with the new header) instead of re-reading it stale."""
+        older, newer, ho, hn, rest = self._two_dirs(tmp_path)
+        cache = str(tmp_path / "c.json")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)  # older cached
+        # simulate recovery writing a recovered trigger into the OLDER dir
+        h2, _ = self._hdr(9)
+        (older / "r_recovered.bin").write_bytes(h2 + rest)
+        hamma_scrub._refresh_cache_dirs(cache, [str(older)])
+        # next scan: older is a cache HIT (refreshed sig matches); only newest re-read
+        with patch.object(hamma_scrub, "_read_dir_headers",
+                          return_value=(set(), 0, 0)) as mock_read:
+            r = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert r["cache_hits"] == 1
+        assert mock_read.call_count == 1
+        assert mock_read.call_args[0][0].endswith("2026-04-10T15")  # newest only
+        assert h2 in r["headers"]  # refresh captured the recovered header
+
+    def test_refresh_cache_dirs_is_safe_noop(self, hamma_scrub, tmp_path):
+        """No cache file, empty dir list, or a missing dir must never raise."""
+        missing = str(tmp_path / "nope.json")
+        hamma_scrub._refresh_cache_dirs(missing, [str(tmp_path / "gone")])
+        assert not os.path.exists(missing)          # nothing created from nothing
+        hamma_scrub._refresh_cache_dirs(None, [str(tmp_path)])   # None cache
+        hamma_scrub._refresh_cache_dirs(str(tmp_path / "c.json"), [])  # no dirs

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2528,41 +2528,90 @@ class TestIncrementalScan:
         d.mkdir(parents=True)
         return d
 
-    def test_second_run_hits_cache_without_rereading(self, hamma_scrub,
-                                                     tmp_path):
+    def _hdr(self, byte50):
+        hdr, rest = _make_trigger()
+        hdr = bytearray(hdr)
+        hdr[50] = byte50
+        return bytes(hdr), rest
+
+    def _two_dirs(self, tmp_path):
+        """Older + newest hourly dir, each with one .bin. Returns (older,newer)."""
+        older = tmp_path / "DATA37" / "2026-04-10T14"
+        newer = tmp_path / "DATA37" / "2026-04-10T15"  # newest -> force-rescanned
+        older.mkdir(parents=True)
+        newer.mkdir(parents=True)
+        ho, rest = self._hdr(1)
+        hn, _ = self._hdr(2)
+        (older / "a.bin").write_bytes(ho + rest)
+        (newer / "a.bin").write_bytes(hn + rest)
+        return older, newer, ho, hn, rest
+
+    def test_unchanged_older_dir_is_cache_hit_newest_rescanned(
+            self, hamma_scrub, tmp_path):
+        older, newer, ho, hn, rest = self._two_dirs(tmp_path)
+        cache = str(tmp_path / "c.json")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)  # build
+        with patch.object(hamma_scrub, "_read_dir_headers",
+                          return_value=(set(), 0, 0)) as mock_read:
+            r2 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert r2["cache_hits"] == 1                    # older reused
+        assert mock_read.call_count == 1                # only the newest re-read
+        assert mock_read.call_args[0][0].endswith("2026-04-10T15")
+
+    def test_older_dir_mtime_change_invalidates(self, hamma_scrub, tmp_path):
+        """In-place content rewrite (same count) with a bumped dir mtime must
+        invalidate -- catches an mtime-blind signature."""
+        older, newer, ho, hn, rest = self._two_dirs(tmp_path)
+        cache = str(tmp_path / "c.json")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        h2, _ = self._hdr(7)
+        (older / "a.bin").write_bytes(h2 + rest)         # same count, new content
+        os.utime(str(older), (9e9, 9e9))                 # bump older's mtime
+        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert h2 in res["headers"] and ho not in res["headers"]
+
+    def test_older_dir_count_change_invalidates(self, hamma_scrub, tmp_path):
+        """A new file (count change) invalidates even with mtime pinned --
+        catches a count-blind signature."""
+        older, newer, ho, hn, rest = self._two_dirs(tmp_path)
+        cache = str(tmp_path / "c.json")
+        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        st = os.stat(str(older))
+        h2, _ = self._hdr(8)
+        (older / "b.bin").write_bytes(h2 + rest)         # count 1 -> 2
+        os.utime(str(older), (st.st_atime, st.st_mtime))  # pin mtime
+        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert h2 in res["headers"]
+
+    def test_newest_dir_inplace_growth_reread(self, hamma_scrub, tmp_path):
+        """A .bin completing IN PLACE (brokkr append-write) in the newest dir --
+        same count, maybe same 2s-vfat mtime -- is still caught, because the
+        newest dir is always re-read."""
+        d = self._dir(tmp_path)  # single dir == newest
+        (d / "a.bin").write_bytes(b"\x00" * 8)  # truncated -> skipped
+        cache = str(tmp_path / "c.json")
+        r1 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert len(r1["headers"]) == 0 and r1["skipped"] == 1
+        hdr, rest = _make_trigger()
+        (d / "a.bin").write_bytes(hdr + rest)   # completes in place, count == 1
+        r2 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
+        assert hdr in r2["headers"]
+
+    def test_save_failure_does_not_raise(self, hamma_scrub, tmp_path):
+        """An unwritable cache location degrades to a full scan, never crashes."""
         d = self._dir(tmp_path)
         hdr, rest = _make_trigger()
         (d / "a.bin").write_bytes(hdr + rest)
-        cache = str(tmp_path / "cache.pkl")
-        r1 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
-        assert r1["cache_hits"] == 0 and hdr in r1["headers"]
-        # Unchanged dir on the 2nd run -> cache hit, files NOT re-read.
-        with patch.object(hamma_scrub, "_read_dir_headers") as mock_read:
-            r2 = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
-        mock_read.assert_not_called()
-        assert r2["cache_hits"] == 1
-        assert r2["headers"] == r1["headers"]
-
-    def test_new_file_invalidates_dir_cache(self, hamma_scrub, tmp_path):
-        d = self._dir(tmp_path)
-        h1, rest = _make_trigger()
-        (d / "a.bin").write_bytes(h1 + rest)
-        cache = str(tmp_path / "c.pkl")
-        hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)  # build
-        h2 = bytearray(h1)
-        h2[50] = 9
-        h2 = bytes(h2)
-        (d / "b.bin").write_bytes(h2 + rest)  # count 1->2 => sig changes
-        res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
-        assert h1 in res["headers"] and h2 in res["headers"]
-        assert res["cache_hits"] == 0  # re-read
+        res = hamma_scrub.scan_mj_files(
+            str(tmp_path), cache_file="/proc/nonexistent/cache.json")
+        assert hdr in res["headers"]
 
     def test_corrupt_cache_falls_back(self, hamma_scrub, tmp_path):
         d = self._dir(tmp_path)
         hdr, rest = _make_trigger()
         (d / "a.bin").write_bytes(hdr + rest)
-        cache = tmp_path / "c.pkl"
-        cache.write_bytes(b"not a pickle")
+        cache = tmp_path / "c.json"
+        cache.write_bytes(b"not valid json {{{")
         res = hamma_scrub.scan_mj_files(str(tmp_path), cache_file=str(cache))
         assert hdr in res["headers"] and res["cache_hits"] == 0
 
@@ -2570,33 +2619,36 @@ class TestIncrementalScan:
         for i, hour in enumerate(["2026-04-10T14", "2026-04-10T15"]):
             d = tmp_path / "DATA37" / hour
             d.mkdir(parents=True)
-            hdr, rest = _make_trigger()
-            hdr = bytearray(hdr)
-            hdr[50] = i
-            (d / "a.bin").write_bytes(bytes(hdr) + rest)
+            hdr, rest = self._hdr(i)
+            (d / "a.bin").write_bytes(hdr + rest)
         (tmp_path / "DATA37" / "2026-04-10T16").mkdir(parents=True)
         (tmp_path / "DATA37" / "2026-04-10T16" / "trunc.bin").write_bytes(
             b"\x00" * 8)  # truncated -> skipped in both
         full = hamma_scrub.scan_mj_files(str(tmp_path))
         incr = hamma_scrub.scan_mj_files(
-            str(tmp_path), cache_file=str(tmp_path / "c.pkl"))
+            str(tmp_path), cache_file=str(tmp_path / "c.json"))
         assert incr["headers"] == full["headers"]
         assert incr["file_count"] == full["file_count"]
         assert incr["skipped"] == full["skipped"]
+        # No cross-dir duplicate headers here, so the counts agree (they can
+        # legitimately diverge for cross-dir dups -- a log stat, never a control).
+        assert incr["duplicate_count"] == full["duplicate_count"]
 
     def test_cache_self_prunes_removed_dir(self, hamma_scrub, tmp_path):
-        import pickle
         da = tmp_path / "DATA37" / "2026-04-10T14"
         da.mkdir(parents=True)
+        db = tmp_path / "DATA37" / "2026-04-10T15"  # keep a 2nd dir present
+        db.mkdir(parents=True)
         hdr, rest = _make_trigger()
         (da / "a.bin").write_bytes(hdr + rest)
-        cache = str(tmp_path / "c.pkl")
+        (db / "b.bin").write_bytes(hdr + rest)
+        cache = str(tmp_path / "c.json")
         hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
         import shutil as _sh
-        _sh.rmtree(str(tmp_path / "DATA37" / "2026-04-10T14"))
+        _sh.rmtree(str(da))
         hamma_scrub.scan_mj_files(str(tmp_path), cache_file=cache)
-        with open(cache, "rb") as f:
-            saved = pickle.load(f)
+        with open(cache) as f:
+            saved = json.load(f)
         assert all("2026-04-10T14" not in k for k in saved)  # pruned
 
     def test_compressed_dir_skipped(self, hamma_scrub, tmp_path):
@@ -2604,7 +2656,7 @@ class TestIncrementalScan:
         comp.mkdir(parents=True)
         (comp / "x.bin").write_bytes(b"\x00" * 200)  # must be ignored
         res = hamma_scrub.scan_mj_files(
-            str(tmp_path), cache_file=str(tmp_path / "c.pkl"))
+            str(tmp_path), cache_file=str(tmp_path / "c.json"))
         assert res["file_count"] == 0
 
     def test_since_filters_dirs(self, hamma_scrub, tmp_path):
@@ -2616,7 +2668,7 @@ class TestIncrementalScan:
             hdr[50] = ord(hour[9])
             (d / "a.bin").write_bytes(bytes(hdr) + rest)
         res = hamma_scrub.scan_mj_files(
-            str(tmp_path), since="2026-04-11", cache_file=str(tmp_path / "c.pkl"))
+            str(tmp_path), since="2026-04-11", cache_file=str(tmp_path / "c.json"))
         assert res["file_count"] == 1 and res["dirs_skipped"] == 1
 
     def test_empty_cache_file_uses_full_scanner(self, hamma_scrub, tmp_path):

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -1854,12 +1854,13 @@ class TestMain:
 
     @pytest.fixture(autouse=True)
     def _stub_control_master(self, hamma_scrub):
-        """run() opens a real SSH ControlMaster + writes a status file to the
-        real home; stub both out in unit tests."""
+        """run() opens a real SSH ControlMaster + writes a status/metrics file
+        to the real home; stub them out in unit tests."""
         with patch.object(hamma_scrub, "open_control_master",
                           return_value=None), \
              patch.object(hamma_scrub, "close_control_master"), \
-             patch.object(hamma_scrub, "write_status"):
+             patch.object(hamma_scrub, "write_status"), \
+             patch.object(hamma_scrub, "write_scan_metrics"):
             yield
 
     def test_exit_code_0_all_match(self, hamma_scrub):
@@ -2192,12 +2193,13 @@ class TestRunSinceAuto:
 
     @pytest.fixture(autouse=True)
     def _stub_control_master(self, hamma_scrub):
-        """run() opens a real SSH ControlMaster + writes a status file to the
-        real home; stub both out in unit tests."""
+        """run() opens a real SSH ControlMaster + writes a status/metrics file
+        to the real home; stub them out in unit tests."""
         with patch.object(hamma_scrub, "open_control_master",
                           return_value=None), \
              patch.object(hamma_scrub, "close_control_master"), \
-             patch.object(hamma_scrub, "write_status"):
+             patch.object(hamma_scrub, "write_status"), \
+             patch.object(hamma_scrub, "write_scan_metrics"):
             yield
 
     def test_since_auto_derives_cutoff_from_ags(self, hamma_scrub):
@@ -2474,6 +2476,7 @@ class TestRunControlMasterWiring:
         with patch.object(hamma_scrub, "scan_ags_files", return_value=ags), \
              patch.object(hamma_scrub, "scan_mj_files", return_value=mj), \
              patch.object(hamma_scrub, "write_status"), \
+             patch.object(hamma_scrub, "write_scan_metrics"), \
              patch.object(hamma_scrub, "open_control_master",
                           return_value=sentinel) as mock_open, \
              patch.object(hamma_scrub, "close_control_master") as mock_close, \
@@ -2720,3 +2723,43 @@ class TestIncrementalScan:
         assert not os.path.exists(missing)          # nothing created from nothing
         hamma_scrub._refresh_cache_dirs(None, [str(tmp_path)])   # None cache
         hamma_scrub._refresh_cache_dirs(str(tmp_path / "c.json"), [])  # no dirs
+
+
+class TestScanMetrics:
+    """A durable per-run CSV of MJ-scan cache performance (hit-rate over time)."""
+
+    HEADER = "utc,dirs_cached,dirs_total,cold,scan_seconds,recovered,purged"
+
+    def test_writes_header_then_row(self, hamma_scrub, tmp_path):
+        path = str(tmp_path / "m.csv")
+        mj = {"cache_hits": 1191, "dirs_total": 1193, "elapsed": 9.14}
+        hamma_scrub.write_scan_metrics(path, mj, recovered=4, purged=78)
+        lines = open(path).read().splitlines()
+        assert lines[0] == self.HEADER
+        # utc is field 0; the rest are the recorded values (warm scan -> cold=0)
+        assert lines[1].split(",")[1:] == ["1191", "1193", "0", "9.1", "4", "78"]
+
+    def test_appends_without_duplicating_header_and_flags_cold(
+            self, hamma_scrub, tmp_path):
+        path = str(tmp_path / "m.csv")
+        cold = {"cache_hits": 0, "dirs_total": 1193, "elapsed": 500.0}
+        hamma_scrub.write_scan_metrics(path, cold, recovered=0, purged=0)
+        hamma_scrub.write_scan_metrics(path, cold, recovered=0, purged=0)
+        lines = open(path).read().splitlines()
+        assert lines.count(self.HEADER) == 1        # header written once
+        assert len(lines) == 3                       # header + 2 rows
+        assert lines[1].split(",")[3] == "1"         # 0/1193 -> cold flagged
+
+    def test_full_scanner_has_blank_cache_fields(self, hamma_scrub, tmp_path):
+        """When the cache is disabled (full scanner), there are no cache stats;
+        the row records blanks rather than a bogus cold flag."""
+        path = str(tmp_path / "m.csv")
+        hamma_scrub.write_scan_metrics(
+            path, {"elapsed": 3.0}, recovered=1, purged=2)
+        row = open(path).read().splitlines()[1].split(",")
+        assert row[1] == "" and row[2] == "" and row[3] == ""   # no cache stats
+
+    def test_none_path_is_noop(self, hamma_scrub, tmp_path):
+        hamma_scrub.write_scan_metrics(
+            None, {"cache_hits": 1, "dirs_total": 1, "elapsed": 1.0}, 0, 0)
+        assert not (tmp_path / "m.csv").exists()

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2495,6 +2495,61 @@ class TestRunControlMasterWiring:
         assert mock_purge.call_args.kwargs.get("control_path") == sentinel
         mock_close.assert_called_once_with("hamma", sentinel)
 
+    def test_refreshes_recovered_dirs_with_ABSOLUTE_paths(self, hamma_scrub):
+        """recover_triggers records target_path RELATIVE to mj_path, but the scan
+        cache is keyed by ABSOLUTE dirs. run() must convert before refreshing, or
+        the refresh silently no-ops (relative dir != cache key)."""
+        hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+        ags = {"entries": [{"header": hdr, "filename": "f.bin",
+                            "offset": 0, "index": 0}],
+               "headers": {hdr}, "duplicate_count": 0, "elapsed": 1.0}
+        mj = {"headers": set(), "file_count": 5, "duplicate_count": 0,
+              "skipped": 0, "elapsed": 1.0, "cache_hits": 0, "dirs_total": 5}
+        # target_path exactly as recover_triggers emits it: relpath to mj_path
+        rec = [{"status": "recovered", "header": hdr,
+                "target_path": "DATA01/2026-07-14T12/mj05_x_recovered.bin",
+                "source_file": "f.bin", "source_offset": 0}]
+        captured = {}
+        with patch.object(hamma_scrub, "scan_ags_files", return_value=ags), \
+             patch.object(hamma_scrub, "scan_mj_files", return_value=mj), \
+             patch.object(hamma_scrub, "write_status"), \
+             patch.object(hamma_scrub, "write_scan_metrics"), \
+             patch.object(hamma_scrub, "open_control_master", return_value=None), \
+             patch.object(hamma_scrub, "close_control_master"), \
+             patch.object(hamma_scrub, "recover_triggers", return_value=rec), \
+             patch.object(hamma_scrub, "identify_purgeable_files",
+                          return_value={"purgeable": [], "retained": []}), \
+             patch.object(hamma_scrub, "purge_ags_files", return_value=[]), \
+             patch.object(hamma_scrub, "_refresh_cache_dirs",
+                          side_effect=lambda cf, d: captured.setdefault(
+                              "dirs", sorted(d))):
+            hamma_scrub.run("hamma", "/ags/data", "/media/pi",
+                            recover=True, mj_cache="/tmp/c.json",
+                            metrics_file=None)
+        assert captured["dirs"] == ["/media/pi/DATA01/2026-07-14T12"]
+
+    def test_run_calls_write_scan_metrics_at_completion(self, hamma_scrub):
+        """The metrics call must be wired into run() -- guards against the call
+        site being deleted (the run-test fixtures otherwise mock it silently)."""
+        hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+        ags = {"entries": [{"header": hdr, "filename": "f.bin",
+                            "offset": 0, "index": 0}],
+               "headers": {hdr}, "duplicate_count": 0, "elapsed": 1.0}
+        mj = {"headers": {hdr}, "file_count": 5, "duplicate_count": 0,
+              "skipped": 0, "elapsed": 2.5, "cache_hits": 4, "dirs_total": 5}
+        with patch.object(hamma_scrub, "scan_ags_files", return_value=ags), \
+             patch.object(hamma_scrub, "scan_mj_files", return_value=mj), \
+             patch.object(hamma_scrub, "write_status"), \
+             patch.object(hamma_scrub, "open_control_master", return_value=None), \
+             patch.object(hamma_scrub, "close_control_master"), \
+             patch.object(hamma_scrub, "write_scan_metrics") as mock_metrics:
+            hamma_scrub.run("hamma", "/ags/data", "/media/pi",
+                            metrics_file="/tmp/m.csv")
+        mock_metrics.assert_called_once()
+        args = mock_metrics.call_args.args
+        assert args[0] == "/tmp/m.csv" and args[1] is mj   # (path, mj, ...)
+        assert args[2] == 0 and args[3] == 0               # recovered, purged
+
 
 class TestWriteStatus:
     """Scrub writes an atomic heartbeat/status file for the monitor to read."""
@@ -2763,3 +2818,16 @@ class TestScanMetrics:
         hamma_scrub.write_scan_metrics(
             None, {"cache_hits": 1, "dirs_total": 1, "elapsed": 1.0}, 0, 0)
         assert not (tmp_path / "m.csv").exists()
+
+    def test_size_capped_rotation_bounds_the_file(
+            self, hamma_scrub, tmp_path, monkeypatch):
+        """Nothing external rotates this file; past the cap it must roll to .1
+        and restart so the SD can't fill (HAM-112/113 stance)."""
+        path = str(tmp_path / "m.csv")
+        monkeypatch.setattr(hamma_scrub, "SCAN_METRICS_MAX_BYTES", 200)
+        mj = {"cache_hits": 1, "dirs_total": 2, "elapsed": 1.0}
+        for _ in range(30):
+            hamma_scrub.write_scan_metrics(path, mj, 0, 0)
+        assert os.path.exists(path + ".1")               # old generation kept
+        assert os.path.getsize(path) < 400               # live file bounded
+        assert open(path).read().splitlines()[0] == self.HEADER  # header restored

--- a/tests/python/test_hamma_scrub.py
+++ b/tests/python/test_hamma_scrub.py
@@ -2313,6 +2313,47 @@ class TestPurgeBatching:
         assert all(r["status"] == "failed" for r in results)
         assert "Connection closed" in results[0]["error"]
 
+    def test_partial_chunk_failure_attributes_per_file(self, hamma_scrub):
+        """A batched delete that returns non-zero retries per-file, so files
+        that WERE deleted are not mis-reported as failed. `rm -f a b c` can
+        delete a and c while erroring on b yet exit non-zero -- the report
+        must not claim all three failed (it would lie during a disk-fill)."""
+        calls = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            calls["n"] += 1
+            remote = cmd[-1]
+            m = MagicMock()
+            if calls["n"] == 1:
+                # the batched `rm -f a b c` -- one file errored -> non-zero
+                m.returncode = 1
+                m.stderr = b"rm: /ags/data/b.bin: Permission denied"
+            else:
+                # per-file retries: only b.bin fails
+                fails = "b.bin" in remote
+                m.returncode = 1 if fails else 0
+                m.stderr = b"rm: Permission denied" if fails else b""
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            results = hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", ["a.bin", "b.bin", "c.bin"],
+                dry_run=False)
+        by = {r["filename"]: r["status"] for r in results}
+        assert by == {"a.bin": "deleted", "b.bin": "failed", "c.bin": "deleted"}
+
+    @pytest.mark.parametrize("nfiles,expected_calls", [
+        (0, 0), (1, 1), (99, 1), (100, 1), (101, 2), (200, 2), (250, 3)])
+    def test_chunk_boundaries(self, hamma_scrub, nfiles, expected_calls):
+        """Exact-multiple boundaries: no spurious empty trailing chunk."""
+        files = ["f{}.bin".format(i) for i in range(nfiles)]
+        with patch("subprocess.run", return_value=self._ok()) as mock_run:
+            results = hamma_scrub.purge_ags_files(
+                "hamma", "/ags/data", files, dry_run=False)
+        assert mock_run.call_count == expected_calls
+        assert len(results) == nfiles
+        assert all(r["status"] == "deleted" for r in results)
+
     def test_passes_control_path_through(self, hamma_scrub):
         with patch("subprocess.run", return_value=self._ok()) as mock_run:
             hamma_scrub.purge_ags_files(
@@ -2374,3 +2415,39 @@ class TestExtractTriggerControlPath:
                 control_path="/tmp/cm.sock")
         joined = " ".join(mock_run.call_args[0][0])
         assert "ControlPath=/tmp/cm.sock" in joined
+
+
+class TestRunControlMasterWiring:
+    """run() must open ONE ControlMaster, thread its socket to BOTH recover
+    and purge, and close it. This is the integration seam the leaf tests miss;
+    without it, dropping control_path (or the open/close) passes silently.
+    Deliberately NO autouse control-master stub here."""
+
+    def test_control_path_threaded_to_recover_and_purge_and_closed(
+            self, hamma_scrub):
+        hdr = b'\xf5\xff\x50\x5d' + b'\x01' + b'\x00' * 123
+        ags = {"entries": [{"header": hdr, "filename": "f.bin",
+                            "offset": 0, "index": 0}],
+               "headers": {hdr}, "duplicate_count": 0, "elapsed": 1.0}
+        mj = {"headers": set(), "file_count": 5, "duplicate_count": 0,
+              "skipped": 0, "elapsed": 1.0}
+        sentinel = "/tmp/sentinel_cm.sock"
+        with patch.object(hamma_scrub, "scan_ags_files", return_value=ags), \
+             patch.object(hamma_scrub, "scan_mj_files", return_value=mj), \
+             patch.object(hamma_scrub, "open_control_master",
+                          return_value=sentinel) as mock_open, \
+             patch.object(hamma_scrub, "close_control_master") as mock_close, \
+             patch.object(hamma_scrub, "recover_triggers",
+                          return_value=[]) as mock_recover, \
+             patch.object(hamma_scrub, "identify_purgeable_files",
+                          return_value={"purgeable": ["f.bin"],
+                                        "retained": []}), \
+             patch.object(hamma_scrub, "purge_ags_files",
+                          return_value=[]) as mock_purge:
+            hamma_scrub.run("hamma", "/ags/data", "/media/pi",
+                            recover=True, purge=True)
+
+        mock_open.assert_called_once_with("hamma")
+        assert mock_recover.call_args.kwargs.get("control_path") == sentinel
+        assert mock_purge.call_args.kwargs.get("control_path") == sentinel
+        mock_close.assert_called_once_with("hamma", sentinel)

--- a/tests/python/test_scrub_timer.py
+++ b/tests/python/test_scrub_timer.py
@@ -1,0 +1,80 @@
+"""Validate the periodic-scrub systemd artifacts (§3.3) and their consistency
+with state_monitor's lock file and config/main.toml's scrub_command.
+
+These are static/structural checks -- the units aren't run here, but drift
+between the timer's command and what state_monitor spawns (different lock,
+different args) would silently break the shared-lock / shared-heartbeat model,
+so we pin those invariants.
+"""
+import re
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent.parent
+FILES = REPO / "files"
+
+
+def _read(name):
+    return (FILES / name).read_text()
+
+
+class TestScrubWrapper:
+    def test_bash_syntax_valid(self):
+        rc = subprocess.run(
+            ["bash", "-n", str(FILES / "hamma-scrub.sh")]).returncode
+        assert rc == 0
+
+    def test_uses_nonblocking_flock_on_shared_lock(self):
+        s = _read("hamma-scrub.sh")
+        assert "flock -n" in s               # non-blocking: skip, don't queue
+        assert "/tmp/hamma_scrub.lock" in s  # the shared lock
+
+    def test_runs_scrub_with_recover_purge_since_auto(self):
+        s = _read("hamma-scrub.sh")
+        assert "hamma_scrub.py" in s
+        for flag in ("--recover", "--purge", "--since auto"):
+            assert flag in s
+
+
+class TestServiceUnit:
+    def test_oneshot_as_pi_running_the_wrapper(self):
+        s = _read("hamma-scrub.service")
+        assert "Type=oneshot" in s
+        assert "User=pi" in s
+        assert "ExecStart=/usr/local/bin/hamma-scrub.sh" in s
+
+    def test_ordered_after_brokkr(self):
+        assert "After=brokkr-hamma-default.service" in _read("hamma-scrub.service")
+
+
+class TestTimerUnit:
+    def test_periodic_and_installed_to_timers_target(self):
+        s = _read("hamma-scrub.timer")
+        assert "OnUnitActiveSec=" in s
+        assert "WantedBy=timers.target" in s
+
+
+class TestConsistencyWithMonitorAndConfig:
+    def test_lock_matches_state_monitor(self):
+        sm = (REPO / "plugins" / "state_monitor.py").read_text()
+        m = re.search(r'SCRUB_LOCK_FILE\s*=\s*"([^"]+)"', sm)
+        assert m, "SCRUB_LOCK_FILE not found in state_monitor.py"
+        assert m.group(1) in _read("hamma-scrub.sh")
+
+    def test_scrub_args_match_main_toml(self):
+        toml = (REPO / "config" / "main.toml").read_text()
+        m = re.search(r'scrub_command\s*=\s*"([^"]+)"', toml)
+        assert m, "scrub_command not found in main.toml"
+        wrapper = _read("hamma-scrub.sh")
+        for token in ("hamma_scrub.py", "--recover", "--purge", "--since auto"):
+            assert token in m.group(1), "main.toml scrub_command missing " + token
+            assert token in wrapper, "wrapper missing " + token
+
+
+class TestInstallWiring:
+    def test_brokkr_install_copies_and_enables_timer(self):
+        s = (REPO / "unified_install" / "lib" / "brokkr.sh").read_text()
+        for f in ("hamma-scrub.sh", "hamma-scrub.service", "hamma-scrub.timer"):
+            assert f in s, "brokkr.sh does not install " + f
+        assert re.search(r"enable\b.*hamma-scrub\.timer", s), \
+            "brokkr.sh does not enable the timer"

--- a/tests/python/test_scrub_timer.py
+++ b/tests/python/test_scrub_timer.py
@@ -43,8 +43,22 @@ class TestServiceUnit:
         assert "User=pi" in s
         assert "ExecStart=/usr/local/bin/hamma-scrub.sh" in s
 
-    def test_ordered_after_brokkr(self):
-        assert "After=brokkr-hamma-default.service" in _read("hamma-scrub.service")
+    def test_ordered_after_brokkr_but_does_not_want_it(self):
+        s = _read("hamma-scrub.service")
+        assert "After=brokkr-hamma-default.service" in s
+        # Wants= would resurrect a deliberately-stopped brokkr every 15 min.
+        assert "Wants=brokkr" not in s
+
+    def test_start_limiting_disabled(self):
+        # §3.2's periodic SIGKILLs must not be able to trip systemd's start
+        # limit and silently disable the timer backstop.
+        assert "StartLimitIntervalSec=0" in _read("hamma-scrub.service")
+
+    def test_no_misleading_io_priority_knob(self):
+        # ionice on the mj-pi governs nothing on the AGS Pi (separate host, SSH)
+        # and mq-deadline ignores it anyway -- don't imply a mitigation that
+        # does nothing.
+        assert "IOSchedulingClass" not in _read("hamma-scrub.service")
 
 
 class TestTimerUnit:

--- a/tests/python/test_state_monitor.py
+++ b/tests/python/test_state_monitor.py
@@ -105,7 +105,9 @@ def _make_monitor(**overrides):
         method="gchat",
         channel="status",
         key_file="/dev/null",
-        low_space=100,
+        purge_space=200,
+        alert_space=75,
+        scrub_cooldown_s=1800,
         power_delim=15,
         enable_drive_checks=True,
     )
@@ -114,58 +116,78 @@ def _make_monitor(**overrides):
     return monitor
 
 
-class TestCheckSensorDriveBoundary:
-    """check_sensor_drive must fire when pre lands exactly on low_space.
-
-    Real-world miss (mj07, 2026-05-28 15:25:03 UTC):
-    bytes_remaining went from 100.0 -> 99.96 GB. Strict `>` against
-    low_space=100 missed the edge. After that, bytes_remaining only
-    decreased, so no future edge could ever fire.
+class TestTwoThresholdDrain:
+    """check_sensor_drive is LEVEL-triggered across two thresholds (§3.4):
+    drain while free < purge_space; alert (once) when free < alert_space
+    despite the draining. The old edge trigger fired once at the crossing and
+    never retried -- the mj05 failure mode this replaces.
     """
 
-    def test_pre_exactly_at_threshold_fires(self):
-        """pre = low_space exactly; now below -> fires."""
-        m = _make_monitor(low_space=100)
-        m._previous_data = {"bytes_remaining": _dv(100.0)}
-        with patch.object(m, "_spawn_scrub") as spawn:
-            msg = m.check_sensor_drive({"bytes_remaining": _dv(99.96)})
-        spawn.assert_called_once()
-        assert msg is not None
-        assert "99.9" in msg or "100.0" in msg or "99.96" in msg
+    def _prev(self, m, v=250.0):
+        m._previous_data = {"bytes_remaining": _dv(v)}
 
-    def test_pre_above_now_below_fires(self):
-        """Standard down-cross: pre clearly above, now clearly below -> fires."""
-        m = _make_monitor(low_space=100)
-        m._previous_data = {"bytes_remaining": _dv(150.0)}
+    def test_above_purge_threshold_no_spawn_no_alert(self):
+        m = _make_monitor()
+        self._prev(m)
         with patch.object(m, "_spawn_scrub") as spawn:
-            msg = m.check_sensor_drive({"bytes_remaining": _dv(80.0)})
-        spawn.assert_called_once()
-        assert msg is not None
-
-    def test_both_below_threshold_no_fire(self):
-        """No edge if already below: pre=50, now=45 -> no fire."""
-        m = _make_monitor(low_space=100)
-        m._previous_data = {"bytes_remaining": _dv(50.0)}
-        with patch.object(m, "_spawn_scrub") as spawn:
-            msg = m.check_sensor_drive({"bytes_remaining": _dv(45.0)})
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(220.0)})
         spawn.assert_not_called()
         assert msg is None
 
-    def test_both_above_threshold_no_fire(self):
-        """No edge if still above: pre=200, now=150 -> no fire."""
-        m = _make_monitor(low_space=100)
-        m._previous_data = {"bytes_remaining": _dv(200.0)}
+    def test_below_purge_above_alert_drains_no_alert(self):
+        """150 GB: below purge(200) but above alert(75) -> drain, no alert."""
+        m = _make_monitor()
+        self._prev(m)
         with patch.object(m, "_spawn_scrub") as spawn:
             msg = m.check_sensor_drive({"bytes_remaining": _dv(150.0)})
-        spawn.assert_not_called()
-        assert msg is None
+        spawn.assert_called_once()   # level-triggered drain
+        assert msg is None           # no alert in the purge band
 
-    def test_now_exactly_at_threshold_no_fire(self):
-        """now exactly on threshold is NOT below; spec is strict `now <`."""
-        m = _make_monitor(low_space=100)
-        m._previous_data = {"bytes_remaining": _dv(150.0)}
+    def test_below_alert_drains_and_alerts_once(self):
+        m = _make_monitor()
+        self._prev(m)
         with patch.object(m, "_spawn_scrub") as spawn:
-            msg = m.check_sensor_drive({"bytes_remaining": _dv(100.0)})
+            msg1 = m.check_sensor_drive({"bytes_remaining": _dv(50.0)})
+            msg2 = m.check_sensor_drive({"bytes_remaining": _dv(45.0)})
+        assert msg1 is not None and "50.0" in msg1
+        assert msg2 is None          # one-shot alert
+        spawn.assert_called_once()   # cooldown holds the 2nd spawn
+
+    def test_level_trigger_fires_even_when_already_below(self):
+        """Unlike the old edge trigger: pre already below purge still drains."""
+        m = _make_monitor()
+        self._prev(m, v=150.0)       # previous ALSO below purge
+        with patch.object(m, "_spawn_scrub") as spawn:
+            m.check_sensor_drive({"bytes_remaining": _dv(140.0)})
+        spawn.assert_called_once()
+
+    def test_cooldown_gates_repeat_spawns(self):
+        m = _make_monitor(scrub_cooldown_s=1800)
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub") as spawn:
+            m.check_sensor_drive({"bytes_remaining": _dv(150.0)})  # spawns
+            m.check_sensor_drive({"bytes_remaining": _dv(148.0)})  # within cooldown
+        spawn.assert_called_once()
+        # After the cooldown elapses, a fresh spawn is allowed.
+        m._last_scrub_spawn = None
+        with patch.object(m, "_spawn_scrub") as spawn2:
+            m.check_sensor_drive({"bytes_remaining": _dv(146.0)})
+        spawn2.assert_called_once()
+
+    def test_alert_rearms_after_recovery_above_purge(self):
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub"):
+            assert m.check_sensor_drive({"bytes_remaining": _dv(50.0)}) is not None
+            # recover above purge -> re-arm
+            assert m.check_sensor_drive({"bytes_remaining": _dv(210.0)}) is None
+            assert m.check_sensor_drive({"bytes_remaining": _dv(50.0)}) is not None
+
+    def test_na_reading_no_spawn_no_alert(self):
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv("NA")})
         spawn.assert_not_called()
         assert msg is None
 

--- a/tests/python/test_state_monitor.py
+++ b/tests/python/test_state_monitor.py
@@ -107,7 +107,7 @@ def _make_monitor(**overrides):
         key_file="/dev/null",
         purge_space=200,
         alert_space=75,
-        scrub_cooldown_s=1800,
+        scrub_cooldown_s=300,
         power_delim=15,
         enable_drive_checks=True,
     )
@@ -190,6 +190,59 @@ class TestTwoThresholdDrain:
             msg = m.check_sensor_drive({"bytes_remaining": _dv("NA")})
         spawn.assert_not_called()
         assert msg is None
+
+    def test_at_purge_threshold_is_healthy(self):
+        """free == purge_space (200) is healthy: no spawn, no alert."""
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(200.0)})
+        spawn.assert_not_called()
+        assert msg is None
+
+    def test_at_alert_threshold_drains_no_alert(self):
+        """free == alert_space (75) is in the drain band: spawn, no alert."""
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub") as spawn:
+            msg = m.check_sensor_drive({"bytes_remaining": _dv(75.0)})
+        spawn.assert_called_once()
+        assert msg is None
+
+    def test_alert_rearms_in_drain_band(self):
+        """Re-arm on recovery into the drain band, not only full recovery --
+        an oscillation below alert_space pages each time (hysteresis)."""
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub"):
+            assert m.check_sensor_drive({"bytes_remaining": _dv(50.0)}) is not None
+            # recover into [alert_space, purge_space) -> re-arm
+            assert m.check_sensor_drive({"bytes_remaining": _dv(150.0)}) is None
+            assert m.check_sensor_drive({"bytes_remaining": _dv(50.0)}) is not None
+
+    def test_noop_spawn_does_not_consume_cooldown(self):
+        """A no-op spawn (lock held -> _spawn_scrub returns False) must NOT arm
+        the cooldown, so the next cycle re-attempts (M3)."""
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub", return_value=False) as spawn:
+            m.check_sensor_drive({"bytes_remaining": _dv(150.0)})
+            m.check_sensor_drive({"bytes_remaining": _dv(148.0)})
+        assert spawn.call_count == 2
+        assert m._last_scrub_spawn is None
+
+    def test_successful_spawn_arms_cooldown(self):
+        m = _make_monitor()
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub", return_value=True) as spawn:
+            m.check_sensor_drive({"bytes_remaining": _dv(150.0)})
+            m.check_sensor_drive({"bytes_remaining": _dv(148.0)})  # gated
+        spawn.assert_called_once()
+
+    def test_misconfig_alert_ge_purge_warns(self):
+        m = _make_monitor(purge_space=75, alert_space=200)
+        assert any("alert_space" in str(c) for c in
+                   m.logger.warning.call_args_list)
 
 
 class TestCheckPowerBoundary:

--- a/tests/python/test_state_monitor.py
+++ b/tests/python/test_state_monitor.py
@@ -244,6 +244,34 @@ class TestTwoThresholdDrain:
         assert any("alert_space" in str(c) for c in
                    m.logger.warning.call_args_list)
 
+    def test_accepts_and_ignores_legacy_low_space(self):
+        """A stale per-unit `low_space` override must NOT crash construction
+        (brokkr's Executable has no **kwargs) -- accept + warn + ignore."""
+        m = _make_monitor(low_space=10)  # must not raise
+        assert not hasattr(m, "low_space")
+        assert any("low_space" in str(c) for c in
+                   m.logger.warning.call_args_list)
+
+    def test_scrub_auto_recover_defaults_off(self):
+        """The SIGKILL self-heal ships OFF (bench-validation gate)."""
+        m = _make_monitor()  # no explicit scrub_auto_recover
+        assert m.scrub_auto_recover is False
+
+    def test_hs_staleness_alerts_when_ags_dark(self):
+        """Persistent NA bytes_remaining (AGS dark) -> alert once, reset on
+        a numeric reading -- so a fill isn't missed silently."""
+        m = _make_monitor(hs_stale_cycles=3)
+        self._prev(m)
+        with patch.object(m, "_spawn_scrub"):
+            assert m.check_sensor_drive({"bytes_remaining": _dv("NA")}) is None
+            assert m.check_sensor_drive({"bytes_remaining": _dv("NA")}) is None
+            msg = m.check_sensor_drive({"bytes_remaining": _dv("NA")})   # 3rd
+            assert msg is not None and "NA" in msg
+            assert m.check_sensor_drive({"bytes_remaining": _dv("NA")}) is None  # one-shot
+            # numeric reading clears the watchdog and re-arms it
+            assert m.check_sensor_drive({"bytes_remaining": _dv(220.0)}) is None
+            assert m._hs_stale_count == 0 and m._hs_stale_alerted is False
+
 
 class TestCheckPowerBoundary:
     """check_power must fire when prior power lands exactly on power_delim."""

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -84,6 +84,8 @@ def make_monitor(scrub_command="", low_space=100, space_previous=150,
     mon.scrub_auto_recover = scrub_auto_recover
     mon.scrub_log = scrub_log
     mon._scrub_first_held = None
+    mon._scrub_last_progress = None
+    mon._scrub_progress_token = None
     mon._stuck_scrub_alerted = False
     return mon
 
@@ -229,74 +231,125 @@ class TestScrubLockHonesty:
 
 
 class TestCheckScrubHealth:
-    """Progress-gated hung-scrub detection: a scrub is hung only if the lock is
-    held AND its heartbeat is stale -- so a long legit recovery (fresh
-    heartbeat) is NOT flagged. On a genuine hang, recover (kill) + alert once."""
+    """Hung-scrub detection is gated on heartbeat *advancement* measured in the
+    monitor's own monotonic clock -- immune to sensor clock skew and to a stale
+    heartbeat from a previous run; a long legit recovery (advancing heartbeat)
+    is never flagged. On a genuine hang: kill + re-spawn + alert once."""
 
     def _mon(self, **kw):
         kw.setdefault("scrub_command", "python3 scrub.py")
         kw.setdefault("scrub_hang_timeout_s", 900)
         return make_monitor(**kw)
 
-    def test_no_alert_when_heartbeat_fresh(self):
-        """Lock held but scrub is progressing (recent heartbeat) -> no alert."""
-        mon = self._mon()
-        fresh = {"pid": 111, "timestamp": time.time()}  # just now
-        with patch.object(StateMonitor, "_scrub_lock_state",
-                          return_value="held"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=fresh):
-            assert mon.check_scrub_health(make_input_data(50)) is None
-        assert mon._stuck_scrub_alerted is False
+    def _idle_streak(self, mon, token, idle_s=1000):
+        """Put mon into an established held-streak idle for idle_s seconds."""
+        mon._scrub_first_held = time.monotonic() - idle_s - 1
+        mon._scrub_last_progress = time.monotonic() - idle_s
+        mon._scrub_progress_token = token
 
-    def test_alerts_and_recovers_when_heartbeat_stale(self):
-        """Lock held + heartbeat stale beyond timeout -> hung: kill + alert."""
-        mon = self._mon(scrub_hang_timeout_s=900, scrub_auto_recover=True)
-        stale = {"pid": 222, "timestamp": time.time() - 1000}  # 1000s ago
+    def test_fresh_streak_gives_grace_ignoring_stale_file(self):
+        """First cycle the lock is seen held -> grace, even if a stale status
+        file from a PREVIOUS run is present (guards the stale-file false-kill)."""
+        mon = self._mon()
+        old = {"pid": 999, "timestamp": time.time() - 99999}  # ancient prev run
         with patch.object(StateMonitor, "_scrub_lock_state",
                           return_value="held"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=stale), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=old), \
+             patch.object(StateMonitor, "_recover_stuck_scrub") as mock_recover:
+            assert mon.check_scrub_health(make_input_data(50)) is None
+        mock_recover.assert_not_called()
+        assert mon._scrub_first_held is not None
+
+    def test_advancing_heartbeat_never_hangs(self):
+        """Idle-looking streak, but the heartbeat token ADVANCES -> progress."""
+        mon = self._mon()
+        s1 = {"pid": 5, "timestamp": 1, "phase": "recover", "recovered": 2}
+        self._idle_streak(mon, StateMonitor._progress_token(s1))
+        s2 = dict(s1, recovered=3)  # advanced (more recovered) -> new token
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s2), \
+             patch.object(StateMonitor, "_recover_stuck_scrub") as mock_recover:
+            assert mon.check_scrub_health(make_input_data(50)) is None
+        mock_recover.assert_not_called()
+
+    def test_stale_heartbeat_hangs_recovers_and_respawns(self):
+        """Idle streak with NO token advance -> hung: kill + re-spawn + alert."""
+        mon = self._mon(scrub_auto_recover=True)
+        s = {"pid": 22, "timestamp": 1, "phase": "recover", "recovered": 2}
+        self._idle_streak(mon, StateMonitor._progress_token(s))
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s), \
              patch.object(StateMonitor, "_recover_stuck_scrub",
-                          return_value=True) as mock_recover:
+                          return_value=True) as mock_recover, \
+             patch.object(StateMonitor, "_spawn_scrub") as mock_spawn:
             msg = mon.check_scrub_health(make_input_data(50))
-        mock_recover.assert_called_once_with(stale)
+        mock_recover.assert_called_once()
+        mock_spawn.assert_called_once()          # freed lock is re-used
         assert msg is not None and "hung" in msg.lower()
+
+    def test_clock_skew_immune_future_timestamp_still_hangs(self):
+        """A heartbeat timestamp in the FUTURE (NTP skew) must not disable
+        detection: detection is by token-change, not absolute time."""
+        mon = self._mon(scrub_auto_recover=False)
+        s = {"pid": 7, "timestamp": time.time() + 999999}  # far future
+        self._idle_streak(mon, StateMonitor._progress_token(s))
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s):
+            assert mon.check_scrub_health(make_input_data(50)) is not None
 
     def test_no_kill_when_auto_recover_disabled(self):
         mon = self._mon(scrub_auto_recover=False)
-        stale = {"pid": 3, "timestamp": time.time() - 1000}
+        s = {"pid": 3, "timestamp": 1}
+        self._idle_streak(mon, StateMonitor._progress_token(s))
         with patch.object(StateMonitor, "_scrub_lock_state",
                           return_value="held"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=stale), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s), \
              patch.object(StateMonitor, "_recover_stuck_scrub") as mock_recover:
             msg = mon.check_scrub_health(make_input_data(50))
         mock_recover.assert_not_called()
         assert msg is not None and "manual" in msg.lower()
 
     def test_no_heartbeat_uses_held_duration_fallback(self):
-        """No status file: not hung until the lock has been held > timeout."""
-        mon = self._mon(scrub_hang_timeout_s=900)
+        """No status file at all: not hung until the lock has been held (in the
+        monitor's monotonic clock) longer than the timeout."""
+        mon = self._mon()
+        self._idle_streak(mon, None)
         with patch.object(StateMonitor, "_scrub_lock_state",
                           return_value="held"), \
              patch.object(StateMonitor, "_read_scrub_status",
                           return_value=None), \
              patch.object(StateMonitor, "_recover_stuck_scrub",
                           return_value=False):
-            # First sighting: held-duration ~0 -> not hung yet
+            assert mon.check_scrub_health(make_input_data(50)) is not None
+
+    def test_boundary_not_hung_at_exact_timeout(self):
+        """idle == timeout is NOT hung (<= is grace); just over IS. Pin
+        monotonic so the boundary is exact (catches <= vs < mutations)."""
+        mon = self._mon(scrub_hang_timeout_s=900)
+        s = {"pid": 9, "timestamp": 1}
+        mon._scrub_first_held = 9000                       # established streak
+        mon._scrub_progress_token = StateMonitor._progress_token(s)
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s), \
+             patch.object(StateMonitor, "_recover_stuck_scrub",
+                          return_value=False), \
+             patch("time.monotonic", return_value=10000):
+            mon._scrub_last_progress = 10000 - 900  # idle == 900 exactly
             assert mon.check_scrub_health(make_input_data(50)) is None
-            # Simulate the lock having first been seen held long ago
-            mon._scrub_first_held = time.monotonic() - 1000
+            mon._scrub_last_progress = 10000 - 901  # idle == 901
             assert mon.check_scrub_health(make_input_data(50)) is not None
 
     def test_alert_is_one_shot_and_re_arms_on_free(self):
         mon = self._mon(scrub_auto_recover=False)
-        stale = {"pid": 4, "timestamp": time.time() - 1000}
+        s = {"pid": 4, "timestamp": 1}
+        self._idle_streak(mon, StateMonitor._progress_token(s))
         with patch.object(StateMonitor, "_scrub_lock_state",
                           return_value="held"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=stale):
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s):
             assert mon.check_scrub_health(make_input_data(50)) is not None  # alert
             assert mon.check_scrub_health(make_input_data(50)) is None      # quiet
         with patch.object(StateMonitor, "_scrub_lock_state",
@@ -304,21 +357,13 @@ class TestCheckScrubHealth:
             assert mon.check_scrub_health(make_input_data(50)) is None
         assert mon._scrub_first_held is None
         assert mon._stuck_scrub_alerted is False
-        with patch.object(StateMonitor, "_scrub_lock_state",
-                          return_value="held"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=stale):
-            assert mon.check_scrub_health(make_input_data(50)) is not None  # re-arm
 
-    def test_unknown_lock_state_is_suspicious_not_free(self):
+    def test_unknown_lock_state_starts_streak_not_reset(self):
         """'unknown' (disk full) must not reset -- it counts toward a hang."""
         mon = self._mon()
         with patch.object(StateMonitor, "_scrub_lock_state",
                           return_value="unknown"), \
-             patch.object(StateMonitor, "_read_scrub_status",
-                          return_value=None), \
-             patch.object(StateMonitor, "_recover_stuck_scrub",
-                          return_value=False):
+             patch.object(StateMonitor, "_read_scrub_status", return_value=None):
             mon.check_scrub_health(make_input_data(50))
             assert mon._scrub_first_held is not None  # streak started, not reset
 
@@ -364,19 +409,27 @@ class TestScrubLockState:
 class TestRecoverStuckScrub:
     """Self-healing: kill a genuinely-hung scrub, guarded against PID reuse."""
 
-    def test_kills_verified_scrub_process_group(self):
+    def test_kills_the_process_GROUP_not_the_pid(self):
+        # pid and pgid differ, so a mutation killpg(pid) instead of
+        # killpg(getpgid(pid)) is caught.
         mon = make_monitor()
         with patch.object(StateMonitor, "_pid_is_scrub", return_value=True), \
-             patch("os.getpgid", return_value=555), \
+             patch("os.getpgid", return_value=777) as mock_getpgid, \
              patch("os.killpg") as mock_killpg:
             assert mon._recover_stuck_scrub({"pid": 555}) is True
-        mock_killpg.assert_called_once_with(555, signal.SIGKILL)
+        mock_getpgid.assert_called_once_with(555)
+        mock_killpg.assert_called_once_with(777, signal.SIGKILL)
 
-    def test_does_not_kill_recycled_pid(self):
+    def test_pid_reuse_guard_prevents_kill(self):
+        # getpgid is valid here, so the ONLY thing preventing a kill is the
+        # _pid_is_scrub guard -- dropping the guard makes this test fail.
         mon = make_monitor()
-        with patch.object(StateMonitor, "_pid_is_scrub", return_value=False), \
+        with patch.object(StateMonitor, "_pid_is_scrub",
+                          return_value=False) as mock_guard, \
+             patch("os.getpgid", return_value=777), \
              patch("os.killpg") as mock_killpg:
             assert mon._recover_stuck_scrub({"pid": 999}) is False
+        mock_guard.assert_called_once_with(999)
         mock_killpg.assert_not_called()
 
     def test_no_pid_cannot_recover(self):

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -81,6 +81,9 @@ def make_monitor(scrub_command="", purge_space=200, alert_space=75,
     mon.scrub_cooldown_s = scrub_cooldown_s
     mon._last_scrub_spawn = None
     mon._low_space_alerted = False
+    mon.hs_stale_cycles = 15
+    mon._hs_stale_count = 0
+    mon._hs_stale_alerted = False
     mon.scrub_command = scrub_command
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -70,12 +70,17 @@ def make_input_data(bytes_remaining):
     return {"bytes_remaining": FakeDataValue(bytes_remaining)}
 
 
-def make_monitor(scrub_command="", low_space=100, space_previous=150,
+def make_monitor(scrub_command="", purge_space=200, alert_space=75,
+                 scrub_cooldown_s=1800, space_previous=250,
                  scrub_hang_timeout_s=900, scrub_status_file="/tmp/nonexistent",
                  scrub_auto_recover=True, scrub_log=""):
     """Create a StateMonitor instance with test defaults."""
     mon = StateMonitor.__new__(StateMonitor)
-    mon.low_space = low_space
+    mon.purge_space = purge_space
+    mon.alert_space = alert_space
+    mon.scrub_cooldown_s = scrub_cooldown_s
+    mon._last_scrub_spawn = None
+    mon._low_space_alerted = False
     mon.scrub_command = scrub_command
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)
@@ -93,7 +98,8 @@ def make_monitor(scrub_command="", low_space=100, space_previous=150,
 # --- Tests ---
 
 class TestScrubSpawning:
-    """Test that check_sensor_drive spawns scrub on threshold crossing."""
+    """check_sensor_drive drains (spawns) whenever free < purge_space --
+    level-triggered, not on a one-shot edge (§3.4)."""
 
     @pytest.fixture(autouse=True)
     def _lock_free(self):
@@ -102,69 +108,43 @@ class TestScrubSpawning:
                           return_value="free"):
             yield
 
-    def test_scrub_spawned_on_low_space(self):
-        """When space drops below threshold, scrub process is spawned."""
+    def test_scrub_spawned_below_purge(self):
+        """Free below purge_space -> scrub spawned (no alert above alert_space)."""
         mon = make_monitor(
-            scrub_command="python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto",
-            space_previous=150,
-        )
+            scrub_command="python3 /home/pi/dev/mjolnir-hamma/scripts/hamma_scrub.py --recover --purge --since auto")
+        with patch("subprocess.Popen") as mock_popen:
+            msg = mon.check_sensor_drive(make_input_data(90))  # 75 < 90 < 200
+        assert msg is None                 # purge band: drain, no alert
+        mock_popen.assert_called_once()
+        assert "flock" in mock_popen.call_args[0][0][0]
 
+    def test_spawns_even_when_previous_also_below(self):
+        """Level, not edge: already below on the prior sample still drains."""
+        mon = make_monitor(scrub_command="python3 /path/to/scrub.py",
+                           space_previous=80)
+        with patch("subprocess.Popen") as mock_popen:
+            mon.check_sensor_drive(make_input_data(70))
+        mock_popen.assert_called_once()
+
+    def test_no_scrub_when_command_empty(self):
+        mon = make_monitor(scrub_command="")
         with patch("subprocess.Popen") as mock_popen:
             msg = mon.check_sensor_drive(make_input_data(90))
-
-        assert msg is not None
-        mock_popen.assert_called_once()
-        popen_cmd = mock_popen.call_args[0][0]
-        assert "flock" in popen_cmd[0]
-
-    def test_no_scrub_when_already_below(self):
-        """No scrub if space was already below threshold (not a crossing)."""
-        mon = make_monitor(
-            scrub_command="python3 /path/to/scrub.py --recover --purge --since auto",
-            space_previous=80,
-        )
-
-        with patch("subprocess.Popen") as mock_popen:
-            msg = mon.check_sensor_drive(make_input_data(70))
-
         assert msg is None
         mock_popen.assert_not_called()
 
-    def test_no_scrub_when_command_empty(self):
-        """No scrub if scrub_command is empty."""
-        mon = make_monitor(scrub_command="", space_previous=150)
-
-        with patch("subprocess.Popen") as mock_popen:
-            msg = mon.check_sensor_drive(make_input_data(90))
-
-        assert msg is not None  # alert still fires
-        mock_popen.assert_not_called()
-
     def test_scrub_failure_logged_not_raised(self):
-        """If Popen fails, error is logged but check_sensor_drive still returns."""
-        mon = make_monitor(
-            scrub_command="python3 /path/to/scrub.py",
-            space_previous=150,
-        )
-
+        mon = make_monitor(scrub_command="python3 /path/to/scrub.py")
         with patch("subprocess.Popen", side_effect=OSError("flock not found")):
-            msg = mon.check_sensor_drive(make_input_data(90))
-
-        assert msg is not None
+            mon.check_sensor_drive(make_input_data(90))  # must not raise
         mon.logger.error.assert_called()
 
     def test_flock_uses_lock_file(self):
-        """Popen command uses flock with a specific lock file."""
         mon = make_monitor(
-            scrub_command="python3 /path/to/scrub.py --recover --purge --since auto",
-            space_previous=150,
-        )
-
+            scrub_command="python3 /path/to/scrub.py --recover --purge --since auto")
         with patch("subprocess.Popen") as mock_popen:
             mon.check_sensor_drive(make_input_data(90))
-
         popen_cmd = mock_popen.call_args[0][0]
-        # Should be: flock -n /tmp/hamma_scrub.lock <scrub_command>
         assert popen_cmd[0] == "flock"
         assert popen_cmd[1] == "-n"
         assert "hamma_scrub.lock" in popen_cmd[2]
@@ -174,13 +154,10 @@ class TestScrubSpawning:
         assert popen_kwargs["stderr"] == subprocess.DEVNULL
 
     def test_no_scrub_when_command_whitespace_only(self):
-        """No scrub if scrub_command is whitespace-only."""
-        mon = make_monitor(scrub_command="   ", space_previous=150)
-
+        mon = make_monitor(scrub_command="   ")
         with patch("subprocess.Popen") as mock_popen:
             msg = mon.check_sensor_drive(make_input_data(90))
-
-        assert msg is not None  # alert still fires
+        assert msg is None
         mock_popen.assert_not_called()
 
 

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -1,7 +1,9 @@
 """Tests for state_monitor scrub-on-low-space integration."""
 
 import importlib.util
+import signal
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -69,15 +71,19 @@ def make_input_data(bytes_remaining):
 
 
 def make_monitor(scrub_command="", low_space=100, space_previous=150,
-                 stuck_scrub_cycles=10):
+                 scrub_hang_timeout_s=900, scrub_status_file="/tmp/nonexistent",
+                 scrub_auto_recover=True, scrub_log=""):
     """Create a StateMonitor instance with test defaults."""
     mon = StateMonitor.__new__(StateMonitor)
     mon.low_space = low_space
     mon.scrub_command = scrub_command
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)
-    mon.stuck_scrub_cycles = stuck_scrub_cycles
-    mon._scrub_lock_held_cycles = 0
+    mon.scrub_hang_timeout_s = scrub_hang_timeout_s
+    mon.scrub_status_file = scrub_status_file
+    mon.scrub_auto_recover = scrub_auto_recover
+    mon.scrub_log = scrub_log
+    mon._scrub_first_held = None
     mon._stuck_scrub_alerted = False
     return mon
 
@@ -90,8 +96,8 @@ class TestScrubSpawning:
     @pytest.fixture(autouse=True)
     def _lock_free(self):
         """These tests assume no prior scrub is running (lock free)."""
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=False):
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"):
             yield
 
     def test_scrub_spawned_on_low_space(self):
@@ -192,89 +198,146 @@ class TestScrubConfig:
 
 class TestScrubLockHonesty:
     """_spawn_scrub must not spawn -- and must not silently claim success --
-    when a prior scrub still holds the lock (the mj05 flock -n no-op)."""
+    when a prior scrub holds the lock (the mj05 flock -n no-op), and must not
+    spawn into an unreadable lock (disk full)."""
 
     def test_no_spawn_when_lock_held(self):
         mon = make_monitor(scrub_command="python3 scrub.py", space_previous=150)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True), \
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
              patch("subprocess.Popen") as mock_popen:
             mon.check_sensor_drive(make_input_data(90))
         mock_popen.assert_not_called()
         mon.logger.warning.assert_called()  # honest: it says it did NOT spawn
 
+    def test_no_spawn_when_lock_unknown(self):
+        mon = make_monitor(scrub_command="python3 scrub.py", space_previous=150)
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="unknown"), \
+             patch("subprocess.Popen") as mock_popen:
+            mon.check_sensor_drive(make_input_data(90))
+        mock_popen.assert_not_called()
+        mon.logger.warning.assert_called()
+
     def test_spawns_when_lock_free(self):
         mon = make_monitor(scrub_command="python3 scrub.py", space_previous=150)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=False), \
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"), \
              patch("subprocess.Popen") as mock_popen:
             mon.check_sensor_drive(make_input_data(90))
         mock_popen.assert_called_once()
 
 
 class TestCheckScrubHealth:
-    """Per-cycle stuck-lock detection: the lock held across many cycles means
-    a prior scrub is hung (the failure mode a timer cannot fix)."""
+    """Progress-gated hung-scrub detection: a scrub is hung only if the lock is
+    held AND its heartbeat is stale -- so a long legit recovery (fresh
+    heartbeat) is NOT flagged. On a genuine hang, recover (kill) + alert once."""
 
-    def _mon(self, cycles=3):
-        return make_monitor(scrub_command="python3 scrub.py",
-                            stuck_scrub_cycles=cycles)
+    def _mon(self, **kw):
+        kw.setdefault("scrub_command", "python3 scrub.py")
+        kw.setdefault("scrub_hang_timeout_s", 900)
+        return make_monitor(**kw)
 
-    def test_alerts_after_threshold_consecutive_held_cycles(self):
-        mon = self._mon(cycles=3)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
-            assert mon.check_scrub_health(make_input_data(50)) is None   # 1
-            assert mon.check_scrub_health(make_input_data(50)) is None   # 2
-            msg = mon.check_scrub_health(make_input_data(50))            # 3
-        assert msg is not None and "hung" in msg.lower()
-
-    def test_alert_is_one_shot(self):
-        mon = self._mon(cycles=1)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
-            assert mon.check_scrub_health(make_input_data(50)) is not None
+    def test_no_alert_when_heartbeat_fresh(self):
+        """Lock held but scrub is progressing (recent heartbeat) -> no alert."""
+        mon = self._mon()
+        fresh = {"pid": 111, "timestamp": time.time()}  # just now
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=fresh):
             assert mon.check_scrub_health(make_input_data(50)) is None
-
-    def test_resets_when_lock_frees(self):
-        mon = self._mon(cycles=2)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
-            mon.check_scrub_health(make_input_data(50))  # 1 held
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=False):
-            assert mon.check_scrub_health(make_input_data(50)) is None
-        assert mon._scrub_lock_held_cycles == 0
         assert mon._stuck_scrub_alerted is False
 
-    def test_re_arms_after_recovery(self):
-        mon = self._mon(cycles=1)
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
-            assert mon.check_scrub_health(make_input_data(50)) is not None
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
+    def test_alerts_and_recovers_when_heartbeat_stale(self):
+        """Lock held + heartbeat stale beyond timeout -> hung: kill + alert."""
+        mon = self._mon(scrub_hang_timeout_s=900, scrub_auto_recover=True)
+        stale = {"pid": 222, "timestamp": time.time() - 1000}  # 1000s ago
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=stale), \
+             patch.object(StateMonitor, "_recover_stuck_scrub",
+                          return_value=True) as mock_recover:
+            msg = mon.check_scrub_health(make_input_data(50))
+        mock_recover.assert_called_once_with(stale)
+        assert msg is not None and "hung" in msg.lower()
+
+    def test_no_kill_when_auto_recover_disabled(self):
+        mon = self._mon(scrub_auto_recover=False)
+        stale = {"pid": 3, "timestamp": time.time() - 1000}
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=stale), \
+             patch.object(StateMonitor, "_recover_stuck_scrub") as mock_recover:
+            msg = mon.check_scrub_health(make_input_data(50))
+        mock_recover.assert_not_called()
+        assert msg is not None and "manual" in msg.lower()
+
+    def test_no_heartbeat_uses_held_duration_fallback(self):
+        """No status file: not hung until the lock has been held > timeout."""
+        mon = self._mon(scrub_hang_timeout_s=900)
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=None), \
+             patch.object(StateMonitor, "_recover_stuck_scrub",
                           return_value=False):
-            mon.check_scrub_health(make_input_data(50))
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
+            # First sighting: held-duration ~0 -> not hung yet
+            assert mon.check_scrub_health(make_input_data(50)) is None
+            # Simulate the lock having first been seen held long ago
+            mon._scrub_first_held = time.monotonic() - 1000
             assert mon.check_scrub_health(make_input_data(50)) is not None
 
+    def test_alert_is_one_shot_and_re_arms_on_free(self):
+        mon = self._mon(scrub_auto_recover=False)
+        stale = {"pid": 4, "timestamp": time.time() - 1000}
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=stale):
+            assert mon.check_scrub_health(make_input_data(50)) is not None  # alert
+            assert mon.check_scrub_health(make_input_data(50)) is None      # quiet
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"):
+            assert mon.check_scrub_health(make_input_data(50)) is None
+        assert mon._scrub_first_held is None
+        assert mon._stuck_scrub_alerted is False
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=stale):
+            assert mon.check_scrub_health(make_input_data(50)) is not None  # re-arm
+
+    def test_unknown_lock_state_is_suspicious_not_free(self):
+        """'unknown' (disk full) must not reset -- it counts toward a hang."""
+        mon = self._mon()
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="unknown"), \
+             patch.object(StateMonitor, "_read_scrub_status",
+                          return_value=None), \
+             patch.object(StateMonitor, "_recover_stuck_scrub",
+                          return_value=False):
+            mon.check_scrub_health(make_input_data(50))
+            assert mon._scrub_first_held is not None  # streak started, not reset
+
     def test_no_op_when_no_scrub_command(self):
-        mon = self._mon(cycles=1)
+        mon = self._mon()
         mon.scrub_command = ""
-        with patch.object(StateMonitor, "_scrub_lock_is_held",
-                          return_value=True):
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"):
             assert mon.check_scrub_health(make_input_data(50)) is None
 
 
-class TestScrubLockProbe:
-    """The real flock(2) probe interoperates with `flock -n`."""
+class TestScrubLockState:
+    """The real flock(2) tri-state probe interoperates with `flock -n`."""
 
     def test_free_when_unlocked(self, tmp_path):
         mon = make_monitor()
         lock = str(tmp_path / "scrub.lock")
         with patch.object(MODULE, "SCRUB_LOCK_FILE", lock):
-            assert mon._scrub_lock_is_held() is False
+            assert mon._scrub_lock_state() == "free"
 
     def test_held_when_locked_by_another_fd(self, tmp_path):
         import fcntl
@@ -285,7 +348,87 @@ class TestScrubLockProbe:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         try:
             with patch.object(MODULE, "SCRUB_LOCK_FILE", lock):
-                assert mon._scrub_lock_is_held() is True
+                assert mon._scrub_lock_state() == "held"
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)
+
+    def test_unknown_when_lockfile_unopenable(self):
+        """os.open failure (e.g. ENOSPC on a full disk) -> 'unknown', not
+        'free' -- the detector must not go blind during a disk-full event."""
+        mon = make_monitor()
+        with patch("os.open", side_effect=OSError("ENOSPC")):
+            assert mon._scrub_lock_state() == "unknown"
+
+
+class TestRecoverStuckScrub:
+    """Self-healing: kill a genuinely-hung scrub, guarded against PID reuse."""
+
+    def test_kills_verified_scrub_process_group(self):
+        mon = make_monitor()
+        with patch.object(StateMonitor, "_pid_is_scrub", return_value=True), \
+             patch("os.getpgid", return_value=555), \
+             patch("os.killpg") as mock_killpg:
+            assert mon._recover_stuck_scrub({"pid": 555}) is True
+        mock_killpg.assert_called_once_with(555, signal.SIGKILL)
+
+    def test_does_not_kill_recycled_pid(self):
+        mon = make_monitor()
+        with patch.object(StateMonitor, "_pid_is_scrub", return_value=False), \
+             patch("os.killpg") as mock_killpg:
+            assert mon._recover_stuck_scrub({"pid": 999}) is False
+        mock_killpg.assert_not_called()
+
+    def test_no_pid_cannot_recover(self):
+        mon = make_monitor()
+        with patch("os.killpg") as mock_killpg:
+            assert mon._recover_stuck_scrub(None) is False
+            assert mon._recover_stuck_scrub({}) is False
+        mock_killpg.assert_not_called()
+
+
+class TestScrubLogRedirect:
+    """The scrub's stdout/stderr go to a durable log, not DEVNULL (the mj05
+    incident ran blind because output was DEVNULL'd)."""
+
+    def test_output_redirected_to_scrub_log(self, tmp_path):
+        log = str(tmp_path / "sub" / "scrub.log")
+        mon = make_monitor(scrub_command="python3 scrub.py", scrub_log=log)
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"), \
+             patch("subprocess.Popen") as mock_popen:
+            mon._spawn_scrub()
+        kwargs = mock_popen.call_args[1]
+        assert kwargs["stdout"] is not subprocess.DEVNULL   # a real file
+        assert kwargs["stderr"] == subprocess.STDOUT        # merged into it
+
+    def test_devnull_when_no_scrub_log(self):
+        mon = make_monitor(scrub_command="python3 scrub.py", scrub_log="")
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"), \
+             patch("subprocess.Popen") as mock_popen:
+            mon._spawn_scrub()
+        kwargs = mock_popen.call_args[1]
+        assert kwargs["stdout"] == subprocess.DEVNULL
+        assert kwargs["stderr"] == subprocess.DEVNULL
+
+    def test_falls_back_to_devnull_when_log_unwritable(self):
+        mon = make_monitor(scrub_command="python3 scrub.py",
+                           scrub_log="/proc/nope/scrub.log")
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"), \
+             patch("subprocess.Popen") as mock_popen:
+            mon._spawn_scrub()
+        kwargs = mock_popen.call_args[1]
+        assert kwargs["stdout"] == subprocess.DEVNULL
+
+    def test_rotates_when_oversized(self, tmp_path):
+        log = tmp_path / "scrub.log"
+        log.write_bytes(b"x" * 10)
+        mon = make_monitor(scrub_command="python3 scrub.py", scrub_log=str(log))
+        with patch.object(MODULE, "SCRUB_LOG_MAX_BYTES", 5), \
+             patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="free"), \
+             patch("subprocess.Popen"):
+            mon._spawn_scrub()
+        assert (tmp_path / "scrub.log.1").exists()  # old log rotated aside

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -71,7 +71,7 @@ def make_input_data(bytes_remaining):
 
 
 def make_monitor(scrub_command="", purge_space=200, alert_space=75,
-                 scrub_cooldown_s=1800, space_previous=250,
+                 scrub_cooldown_s=300, space_previous=250,
                  scrub_hang_timeout_s=900, scrub_status_file="/tmp/nonexistent",
                  scrub_auto_recover=True, scrub_log=""):
     """Create a StateMonitor instance with test defaults."""

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -68,13 +68,17 @@ def make_input_data(bytes_remaining):
     return {"bytes_remaining": FakeDataValue(bytes_remaining)}
 
 
-def make_monitor(scrub_command="", low_space=100, space_previous=150):
+def make_monitor(scrub_command="", low_space=100, space_previous=150,
+                 stuck_scrub_cycles=10):
     """Create a StateMonitor instance with test defaults."""
     mon = StateMonitor.__new__(StateMonitor)
     mon.low_space = low_space
     mon.scrub_command = scrub_command
     mon.logger = MagicMock()
     mon._previous_data = make_input_data(space_previous)
+    mon.stuck_scrub_cycles = stuck_scrub_cycles
+    mon._scrub_lock_held_cycles = 0
+    mon._stuck_scrub_alerted = False
     return mon
 
 
@@ -82,6 +86,13 @@ def make_monitor(scrub_command="", low_space=100, space_previous=150):
 
 class TestScrubSpawning:
     """Test that check_sensor_drive spawns scrub on threshold crossing."""
+
+    @pytest.fixture(autouse=True)
+    def _lock_free(self):
+        """These tests assume no prior scrub is running (lock free)."""
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=False):
+            yield
 
     def test_scrub_spawned_on_low_space(self):
         """When space drops below threshold, scrub process is spawned."""
@@ -177,3 +188,104 @@ class TestScrubConfig:
         """Default scrub_command is empty string (disabled)."""
         mon = make_monitor(scrub_command="")
         assert mon.scrub_command == ""
+
+
+class TestScrubLockHonesty:
+    """_spawn_scrub must not spawn -- and must not silently claim success --
+    when a prior scrub still holds the lock (the mj05 flock -n no-op)."""
+
+    def test_no_spawn_when_lock_held(self):
+        mon = make_monitor(scrub_command="python3 scrub.py", space_previous=150)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True), \
+             patch("subprocess.Popen") as mock_popen:
+            mon.check_sensor_drive(make_input_data(90))
+        mock_popen.assert_not_called()
+        mon.logger.warning.assert_called()  # honest: it says it did NOT spawn
+
+    def test_spawns_when_lock_free(self):
+        mon = make_monitor(scrub_command="python3 scrub.py", space_previous=150)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=False), \
+             patch("subprocess.Popen") as mock_popen:
+            mon.check_sensor_drive(make_input_data(90))
+        mock_popen.assert_called_once()
+
+
+class TestCheckScrubHealth:
+    """Per-cycle stuck-lock detection: the lock held across many cycles means
+    a prior scrub is hung (the failure mode a timer cannot fix)."""
+
+    def _mon(self, cycles=3):
+        return make_monitor(scrub_command="python3 scrub.py",
+                            stuck_scrub_cycles=cycles)
+
+    def test_alerts_after_threshold_consecutive_held_cycles(self):
+        mon = self._mon(cycles=3)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            assert mon.check_scrub_health(make_input_data(50)) is None   # 1
+            assert mon.check_scrub_health(make_input_data(50)) is None   # 2
+            msg = mon.check_scrub_health(make_input_data(50))            # 3
+        assert msg is not None and "hung" in msg.lower()
+
+    def test_alert_is_one_shot(self):
+        mon = self._mon(cycles=1)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            assert mon.check_scrub_health(make_input_data(50)) is not None
+            assert mon.check_scrub_health(make_input_data(50)) is None
+
+    def test_resets_when_lock_frees(self):
+        mon = self._mon(cycles=2)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            mon.check_scrub_health(make_input_data(50))  # 1 held
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=False):
+            assert mon.check_scrub_health(make_input_data(50)) is None
+        assert mon._scrub_lock_held_cycles == 0
+        assert mon._stuck_scrub_alerted is False
+
+    def test_re_arms_after_recovery(self):
+        mon = self._mon(cycles=1)
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            assert mon.check_scrub_health(make_input_data(50)) is not None
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=False):
+            mon.check_scrub_health(make_input_data(50))
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            assert mon.check_scrub_health(make_input_data(50)) is not None
+
+    def test_no_op_when_no_scrub_command(self):
+        mon = self._mon(cycles=1)
+        mon.scrub_command = ""
+        with patch.object(StateMonitor, "_scrub_lock_is_held",
+                          return_value=True):
+            assert mon.check_scrub_health(make_input_data(50)) is None
+
+
+class TestScrubLockProbe:
+    """The real flock(2) probe interoperates with `flock -n`."""
+
+    def test_free_when_unlocked(self, tmp_path):
+        mon = make_monitor()
+        lock = str(tmp_path / "scrub.lock")
+        with patch.object(MODULE, "SCRUB_LOCK_FILE", lock):
+            assert mon._scrub_lock_is_held() is False
+
+    def test_held_when_locked_by_another_fd(self, tmp_path):
+        import fcntl
+        import os
+        mon = make_monitor()
+        lock = str(tmp_path / "scrub.lock")
+        fd = os.open(lock, os.O_CREAT | os.O_RDWR)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            with patch.object(MODULE, "SCRUB_LOCK_FILE", lock):
+                assert mon._scrub_lock_is_held() is True
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)

--- a/tests/python/test_state_monitor_scrub.py
+++ b/tests/python/test_state_monitor_scrub.py
@@ -269,6 +269,24 @@ class TestCheckScrubHealth:
         mock_spawn.assert_called_once()          # freed lock is re-used
         assert msg is not None and "hung" in msg.lower()
 
+    def test_post_kill_respawn_is_cooldown_gated(self):
+        """After killing a hung scrub, the respawn must go through the cooldown
+        gate -- a rapid re-hang must not drive an unbounded kill/respawn cycle
+        (bounded only by scrub_hang_timeout_s). Jeff review #1."""
+        mon = self._mon(scrub_auto_recover=True)
+        mon._last_scrub_spawn = time.monotonic()  # a scrub launched just now
+        s = {"pid": 22, "timestamp": 1, "phase": "recover", "recovered": 2}
+        self._idle_streak(mon, StateMonitor._progress_token(s))
+        with patch.object(StateMonitor, "_scrub_lock_state",
+                          return_value="held"), \
+             patch.object(StateMonitor, "_read_scrub_status", return_value=s), \
+             patch.object(StateMonitor, "_recover_stuck_scrub",
+                          return_value=True), \
+             patch.object(StateMonitor, "_spawn_scrub") as mock_spawn:
+            msg = mon.check_scrub_health(make_input_data(50))
+        mock_spawn.assert_not_called()  # cooldown gate blocks the immediate respawn
+        assert msg is not None and "hung" in msg.lower()
+
     def test_clock_skew_immune_future_timestamp_still_hangs(self):
         """A heartbeat timestamp in the FUTURE (NTP skew) must not disable
         detection: detection is by token-change, not absolute time."""

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -222,9 +222,11 @@ configure_brokkr() {
     local systemd_path="/etc/systemd/system"
 
     if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "rm -f $bin_path/hamma-scrub.sh (pre-copy, avoids same-file error)"
         log_dry_run "cp $files_dir/hamma-scrub.sh $bin_path/ (chmod +x)"
         log_dry_run "cp hamma-scrub.{service,timer} to $systemd_path/"
         log_dry_run "systemctl daemon-reload; enable --now hamma-scrub.timer"
+        manifest_add "remove" "path" "$bin_path/hamma-scrub.sh" "sudo" "true"
         manifest_add "copy" "src" "$files_dir/hamma-scrub.sh" "dst" "$bin_path/hamma-scrub.sh" "sudo" "true"
         manifest_add "chmod" "path" "$bin_path/hamma-scrub.sh" "mode" "+x" "sudo" "true"
         manifest_add "copy" "src" "$files_dir/hamma-scrub.service" "dst" "$systemd_path/hamma-scrub.service" "sudo" "true"

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -212,6 +212,37 @@ configure_brokkr() {
         log_success "Brokkr services installed"
     fi
 
+    # --- Step 5: Install the periodic AGS scrub timer ---
+    # Steady-state drain of /ags/data, independent of the low-space telemetry
+    # trigger, and the re-spawn path after check_scrub_health kills a hung scrub.
+    log_step "[Brokkr Config 5/5] Installing AGS scrub timer..."
+
+    local files_dir="${FILES_DIR:-$INSTALL_PATH/mjolnir-hamma/files}"
+    local bin_path="/usr/local/bin"
+    local systemd_path="/etc/systemd/system"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry_run "cp $files_dir/hamma-scrub.sh $bin_path/ (chmod +x)"
+        log_dry_run "cp hamma-scrub.{service,timer} to $systemd_path/"
+        log_dry_run "systemctl daemon-reload; enable --now hamma-scrub.timer"
+        manifest_add "copy" "src" "$files_dir/hamma-scrub.sh" "dst" "$bin_path/hamma-scrub.sh" "sudo" "true"
+        manifest_add "chmod" "path" "$bin_path/hamma-scrub.sh" "mode" "+x" "sudo" "true"
+        manifest_add "copy" "src" "$files_dir/hamma-scrub.service" "dst" "$systemd_path/hamma-scrub.service" "sudo" "true"
+        manifest_add "copy" "src" "$files_dir/hamma-scrub.timer" "dst" "$systemd_path/hamma-scrub.timer" "sudo" "true"
+        manifest_add "command" "cmd" "systemctl daemon-reload" "sudo" "true"
+        manifest_add "systemctl" "action" "enable" "service" "hamma-scrub.timer"
+        manifest_add "systemctl" "action" "start" "service" "hamma-scrub.timer"
+    else
+        sudo rm -f "$bin_path/hamma-scrub.sh"
+        sudo cp "$files_dir/hamma-scrub.sh" "$bin_path/"
+        sudo chmod +x "$bin_path/hamma-scrub.sh"
+        sudo cp "$files_dir/hamma-scrub.service" "$systemd_path/"
+        sudo cp "$files_dir/hamma-scrub.timer" "$systemd_path/"
+        sudo systemctl daemon-reload
+        sudo systemctl enable --now hamma-scrub.timer
+        log_success "hamma-scrub.timer enabled (drain every 15 min)"
+    fi
+
     log_success "Brokkr configuration complete!"
     echo ""
     log_info "To verify:"


### PR DESCRIPTION
## Why

After mj05's Jul 9–13 incident, `/ags/data` filled despite a clean `low_space` crossing on Jul 9 20:56 that **should** have fired a scrub — but no space was freed and no usable trace survived. Root cause (honest version, `docs/scrub-resilience-design.md` §2): the deployed scrub could **silently no-op** — `flock -n` returns nonzero when a prior scrub already holds the lock, yet the caller logged success unconditionally and ran output to `DEVNULL`. A hung or wedged scrub therefore looked healthy, freed nothing, and left no forensics (compounded by log-spam destroying the SD, HAM-112/113).

This is **not** a trigger bug and PR #78 does not address it. This PR makes silent scrub failure **impossible, visible, and (optionally) self-healing**.

## What's in it

Ranked by the design doc (silent-failure elimination first, timer demoted to steady-state backstop):

- **§3.1 Honest lock handling** — probe the flock state (held/free/unknown) and log the truth; never claim a scrub ran when it didn't.
- **§3.2 Durable observability + real stuck-detection** — a progress **heartbeat token** on tmpfs (`/dev/shm`, survives an SD fill), hung-detection by **token advancement in the monitor's own `monotonic` clock** (immune to sensor clock skew and stale-file races), a rotated durable `scrub_log`, and an **opt-in** self-heal that `killpg(SIGKILL)`s a genuinely-hung scrub to free the lock, then re-spawns.
- **§3.3 systemd timer backstop** (`hamma-scrub.{sh,service,timer}`, ~15 min, `flock -n -E 0`, `Nice=10`) — steady-state drain independent of the NA-prone `bytes_remaining` signal.
- **§3.4 Two-threshold drain** — `purge_space=200` (drain harder, no alert) / `alert_space=75` (alert: purge is losing), replacing the single edge-triggered `low_space`. Level-triggered with cooldown. A stale per-unit `low_space` override is accepted+warned+ignored so it can't crash pipeline build.
- **§3.5 Fast + incremental scan** — batched deletes over one SSH ControlMaster, bounded timeouts (no more unbounded scan hang), JSON incremental scan cache (force-rescan newest dir).
- **Telemetry watchdog** — alert once when `bytes_remaining` reads NA for `hs_stale_cycles` (~15 min): a *dark* AGS is exactly when every space decision goes blind.

## Honest scope (what it does NOT do)

Killing a hung scrub frees the **lock**, not AGS bytes. While the AGS itself is wedged, only a *completed* purge against a *reachable* AGS drains `/ags/data`. This work makes the wedge **visible and recoverable on reconnect**; it does not make a dead AGS write data. The two-threshold layer reads `bytes_remaining`, which goes NA in the exact failure mode — so it would **not** have prevented mj05 on its own (hence §3.2 ranks above it). See design doc §3.2 as-built + §6.

## Deploy notes (design doc §7)

- **Branch-only; nothing deployed.**
- The systemd timer auto-installs only on a fresh `unified_install` run — **existing units need the units copied + `enable --now` by hand** (same class as the DNS/40-eth0 redeploy gap).
- Clean mj54's per-unit `low_space=10` override → `purge_space`/`alert_space` before config deploy.
- **`scrub_auto_recover` ships `false`** (SIGKILL self-heal). Enabling it fleet-wide is bench-gated and tracked in #81.

## Follow-ups (bench/measurement, not code)

- #81 — validate `scrub_auto_recover` on a bench unit + measure real fast-scrub wall-clock (incl. `recover`) under load, then enable.
- Durable forensics have a hard dependency on HAM-112 / #73 (HAM-113): the SD `scrub_log` self-disables under a log-flooded SD. The tmpfs heartbeat is the load-bearing *live* signal; #73 is what makes the *forensic* record survive.

## Supersedes / relates

- Reframes **#78** (level-trigger + cooldown survive as §3.4; `scrub_log` kept & promoted) — #78's fix does not address the silent-no-op root cause.
- Folds in parts of **#80** (H&S staleness watchdog; the "futile-scrub" concern is split — stuck-detection here, "space still falling despite scrubs" = `alert_space`).

## Tests

258 scrub-suite tests passing (`test_state_monitor.py`, `test_state_monitor_scrub.py`, `test_hamma_scrub.py`, `test_scrub_timer.py`), incl. lock-honesty, heartbeat-advancement stuck-detection (with false-kill-vector mutations), killpg process-group + PID-reuse guard, two-threshold drain/debounce, batched-purge boundaries + per-chunk heartbeat, incremental-scan cache hit/miss, and the timer wrapper. Integration/load reproduction is the remaining TODO (tracked in #81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)