### PR TITLE
feat(state_monitor): alert when the mj-side DATA drives run low (replaces #80)

### DIFF
--- a/config/main.toml
+++ b/config/main.toml
@@ -64,6 +64,7 @@ config_version = 1
         scrub_hang_timeout_s = 900  # judge a scrub hung if the lock is held with no heartbeat progress this long (>SCAN_TIMEOUT=600s)
         scrub_auto_recover = false  # kill a genuinely-hung scrub to free the lock (self-healing). DEFAULT OFF: validate on a bench unit (inject a hung scrub) before enabling fleet-wide; false = alert only. Enable tracked in hamma-dev/mjolnir-hamma#81
         scrub_log = "/home/pi/brokkr/hamma/log/hamma_scrub.log"  # durable capture of scrub stdout/stderr (rotated); mj05 ran blind on DEVNULL
+        recovery_low_gb = 25  # GB free on the roomiest mj-side DATA drive below which to alert; these are brokkr's write target AND where scrub recovery lands, so if they all fill both stop. Alert-only -- scrubbing the AGS does not free them
 
     # Step to create HAMMA plot
     [steps.hamma_plot]

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -31,6 +31,13 @@ DEFAULT_SCRUB_STATUS_FILE = "/dev/shm/hamma_scrub_status.json"
 # this was DEVNULL'd). Rotated at SCRUB_LOG_MAX_BYTES so it can't fill the disk.
 DEFAULT_SCRUB_LOG = os.path.expanduser("~/brokkr/hamma/log/hamma_scrub.log")
 SCRUB_LOG_MAX_BYTES = 5 * 1024 * 1024  # rotate the scrub log past this size
+# Mountpoint base for the mj-side DATA drives. Deliberately the same template
+# brokkr's own get_output_drive uses (utils/output.py), rather than a hardcoded
+# /media/pi, so this cannot drift from where brokkr actually writes.
+# check_drive discovers drives by *label* under /dev/disk/by-label, but free
+# space is a property of the mounted filesystem, so this check must work from
+# mountpoints instead.
+RECOVERY_MOUNT_BASE = "/media/{current_user}"
 
 
 def sensor_prefix():
@@ -64,6 +71,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_status_file=DEFAULT_SCRUB_STATUS_FILE,
         scrub_auto_recover=False,
         scrub_log=DEFAULT_SCRUB_LOG,
+        recovery_low_gb=25,
         low_space=None,   # DEPRECATED: replaced by purge_space/alert_space
         **output_step_kwargs,
         ):
@@ -125,6 +133,14 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         scrub_log : str, optional
             Durable file capturing the scrub's stdout/stderr (rotated); empty
             string disables (falls back to DEVNULL).
+        recovery_low_gb : numeric, optional
+            GB free on the roomiest mj-side DATA drive below which to alert.
+            These drives are both brokkr's science-data write target and where
+            the scrubber lands recovered AGS triggers -- if they all fill,
+            writes stop and recovery has nowhere to go. A single drive at 100%
+            is normal rotation, so only the *roomiest* drive is judged.
+            Alert-only: a full DATA drive is not fixed by scrubbing the AGS.
+            Default 25.
         low_space : numeric, optional
             **Deprecated.** The old single edge-triggered threshold, replaced by
             purge_space/alert_space (§3.4). Accepted only so a stale per-unit
@@ -185,6 +201,10 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self._scrub_last_progress = None   # monotonic; last heartbeat advance
         self._scrub_progress_token = None  # last-seen heartbeat identity
         self._stuck_scrub_alerted = False
+        # mj-side recovery-target drives (where brokkr writes science data and
+        # where the scrubber lands recovered AGS triggers).
+        self.recovery_low_gb = recovery_low_gb
+        self._recovery_low_active = False  # latch: alert once per descent
 
         self.notifier = Notifier(
             method=method, key_file=key_file, channel=channel, logger=self.logger)
@@ -298,6 +318,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         ]
         if self.enable_drive_checks:
             checks.insert(0, self.check_drive)
+            checks.append(self.check_recovery_drives)
             checks.append(self.check_sensor_drive)
             checks.append(self.check_scrub_health)
 
@@ -353,6 +374,78 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return "No drives available."
         else:
             return None
+
+    def check_recovery_drives(self, input_data):
+        """
+        Check free space on the mj-side recovery-target DATA drives.
+
+        These are both brokkr's science-data write target and where the
+        scrubber lands recovered AGS triggers. If they all fill, writes stop
+        and recovery has nowhere to go. A single drive at 100% is normal
+        rotation, so only the *roomiest* drive is judged. Local and
+        telemetry-independent -- no AGS dependency, so this still reports when
+        the AGS is dark. Alert-only: a full DATA drive is not fixed by
+        scrubbing the AGS.
+
+        Drives are resolved with `brokkr.utils.output.find_drives`, which drops
+        any match that is a directory but not a mountpoint. That filter is
+        load-bearing here: when udisks hits a stale `/media/pi/DATA07` dir it
+        mounts the real drive at `DATA071`, and `shutil.disk_usage()` on the
+        leftover directory returns the *SD root's* free space. Because this
+        check takes `max()`, a roomy root would then mask genuinely full DATA
+        drives. The trailing `*` on the glob catches the suffixed mountpoint
+        that a bare `DATA??` would miss.
+
+        Returns
+        -------
+        str | None
+            Message if the roomiest drive is below `recovery_low_gb`, else None.
+
+        """
+        # `from ... import name` rather than `import brokkr.utils.misc`: the
+        # latter would bind a local `brokkr`, shadowing the module-global one
+        # that brokkr.utils.output is resolved through below.
+        from brokkr.config.main import CONFIG
+        from brokkr.utils.misc import get_actual_username
+        drive_glob = (CONFIG['steps']['science_binary_output']
+                      ['drive_kwargs']['drive_glob'])
+
+        # Trailing "*" tolerates udisks-suffixed mountpoints (DATA07 -> DATA071).
+        # Both parts matter: the "*" finds the suffixed mount, and find_drives'
+        # ismount filter drops the stale directory that caused the suffix.
+        # Either alone is wrong -- see test_both_fixes_are_required.
+        paths = brokkr.utils.output.find_drives(
+            drive_glob + "*", RECOVERY_MOUNT_BASE,
+            filename_kwargs={"current_user": get_actual_username()})
+        if not paths:
+            # Nothing mounted -- leave the "no drives" alert to check_drive.
+            return None
+
+        frees = []
+        for path in paths:
+            try:
+                frees.append(shutil.disk_usage(str(path)).free)
+            except OSError:
+                # Drive unmounted mid-check; skip it rather than aborting.
+                continue
+        if not frees:
+            # Paths resolved but every one errored -- avoid max([]) ValueError.
+            return None
+
+        threshold = self.recovery_low_gb * (2 ** 30)
+        best_free = max(frees)
+        if best_free >= threshold:
+            self._recovery_low_active = False   # re-arm for the next descent
+            return None
+        if self._recovery_low_active:
+            return None                          # already alerted this descent
+        self._recovery_low_active = True
+        below = sum(1 for free in frees if free < threshold)
+        return ("Recovery drives low: roomiest {} has {:.1f} GB free "
+                "({}/{} below {} GB) -- brokkr writes and AGS recovery both "
+                "land here".format(
+                    drive_glob, best_free / (2 ** 30), below, len(frees),
+                    self.recovery_low_gb))
 
     def check_power(self, input_data):
         """

--- a/tests/python/test_state_monitor_drives.py
+++ b/tests/python/test_state_monitor_drives.py
@@ -1,0 +1,406 @@
+"""Tests for check_recovery_drives (mj-side DATA drive free space).
+
+Ported from the disk-safety-monitors work (PR #80) onto the post-#82
+state_monitor. Only Layer 1 is carried over -- Layer 2 (H&S staleness) is
+already implemented in check_sensor_drive as hs_stale_cycles, and Layer 3
+(futile-scrub alerting) needs redesign against the purge_space/alert_space
+model rather than a port.
+
+Drive discovery deliberately goes through brokkr.utils.output.find_drives
+rather than a raw glob, because find_drives drops matches that are directories
+but not mountpoints. See test_glob_pattern_tolerates_suffixed_mount and
+test_uses_find_drives_so_stale_dirs_are_excluded.
+"""
+
+import fnmatch
+import importlib.util
+import os
+from collections import namedtuple
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PLUGIN_PATH = REPO_ROOT / "plugins" / "state_monitor.py"
+
+
+class MockOutputStep:
+    def __init__(self, **kwargs):
+        self.logger = MagicMock()
+        self.name = kwargs.get("name", "test_step")
+
+
+def load_state_monitor_module():
+    mock_base = MagicMock()
+    mock_base.OutputStep = MockOutputStep
+    mock_pipeline = MagicMock()
+    mock_pipeline.base = mock_base
+    mock_brokkr = MagicMock()
+    mock_brokkr.pipeline = mock_pipeline
+    mock_brokkr.pipeline.base = mock_base
+    with patch.dict("sys.modules", {
+        "brokkr": mock_brokkr,
+        "brokkr.pipeline": mock_pipeline,
+        "brokkr.pipeline.base": mock_base,
+        "brokkr.pipeline.decode": MagicMock(),
+        "brokkr.utils": MagicMock(),
+        "brokkr.utils.output": MagicMock(),
+        "notifiers": MagicMock(),
+    }):
+        spec = importlib.util.spec_from_file_location(
+            "state_monitor", str(PLUGIN_PATH))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load_state_monitor_module()
+StateMonitor = MODULE.StateMonitor
+
+DU = namedtuple("DU", ["total", "used", "free"])
+GB = 2 ** 30
+
+
+def du(free_gb):
+    return DU(2000 * GB, 0, int(free_gb * GB))
+
+
+class FakeDataValue:
+    def __init__(self, value):
+        self.value = value
+
+
+def make_input_data(bytes_remaining):
+    return {"bytes_remaining": FakeDataValue(bytes_remaining)}
+
+
+def make_drive_monitor(recovery_low_gb=25, scrub_command=""):
+    """Build a StateMonitor with just the attrs check_recovery_drives needs.
+
+    Bypasses __init__ so this stays decoupled from the rest of the plugin's
+    constructor surface.
+    """
+    mon = StateMonitor.__new__(StateMonitor)
+    mon.logger = MagicMock()
+    mon.scrub_command = scrub_command
+    mon.recovery_low_gb = recovery_low_gb
+    mon._recovery_low_active = False
+    return mon
+
+
+@contextmanager
+def mounted(paths, drive_glob="DATA??"):
+    """Patch the CONFIG lookup and find_drives to report `paths` as mounted."""
+    mock_config = {"steps": {"science_binary_output": {
+        "drive_kwargs": {"drive_glob": drive_glob}}}}
+    find_drives = MODULE.brokkr.utils.output.find_drives
+    find_drives.reset_mock()
+    find_drives.return_value = list(paths)
+    with patch.dict("sys.modules", {
+            "brokkr.config.main": MagicMock(CONFIG=mock_config),
+            "brokkr.utils.misc": MagicMock(
+                get_actual_username=lambda: "pi")}):
+        yield find_drives
+
+
+def brokkr_find_drives(base, drive_glob, filename_kwargs=None):
+    """Faithful stand-in for brokkr.utils.output.find_drives.
+
+    Same filter as brokkr/src/brokkr/utils/output.py: keep a match unless it is
+    a directory that is not a mountpoint. Used against a REAL temp tree so the
+    udisks topology tests exercise real globbing and real is_dir(), rather than
+    asserting against a hand-written list of paths.
+    """
+    return [p for p in Path(base).glob(drive_glob)
+            if not p.is_dir() or os.path.ismount(p)]
+
+
+# --- discovery: the glob fix -------------------------------------------------
+
+class TestDriveDiscovery:
+    """The bugs this port fixes relative to the original PR #80 implementation."""
+
+    def test_uses_find_drives_so_stale_dirs_are_excluded(self):
+        """Discovery must go through find_drives, not a raw glob.
+
+        find_drives filters `not is_dir() or ismount()`, which is what keeps a
+        stale /media/pi/DATA07 directory out of the results. shutil.disk_usage
+        on such a directory reports the SD root's free space, and since this
+        check takes max(), a roomy root would mask genuinely full DATA drives.
+        """
+        mon = make_drive_monitor()
+        with mounted(["/media/pi/DATA56"]) as find_drives:
+            with patch("shutil.disk_usage", side_effect=[du(500)]):
+                mon.check_recovery_drives(make_input_data(100))
+        find_drives.assert_called_once_with(
+            "DATA??*", MODULE.RECOVERY_MOUNT_BASE,
+            filename_kwargs={"current_user": "pi"})
+
+    def test_glob_pattern_tolerates_suffixed_mount(self):
+        """DATA??* matches both the plain and the udisks-suffixed mountpoint.
+
+        A bare DATA?? matches exactly two trailing characters, so it misses
+        DATA071 -- the name udisks uses when a stale DATA07 dir blocks it.
+        """
+        pattern = "DATA??" + "*"
+        assert fnmatch.fnmatch("DATA07", pattern)
+        assert fnmatch.fnmatch("DATA071", pattern)
+        # still requires at least two chars after DATA, as the original did
+        assert not fnmatch.fnmatch("DATA0", pattern)
+        # and the unfixed pattern demonstrably misses the suffixed mount
+        assert not fnmatch.fnmatch("DATA071", "DATA??")
+
+    def test_glob_comes_from_config_not_hardcoded(self):
+        """The pattern is sourced from science_binary_output.drive_kwargs."""
+        mon = make_drive_monitor()
+        with mounted(["/media/pi/XYZ99"], drive_glob="XYZ??") as find_drives:
+            with patch("shutil.disk_usage", side_effect=[du(500)]):
+                mon.check_recovery_drives(make_input_data(100))
+        find_drives.assert_called_once_with(
+            "XYZ??*", MODULE.RECOVERY_MOUNT_BASE,
+            filename_kwargs={"current_user": "pi"})
+
+    def test_mount_base_matches_brokkr_not_hardcoded_pi(self):
+        """Base path is brokkr's own template, so it can't drift from where
+        brokkr actually writes (it uses /media/{current_user}, not /media/pi)."""
+        assert MODULE.RECOVERY_MOUNT_BASE == "/media/{current_user}"
+
+
+# --- the udisks topology, against a real directory tree ----------------------
+
+class TestUdisksTopology:
+    """Reproduce sensor-log #52 (mj51) on a real filesystem.
+
+    A dirty unmount left an empty /media/pi/DATA07 directory; udisks then
+    mounted the real drive at DATA071. Brokkr's `DATA??` glob skipped the
+    suffixed mount and science data fell back to the SD card for ~8 days
+    with no alert.
+
+    These tests use real directories and real globbing -- only os.path.ismount
+    is stubbed, because creating an actual mount needs privileges. Mocking
+    find_drives wholesale (as the other tests do) proves nothing about path
+    resolution, which is where both bugs live.
+    """
+
+    @staticmethod
+    def _tree(tmp_path):
+        """stale DATA07 dir + real DATA071 and DATA55 mounts."""
+        for name in ("DATA07", "DATA071", "DATA55"):
+            (tmp_path / name).mkdir()
+        mounts = {str(tmp_path / "DATA071"), str(tmp_path / "DATA55")}
+        return mounts
+
+    @contextmanager
+    def _resolved(self, tmp_path, drive_glob, free_by_name):
+        """Run check_recovery_drives against the real tree."""
+        mounts = self._tree(tmp_path)
+        mock_config = {"steps": {"science_binary_output": {
+            "drive_kwargs": {"drive_glob": drive_glob}}}}
+
+        def fake_find(glob_pat, base, filename_kwargs=None):
+            return brokkr_find_drives(tmp_path, glob_pat, filename_kwargs)
+
+        def fake_usage(path):
+            return du(free_by_name[Path(str(path)).name])
+
+        MODULE.brokkr.utils.output.find_drives.side_effect = fake_find
+        with patch.dict("sys.modules", {
+                "brokkr.config.main": MagicMock(CONFIG=mock_config),
+                "brokkr.utils.misc": MagicMock(
+                    get_actual_username=lambda: "pi")}), \
+                patch("os.path.ismount", lambda p: str(p) in mounts), \
+                patch("shutil.disk_usage", side_effect=fake_usage):
+            yield
+        MODULE.brokkr.utils.output.find_drives.side_effect = None
+
+    def test_alerts_when_real_drives_full_behind_a_stale_dir(self, tmp_path):
+        """Both real drives full; the stale dir would otherwise hide it."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+        # stale dir would report the roomy root filesystem (40 GB)
+        free = {"DATA07": 40, "DATA071": 0.5, "DATA55": 0.5}
+        with self._resolved(tmp_path, "DATA??", free):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is not None, "stale dir masked a genuine fill"
+        assert "2/2" in msg, "only the two real mounts should be counted"
+
+    def test_suffixed_mount_is_examined(self, tmp_path):
+        """DATA071 must be seen; a bare DATA?? glob would skip it."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+        # DATA55 healthy, suffixed DATA071 nearly full -> roomiest is fine
+        free = {"DATA07": 40, "DATA071": 0.5, "DATA55": 500}
+        with self._resolved(tmp_path, "DATA??", free):
+            msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None, "roomiest real drive has space; should not alert"
+
+    def test_both_fixes_are_required(self, tmp_path):
+        """Neither the ismount filter nor the glob widening suffices alone.
+
+        Correct answer with both real drives at 0.5 GB and the root at 40 GB
+        is ALERT. Only filter+widened-glob together get there.
+        """
+        mounts = self._tree(tmp_path)
+        free = {"DATA07": 40, "DATA071": 0.5, "DATA55": 0.5}
+
+        def usage(name):
+            return du(free[name]).free
+
+        def resolve(glob_pat, use_filter):
+            paths = list(Path(tmp_path).glob(glob_pat))
+            if use_filter:
+                paths = [p for p in paths
+                         if not p.is_dir() or str(p) in mounts]
+            return [p.name for p in paths]
+
+        def best(glob_pat, use_filter):
+            names = resolve(glob_pat, use_filter)
+            return max(usage(n) for n in names) if names else None
+
+        threshold = 25 * GB
+        # A: as PR #80 shipped -- raw glob, no filter
+        assert best("DATA??", False) >= threshold, "unfixed: silent"
+        # B: widened glob alone -- stale dir still dominates max()
+        assert best("DATA??*", False) >= threshold, "glob alone: still silent"
+        # C: filter alone -- correct here, but never examines DATA071
+        assert "DATA071" not in resolve("DATA??", True)
+        # D: both -- alerts, and sees the suffixed mount
+        assert best("DATA??*", True) < threshold, "both fixes: alerts"
+        assert "DATA071" in resolve("DATA??*", True)
+
+
+# --- Layer 1: check_recovery_drives -----------------------------------------
+
+class TestRecoveryDrives:
+    def test_alert_when_all_drives_low(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with mounted(["/media/pi/DATA55", "/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(2), du(10)]):
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is not None
+        assert "GB" in msg
+        assert "2/2" in msg, "message should report how many drives are below"
+
+    def test_no_alert_when_one_drive_has_room(self):
+        """DATA55 at 0 (normal rotation), DATA56 has room -> no alert."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with mounted(["/media/pi/DATA55", "/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(0), du(800)]):
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+
+    def test_no_drives_returns_none(self):
+        mon = make_drive_monitor()
+        with mounted([]):
+            with patch("shutil.disk_usage") as usage:
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+        usage.assert_not_called(), "must not stat anything when nothing is mounted"
+
+    def test_all_paths_oserror_returns_none(self):
+        """Every path raises -> None, NOT a ValueError from max([])."""
+        mon = make_drive_monitor()
+        with mounted(["/media/pi/DATA55", "/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=OSError("unmounted")):
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None
+        mon.logger.error.assert_not_called()
+
+    def test_per_path_oserror_skipped_healthy_evaluated(self):
+        """One path errors, the other is low -> still alerts on the good one."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+
+        def side(path):
+            if "DATA55" in str(path):
+                raise OSError("unmounted")
+            return du(3)
+
+        with mounted(["/media/pi/DATA55", "/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=side):
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is not None
+        assert "1/1" in msg, "only the surviving drive should be counted"
+
+    def test_debounce_and_rearm(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with mounted(["/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(2)]):
+                m1 = mon.check_recovery_drives(make_input_data(100))
+            with patch("shutil.disk_usage", side_effect=[du(1)]):
+                m2 = mon.check_recovery_drives(make_input_data(100))   # still low
+            with patch("shutil.disk_usage", side_effect=[du(500)]):
+                m3 = mon.check_recovery_drives(make_input_data(100))   # recovered
+            with patch("shutil.disk_usage", side_effect=[du(1)]):
+                m4 = mon.check_recovery_drives(make_input_data(100))   # low again
+        assert m1 is not None
+        assert m2 is None      # debounced
+        assert m3 is None      # recovery is silent
+        assert m4 is not None  # re-armed -> re-alert
+
+    def test_boundary_equal_threshold_no_alert(self):
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with mounted(["/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(25)]):
+                msg = mon.check_recovery_drives(make_input_data(100))
+        assert msg is None  # free == threshold is NOT below
+
+    def test_alert_only_never_spawns(self):
+        """This check must never launch a scrub -- a full DATA drive is not
+        fixed by scrubbing the AGS."""
+        mon = make_drive_monitor(recovery_low_gb=25,
+                                 scrub_command="python3 scrub.py")
+        with mounted(["/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(1)]), \
+                    patch("subprocess.Popen") as popen:
+                mon.check_recovery_drives(make_input_data(100))
+        popen.assert_not_called()
+
+    def test_no_agsdependency(self):
+        """Runs off local mounts only -- still reports when the AGS is dark."""
+        mon = make_drive_monitor(recovery_low_gb=25)
+        with mounted(["/media/pi/DATA56"]):
+            with patch("shutil.disk_usage", side_effect=[du(1)]):
+                msg = mon.check_recovery_drives(make_input_data("NA"))
+        assert msg is not None
+
+
+# --- wiring ------------------------------------------------------------------
+
+class TestRunChecksWiring:
+    """Nothing previously proved the checks are actually invoked."""
+
+    def _monitor_with_stubbed_checks(self, enable_drive_checks):
+        mon = StateMonitor.__new__(StateMonitor)
+        mon.logger = MagicMock()
+        mon.send_message = MagicMock()
+        mon.log_error = MagicMock()
+        mon.enable_drive_checks = enable_drive_checks
+        for name in ("check_pi_space", "check_ping", "check_power",
+                     "check_battery_voltage", "check_drive",
+                     "check_recovery_drives", "check_sensor_drive",
+                     "check_scrub_health"):
+            setattr(mon, name, MagicMock(return_value=None))
+        return mon
+
+    def test_recovery_check_is_registered(self):
+        mon = self._monitor_with_stubbed_checks(enable_drive_checks=True)
+        mon.run_checks(make_input_data(100))
+        mon.check_recovery_drives.assert_called_once()
+
+    def test_recovery_check_suppressed_without_drive_checks(self):
+        """Units with no sensor hardware (enable_drive_checks=False) skip it."""
+        mon = self._monitor_with_stubbed_checks(enable_drive_checks=False)
+        mon.run_checks(make_input_data(100))
+        mon.check_recovery_drives.assert_not_called()
+
+    def test_alert_is_sent_when_check_returns_a_message(self):
+        mon = self._monitor_with_stubbed_checks(enable_drive_checks=True)
+        mon.check_recovery_drives.return_value = "Recovery drives low: ..."
+        mon.run_checks(make_input_data(100))
+        mon.send_message.assert_called_once_with("Recovery drives low: ...")
+
+    def test_check_exception_does_not_abort_other_checks(self):
+        mon = self._monitor_with_stubbed_checks(enable_drive_checks=True)
+        mon.check_recovery_drives.side_effect = OSError("boom")
+        mon.run_checks(make_input_data(100))
+        mon.log_error.assert_called_once()
+        mon.check_scrub_health.assert_called_once()


### PR DESCRIPTION
Replaces **#80**, which cannot merge as-is: it targets `feature/scrub-trigger-fix` (PR #78, now closed as superseded by #82), and two of its three layers have since shipped in `0.4.x`.

## Why

`brokkr` writes science data to `/media/<user>/DATA??`, and `hamma_scrub.py` lands recovered AGS triggers on the same drives. Nothing watches their free space. If they all fill, writes stop **and** recovery has nowhere to go. `check_drive` only asks whether a drive is *present*, never how full it is.

This is local and telemetry-independent, so unlike the AGS-side checks it still reports when the AGS is dark.

A single drive at 100% is normal rotation, so only the **roomiest** drive is judged, and the alert is latched — one message per descent, re-armed on recovery. Alert-only: a full DATA drive is not fixed by scrubbing the AGS, so this never spawns a scrub.

## Scope: Layer 1 of #80 only

| #80 layer | Here | Why |
|---|---|---|
| 1 — `check_recovery_drives` | **ported** | Genuinely new; no free-space check on the DATA drives exists in `0.4.x` |
| 2 — `check_hs_staleness` | dropped | PR #82 already ships this as `hs_stale_cycles` in `check_sensor_drive`. Porting it sends **two** alerts per AGS-dark event — verified by running both against 20 consecutive NA samples |
| 3 — futile-scrub alert | dropped | Every line references `low_space` / `_low_space_active`, which #82 removed. It also duplicates the `alert_space` escalation and interacts badly with `check_scrub_health`. Needs redesign against the two-threshold model, not a port — filed separately |

## Two bugs fixed relative to #80's implementation

#80 did `glob.glob("/media/pi/DATA??")` and stat'd whatever came back. Both halves are wrong, and **each fix alone still gives the wrong answer**.

**The topology** (sensor-log #52, mj51, 2026-05-28): a dirty unmount leaves an empty `/media/pi/DATA07` directory; udisks then mounts the real drive at `DATA071`. Quoting that issue:

> udisks2 v2.8.1 picks `/media/<user>/<label>` and increments suffix on collision. Pre-existing empty `DATA07`/`DATA08` dirs forced mounts at `DATA071`/`DATA081`. Brokkr's glob `DATA??` matches exactly 6 chars, so the suffixed mountpoints were silently skipped.

Consequence there: **brokkr fell back to the SD card for ~8 days.**

**Bug A — the stale directory is stat'd as a drive.** `shutil.disk_usage()` on a non-mountpoint directory returns the *containing* filesystem — the SD root. Since the check takes `max()`, a roomy root pushes the result above the threshold and **suppresses the alert while every real drive is full**. Below the threshold it flips to a false positive, alerting about a "DATA drive" that is really the SD card. Either way the reported GB figure and the `N/M` count are the root's, not any drive's.

Fixed by discovering through `brokkr.utils.output.find_drives`, whose `not is_dir() or ismount()` filter drops stale directories. Reusing brokkr's helper rather than reimplementing discovery.

**Bug B — the suffixed mount is never examined.** `DATA??` matches exactly two trailing characters. Widened to `DATA??*`, which still requires at least two (so `DATA0` is not matched) but also catches `DATA071`.

Demonstrated in `test_both_fixes_are_required`, with both real drives at 0.5 GB and the root at 40 GB — correct answer is ALERT:

| | discovery | result |
|---|---|---|
| A: as #80 shipped | raw glob, `DATA??` | **silent** |
| B: widened glob alone | raw glob, `DATA??*` | **silent** (stale dir still dominates `max()`) |
| C: filter alone | `find_drives`, `DATA??` | alerts, but never sees `DATA071` |
| D: both | `find_drives`, `DATA??*` | **alerts, and sees the suffixed mount** |

Also: the glob comes from `CONFIG['steps']['science_binary_output']['drive_kwargs']['drive_glob']` and the base path is brokkr's own `/media/{current_user}` template rather than a hardcoded `/media/pi`, so neither can drift from where brokkr actually writes.

## Testing

`pytest tests/python tests/unified` → **727 passed, 3 failed**, against a clean `0.4.x` baseline of **707 passed, 3 failed**. Same three pre-existing `test_hamma_noise.py` failures on both sides; the +20 are this PR.

20 new tests. Notably, `TestUdisksTopology` runs against a **real temp directory tree** with real globbing and real `is_dir()` — only `os.path.ismount` is stubbed, since creating an actual mount needs privileges. #80's tests patched `glob.glob` with literal path lists, which gives zero coverage of path resolution, and path resolution is exactly where both bugs live.

`TestRunChecksWiring` is also new: `run_checks` previously had **no test at all**, so nothing proved any check was actually invoked, or that `enable_drive_checks=False` suppresses the drive checks on units without sensor hardware.

`pyflakes` clean; `py_compile` passes for the fleet's Python 3.7.

## Deliberately not included

- The check could also **detect the suffixed-mount state itself** by comparing `DATA??*` against plain `DATA??` — the silent failure that cost mj51 eight days, which nothing currently alerts on. Out of scope here; worth its own issue.
- `check_pi_space` is **dead code**: `shutil.disk_usage("/")` returns bytes but is compared against `low_pi_space`, which defaults to `5` and is set nowhere in `config/main.toml` or the presets. The threshold is 5 *bytes*, so it can never fire — the SD root is effectively unmonitored fleet-wide. Pre-existing, filed separately, not touched here.
