### PR TITLE
fix(install): pin gpiozero<2.0 on Python 3.7 (HAM-84)

### DIFF
--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -284,6 +284,20 @@ check_brokkr_status() {
         fail "Brokkr status command failed"
         info "Output: $status_output"
     fi
+
+    # gpiozero must import in ltgenv — gpiozero 2.0 on Python 3.7 raises
+    # ModuleNotFoundError, which breaks relay.py and therefore sensor power
+    # control via mjol_array --up/--down (HAM-84).
+    local ltgenv_py="/home/pi/dev/ltgenv/bin/python"
+    if [[ -x "$ltgenv_py" ]]; then
+        if "$ltgenv_py" -c "import gpiozero" 2>/dev/null; then
+            pass "gpiozero imports in ltgenv"
+        else
+            fail "gpiozero fails to import in ltgenv (pin gpiozero<2.0 on Python 3.7 — HAM-84)"
+        fi
+    else
+        skip "ltgenv python not found — cannot check gpiozero"
+    fi
 }
 
 check_server_connection() {

--- a/tests/unified/test_gpiozero_pin.py
+++ b/tests/unified/test_gpiozero_pin.py
@@ -1,0 +1,119 @@
+"""
+Tests for the HAM-84 gpiozero pin.
+
+gpiozero 2.0 imports importlib.metadata, which does not exist on Python 3.7,
+so `import gpiozero` raises ModuleNotFoundError on Buster. That breaks
+relay.py and therefore sensor power control (mjol_array --up/--down).
+
+install_brokkr must pin gpiozero<2.0 when the interpreter is Python <=3.7,
+and must NOT pin it on newer Python so the constraint auto-heals once the
+fleet moves off Buster.
+"""
+
+import os
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+FILES_DIR = REPO_ROOT / "files"
+UNIFIED_DIR = REPO_ROOT / "unified_install"
+
+
+def _run_install(tmp_path, path_prepend=None):
+    """Run install.sh --dry-run through the brokkr phase, return pip ops.
+
+    Brokkr is deliberately NOT skipped -- install_brokkr is what emits the
+    gpiozero pip_install operation into the manifest.
+    """
+    manifest_file = tmp_path / "manifest.json"
+    env = os.environ.copy()
+    env["MANIFEST_FILE"] = str(manifest_file)
+    env["HOME"] = str(tmp_path)
+    env["FILES_DIR"] = str(FILES_DIR)
+    if path_prepend:
+        env["PATH"] = f"{path_prepend}:{env['PATH']}"
+
+    result = subprocess.run(
+        ["bash", str(UNIFIED_DIR / "install.sh"),
+         "01", "--wifi", "--dry-run",
+         "--skip-packages", "--skip-hardware", "--skip-extras"],
+        capture_output=True, text=True, env=env, cwd=str(UNIFIED_DIR),
+    )
+    if not manifest_file.exists():
+        pytest.fail(
+            f"Manifest not created.\nstdout: {result.stdout}\nstderr: {result.stderr}")
+    manifest = json.loads(manifest_file.read_text())
+    return [op.get("package", "") for op in manifest["operations"]
+            if op.get("type") == "pip_install"]
+
+
+def _python3_stub(tmp_path, minor):
+    """Build a python3 stub reporting the given minor version.
+
+    Only the version_info.minor probe is faked; everything else delegates to
+    the real interpreter so the rest of the install is unaffected.
+    """
+    stub_dir = tmp_path / f"stub{minor}"
+    stub_dir.mkdir()
+    stub = stub_dir / "python3"
+    stub.write_text(textwrap.dedent(f"""\
+        #!/bin/bash
+        if [[ "$*" == *"version_info.minor"* ]]; then echo {minor}; exit 0; fi
+        exec /usr/bin/python3 "$@" 2>/dev/null || exec python3 "$@"
+    """))
+    stub.chmod(0o755)
+    return str(stub_dir)
+
+
+class TestGpiozeroPinWiring:
+    """The pin logic is present in the brokkr install lib."""
+
+    def test_pin_logic_defined(self):
+        brokkr = (UNIFIED_DIR / "lib" / "brokkr.sh").read_text()
+        assert "gpiozero_spec" in brokkr, \
+            "install_brokkr must compute a gpiozero spec, not hardcode 'gpiozero'"
+        assert "gpiozero<2.0" in brokkr, "the <2.0 pin must appear in brokkr.sh"
+        assert "HAM-84" in brokkr, "reference the ticket so the pin isn't removed blindly"
+
+    def test_pin_is_version_conditional(self):
+        brokkr = (UNIFIED_DIR / "lib" / "brokkr.sh").read_text()
+        assert "version_info.minor" in brokkr, \
+            "the pin must be conditional on the interpreter version, not unconditional"
+
+
+class TestGpiozeroPinManifest:
+    """The dry-run manifest carries the right gpiozero spec per Python version."""
+
+    def test_gpiozero_still_installed(self, tmp_path):
+        packages = _run_install(tmp_path)
+        assert any("gpiozero" in p for p in packages), \
+            f"gpiozero pip_install op missing from brokkr install. pip ops: {packages}"
+
+    def test_gpiozero_pinned_on_python37(self, tmp_path):
+        packages = _run_install(
+            tmp_path, path_prepend=_python3_stub(tmp_path, 7))
+        assert any("gpiozero<2.0" in p for p in packages), \
+            f"gpiozero not pinned <2.0 on Python 3.7. pip ops: {packages}"
+
+    def test_gpiozero_unpinned_on_newer_python(self, tmp_path):
+        """On Python >=3.8 the pin must NOT apply, so it auto-heals off Buster."""
+        packages = _run_install(
+            tmp_path, path_prepend=_python3_stub(tmp_path, 11))
+        gpz = [p for p in packages if "gpiozero" in p]
+        assert gpz, f"gpiozero op missing entirely. pip ops: {packages}"
+        assert not any("<2.0" in p for p in gpz), \
+            f"gpiozero should be unpinned on Python 3.11, got: {gpz}"
+
+
+class TestVerifyDeploymentCheck:
+    """verify_deployment.sh catches a broken gpiozero at bring-up."""
+
+    def test_gpiozero_import_check_present(self):
+        verify = (REPO_ROOT / "scripts" / "verify_deployment.sh").read_text()
+        assert "import gpiozero" in verify, \
+            "verify_deployment.sh must check that gpiozero imports in ltgenv"
+        assert "HAM-84" in verify, "the failure message should point at the ticket"

--- a/unified_install/lib/brokkr.sh
+++ b/unified_install/lib/brokkr.sh
@@ -112,15 +112,29 @@ install_brokkr() {
     # --- Step 4: Install Python packages ---
     log_step "[Brokkr 4/4] Installing Python packages..."
 
+    # gpiozero 2.0 dropped Python 3.7 support (it imports importlib.metadata,
+    # which does not exist on 3.7), breaking `import gpiozero` and relay.py on
+    # Buster. Pin <2.0 on Python 3.7; newer Python can take the current release.
+    # (HAM-84 — mirrors the cartopy version-detection in install_pyltg.)
+    local python_minor
+    # Fall back to a high value if the probe yields nothing, so an empty result
+    # doesn't silently pin (bash treats "" as 0 in [[ -le ]]).
+    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null || echo 99)
+    local gpiozero_spec="gpiozero"
+    if [[ "$python_minor" -le 7 ]]; then
+        gpiozero_spec="gpiozero<2.0"
+        log_info "Python 3.$python_minor detected, pinning $gpiozero_spec (HAM-84)"
+    fi
+
     if [[ "$DRY_RUN" == "true" ]]; then
         log_dry_run "pip install $INSTALL_PATH/brokkr (as pi user)"
         log_dry_run "pip install $INSTALL_PATH/serviceinstaller (as pi user)"
         log_dry_run "pip install $INSTALL_PATH/notifiers (as pi user)"
-        log_dry_run "pip install gpiozero RPi.GPIO (as pi user)"
+        log_dry_run "pip install $gpiozero_spec RPi.GPIO (as pi user)"
         manifest_add "pip_install" "package" "$INSTALL_PATH/brokkr" "user" "pi"
         manifest_add "pip_install" "package" "$INSTALL_PATH/serviceinstaller" "user" "pi"
         manifest_add "pip_install" "package" "$INSTALL_PATH/notifiers" "user" "pi"
-        manifest_add "pip_install" "package" "gpiozero RPi.GPIO" "user" "pi"
+        manifest_add "pip_install" "package" "$gpiozero_spec RPi.GPIO" "user" "pi"
     else
         # Run as pi user to ensure correct ownership
         # Use non-editable installs to avoid .pth file issues with sudo
@@ -128,8 +142,8 @@ install_brokkr() {
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/serviceinstaller'"
         sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$INSTALL_PATH/notifiers'"
 
-        # GPIO packages for relay control
-        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install gpiozero RPi.GPIO"
+        # GPIO packages for relay control (gpiozero pinned per HAM-84 above)
+        sudo -H -u pi bash -c "source '$VENV_PATH/bin/activate' && pip install '$gpiozero_spec' RPi.GPIO"
 
         log_success "Python packages installed"
     fi


### PR DESCRIPTION
## Why

`gpiozero` is a hard runtime dependency of `scripts/relay.py`, but nothing in the install flow installs it *pinned* — `install_brokkr` ran a bare `pip install gpiozero RPi.GPIO`. gpiozero 2.0 imports `importlib.metadata`, which does not exist on Python 3.7, so every unit provisioned after that release got a version that cannot import on Buster:

```
File ".../gpiozero/devices.py", line 19, in <module>
    from importlib.metadata import entry_points
ModuleNotFoundError: No module named 'importlib.metadata'
```

**This breaks sensor power control outright.** `relay.py` dies, so both `mjol_array --up` and `--down` fail. Worse, `sensors.py::sensor_off()` is a 6-step sequence with the relay toggle at step 2, so the abort leaves the unit half-toggled: brokkr and sindri stopped, relay untouched, **no `nosensor` mode drop-in written** — services shed while the frontend keeps drawing.

The failure is invisible until you actually need to move the relay. On 2026-08-05 that was mj04 at **11.456 V** against a 10.977 V LVD, drawing 1.689 A with no charge current. The power-down failed and had to be completed by hand through the system `python3`.

This is **HAM-84**, open since 2026-04-10, and this is the third round of hand-fixing: mj02 (April), mj00/51/54 (May), mj04/05/06/50 (August). Each round the fleet gets cleaned and the installer regresses it on the next bring-up.

## What this does

- **`unified_install/lib/brokkr.sh`** — detect the interpreter minor version and pin `gpiozero<2.0` only when Python <= 3.7. Newer Python takes the current release, so the constraint auto-heals when the fleet moves off Buster. Mirrors the existing cartopy version-detection in `install_pyltg`. The probe falls back to `99` if it yields nothing, since bash treats `""` as `0` in `[[ -le ]]` and an empty result would otherwise silently pin.
- **`scripts/verify_deployment.sh`** — check that `gpiozero` imports in `ltgenv`, so a broken venv is caught at bring-up instead of during an outage. Added to `check_brokkr_status`, which already gates on that venv.
- **`tests/unified/test_gpiozero_pin.py`** — new, covering the pin on 3.7, the *absence* of the pin on 3.11, that gpiozero is still installed at all, and that the verify check exists.

## Provenance

The implementation is ported from **PR #79**, which has carried this fix (along with ~600 lines of other install hardening) since 2026-07-12 without review. Splitting the pin out so it can land on its own — #79 remains open for its own review.

Deliberately **not** taken from #79: the notifiers-editable change (HAM-158), and the scrub-timer block that #79's diff would revert because it predates PR #82. This branch is cut fresh from current `0.4.x`.

Expect a small conflict in #79 when this merges; it should resolve to this version.

## Testing

```
$ pytest tests/unified/test_gpiozero_pin.py -v
6 passed
```

Verified the tests actually fail without the fix — reverting just the two script changes gives **4 failed, 2 passed**, including `test_gpiozero_pinned_on_python37`. The 2 that still pass are correct controls: gpiozero was always installed (just unpinned), and unmodified code never over-pins.

Full suite: `pytest tests/shell tests/unified` → **173 passed, 7 failed, 5 skipped**. All 7 failures are pre-existing shellcheck violations on clean `0.4.x` (verified against a stashed baseline — identical failures, same files, including 6 files this PR does not touch). `shellcheck` reports no new warnings in the added block.

## Notes for the reviewer

- The version probe reads the **system** `python3`, not the venv interpreter. That is correct in practice because `install_brokkr` creates the venv via `python3 -m venv`, and Buster's Python never moves off 3.7. It would only diverge if the venv pre-existed from a different interpreter, since the venv is only created when absent.
- Unrelated wart noticed while staging: `.gitignore` line 30 (`lib/`, a Python build-artifact pattern) also matches `unified_install/lib/`, so `git add` warns on paths there and **new** files under that directory would be silently ignored. Existing tracked files are unaffected. Worth a separate fix.
